### PR TITLE
#79: Add path creation for `agent-standalone/run.sh` to fix failure (#1)

### DIFF
--- a/all-in-one.sh
+++ b/all-in-one.sh
@@ -32,36 +32,41 @@ rm -fr $INSTALL_DIR/tomcat6/webapps/docs $INSTALL_DIR/tomcat6/webapps/examples $
 wget -O $INSTALL_DIR/tomcat6/webapps/ROOT.war http://tank-public.s3-website-us-east-1.amazonaws.com/tank.war 2>/dev/null
 
 echo "Creating start script at $INSTALL_DIR/start.sh ..."
-echo "#!/bin/bash">$INSTALL_DIR/start.sh
-echo "echo \"Starting Tomcat...\"">>$INSTALL_DIR/start.sh
-echo "export JAVA_OPTS=\"-Xms256m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=128m -Djava.awt.headless=true\"">>$INSTALL_DIR/start.sh
-echo "cd $INSTALL_DIR/tomcat6/">>$INSTALL_DIR/start.sh
-echo "bin/startup.sh 2> \&1 >/dev/null">>$INSTALL_DIR/start.sh
-echo "echo \"Tomcat started.\"">>$INSTALL_DIR/start.sh
-echo "cd $INSTALL_DIR/agent-standalone/">>$INSTALL_DIR/start.sh
-echo "echo \"Starting Agent...\"">>$INSTALL_DIR/start.sh
-echo "./run.sh 2> \&1 >/dev/null">>$INSTALL_DIR/start.sh
-echo "echo \"Agent started.\"">>$INSTALL_DIR/start.sh
+cat << EOF > $INSTALL_DIR/start.sh
+#!/bin/bash
+echo "Starting Tomcat..."
+export JAVA_OPTS="-Xms256m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=128m -Djava.awt.headless=true"
+cd $INSTALL_DIR/tomcat6/
+bin/startup.sh &> /dev/null
+echo "Tomcat started."
+cd $INSTALL_DIR/agent-standalone/
+echo "Starting Agent..."
+./run.sh &> /dev/null
+echo "Agent started."
+EOF
 chmod 755 $INSTALL_DIR/start.sh 2>/dev/null
 
 echo "Creating stop script at $INSTALL_DIR/stop.sh..."
-echo "#!/bin/bash">$INSTALL_DIR/stop.sh
-echo "echo \"Stopping Tomcat...\"">>$INSTALL_DIR/stop.sh
-echo "$INSTALL_DIR/tomcat6/bin/shutdown.sh 2> \&1 >/dev/null">>$INSTALL_DIR/stop.sh
-echo "echo \"Stopping Agent...\"">>$INSTALL_DIR/stop.sh
-echo "kill \$(ps aux | grep '[a]gent-standalone' | awk '{print \$2}') 2> \&1 >/dev/null">>$INSTALL_DIR/stop.sh
-echo "kill \$(ps aux | grep '[a]piharness' | awk '{print \$2}') 2> \&1 >/dev/null">>$INSTALL_DIR/stop.sh
-echo "kill \$(ps aux | grep '[t]omcat' | awk '{print \$2}') 2> \&1 >/dev/null">>$INSTALL_DIR/stop.sh
-echo "echo \"Tomcat and Agents stopped.\"">>$INSTALL_DIR/stop.sh
+cat << EOF > $INSTALL_DIR/stop.sh
+#!/bin/bash
+echo "Stopping Tomcat..."
+$INSTALL_DIR/tomcat6/bin/shutdown.sh &> /dev/null
+echo "Stopping Agent..."
+kill $(ps aux | grep '[a]gent-standalone' | awk '{print $2}') &> /dev/null
+kill $(ps aux | grep '[a]piharness' | awk '{print $2}') &> /dev/null
+kill $(ps aux | grep '[t]omcat' | awk '{print $2}') &> /dev/null
+echo "Tomcat and Agents stopped."
+EOF
 chmod 755 $INSTALL_DIR/stop.sh 2>/dev/null
 
-echo "#!/bin/bash">$INSTALL_DIR/agent-standalone/run.sh
-echo "controller=\"http://localhost:8080\"">>$INSTALL_DIR/agent-standalone/run.sh
-echo "host=\`hostname\`">>$INSTALL_DIR/agent-standalone/run.sh
-echo "capacity=400">>$INSTALL_DIR/agent-standalone/run.sh
-echo "nohup java -jar agent-standalone-all.jar -controller=\$controller -host=\$host -capacity=\$capacity &">>$INSTALL_DIR/agent-standalone/run.sh
-
-
+mkdir -p $INSTALL_DIR/agent-standalone
+cat << EOF > $INSTALL_DIR/agent-standalone/run.sh
+#!/bin/bash
+controller="http://localhost:8080"
+host=`hostname`
+capacity=400
+nohup java -jar agent-standalone-all.jar -controller=$controller -host=$host -capacity=$capacity &
+EOF
 
 echo "Installing all in one in $INSTALL_DIR"
 echo "Run $INSTALL_DIR/start.sh to start the all in one server and $INSTALL_DIR/stop.sh to kill it"


### PR DESCRIPTION
title:
* Add path creation for `agent-standalone/run.sh` to fix failure
* Refactored creation of `start.sh`, `stop.sh`,  `agent-standalone/run.sh`
* Cleaning up redirect syntax

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.