### PR TITLE
Add compression to longBlob storage in RDS

### DIFF
--- a/data_access/src/main/java/com/intuit/tank/dao/ScriptDao.java
+++ b/data_access/src/main/java/com/intuit/tank/dao/ScriptDao.java
@@ -154,7 +154,7 @@ public class ScriptDao extends BaseDao<Script> {
         if (script.getScriptSteps() == null || script.getScriptSteps().isEmpty()) {
             SerializedScriptStep serializedScriptStep = new SerializedScriptStepDao().findById(script
                     .getSerializedScriptStepId());
-            script.setSerializedSteps(serializedScriptStep);
+            script.deserializeSteps(serializedScriptStep);
         }
         return script;
     }

--- a/data_access/src/main/java/com/intuit/tank/dao/ScriptDao.java
+++ b/data_access/src/main/java/com/intuit/tank/dao/ScriptDao.java
@@ -200,7 +200,8 @@ public class ScriptDao extends BaseDao<Script> {
     }
 
     private SerializedScriptStep serialize(Script script) {
-        SerializedScriptStep serializedScriptStep = new SerializedScriptStepDao().findById(script.getId());
+        SerializedScriptStep serializedScriptStep =
+                new SerializedScriptStepDao().findById(script.getSerializedScriptStepId());
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
              GZIPOutputStream gz = new GZIPOutputStream(bos);
              ObjectOutputStream s = new ObjectOutputStream(gz) ) {

--- a/data_access/src/test/java/com/intuit/tank/dao/ScriptDaoTest.java
+++ b/data_access/src/test/java/com/intuit/tank/dao/ScriptDaoTest.java
@@ -24,20 +24,17 @@ import java.util.stream.Stream;
 
 import javax.validation.ConstraintViolationException;
 
-import com.intuit.tank.project.SerializedScriptStep;
 import com.intuit.tank.test.TestGroups;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 
-import com.intuit.tank.dao.ScriptDao;
 import com.intuit.tank.project.Script;
 import com.intuit.tank.project.ScriptStep;
 import com.intuit.tank.view.filter.ViewFilterType;
-import org.junit.jupiter.api.AfterEach;
+import org.hibernate.PropertyValueException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,7 +82,6 @@ public class ScriptDaoTest {
 
     @Test
     @Tag(TestGroups.FUNCTIONAL)
-    @Disabled
     public void testChildOrder() throws Exception {
         Script entity = DaoTestUtil.createScript();
         entity.addStep(DaoTestUtil.createScriptStep());
@@ -100,17 +96,17 @@ public class ScriptDaoTest {
             children.add(0, removed);
             persisted = dao.saveOrUpdate(persisted);
             persisted = dao.findById(id);
-            assertFalse(persisted.getScriptSteps().get(0).equals(originalOrder.get(0)));
-            assertTrue(persisted.getScriptSteps().get(0).equals(originalOrder.get(2)));
-            assertTrue(persisted.getScriptSteps().get(1).equals(originalOrder.get(0)));
-            assertTrue(persisted.getScriptSteps().get(2).equals(originalOrder.get(1)));
+            assertNotEquals(originalOrder.get(0), persisted.getScriptSteps().get(0));
+            assertEquals(originalOrder.get(2), persisted.getScriptSteps().get(0));
+            assertEquals(originalOrder.get(0), persisted.getScriptSteps().get(1));
+            assertEquals(originalOrder.get(1), persisted.getScriptSteps().get(2));
 
             originalOrder = new ArrayList<ScriptStep>(persisted.getScriptSteps());
             persisted.getScriptSteps().remove(2);
             persisted.getScriptSteps().remove(0);
             persisted = dao.saveOrUpdate(persisted);
             persisted = dao.findById(id);
-            assertTrue(persisted.getScriptSteps().get(0).equals(originalOrder.get(1)));
+            assertEquals(originalOrder.get(1), persisted.getScriptSteps().get(0));
             assertEquals(1, persisted.getScriptSteps().size());
 
         } finally {
@@ -184,7 +180,6 @@ public class ScriptDaoTest {
     @ParameterizedTest
     @Tag(TestGroups.FUNCTIONAL)
     @MethodSource("validations")
-    @Disabled
     public void testValidation(Script entity, String property, String messageContains) throws Exception {
         try {
             dao.saveOrUpdate(entity);
@@ -192,12 +187,17 @@ public class ScriptDaoTest {
         } catch (ConstraintViolationException e) {
             // expected validation
             DaoTestUtil.checkConstraintViolation(e, property, messageContains);
+        } catch (RuntimeException e) {
+            if (e.getCause().getCause() instanceof PropertyValueException) {
+                assertTrue(e.getCause().getCause().getMessage().startsWith("not-null property references a null or transient value"));
+                return;
+            }
+            assertTrue(e.getCause().getCause().getCause().getMessage().startsWith("Value too long for column "));
         }
     }
 
     @Test
     @Tag(TestGroups.FUNCTIONAL)
-    @Disabled
     public void testBasicCreateUpdateDelete() throws Exception {
         List<Script> all = dao.findAll();
         int originalSize = all.size();

--- a/data_access/src/test/java/com/intuit/tank/dao/ScriptDaoTest.java
+++ b/data_access/src/test/java/com/intuit/tank/dao/ScriptDaoTest.java
@@ -19,10 +19,12 @@ package com.intuit.tank.dao;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.validation.ConstraintViolationException;
 
+import com.intuit.tank.project.SerializedScriptStep;
 import com.intuit.tank.test.TestGroups;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +35,7 @@ import com.intuit.tank.dao.ScriptDao;
 import com.intuit.tank.project.Script;
 import com.intuit.tank.project.ScriptStep;
 import com.intuit.tank.view.filter.ViewFilterType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -158,6 +161,24 @@ public class ScriptDaoTest {
         assertEquals(second.getId(), list.get(1).getId());
         assertEquals(third.getId(), list.get(2).getId());
         assertEquals(fourth.getId(), list.get(3).getId());
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void testCompressScripSteps() {
+
+        Script script = DaoTestUtil.createScript();
+        IntStream.range(0, 500).forEach(i -> script.addStep(DaoTestUtil.createScriptStep()));
+        int id = dao.saveOrUpdate(script).getId();
+
+        Script scriptOut = dao.findById(id);
+        assertNotNull(scriptOut);
+
+        dao.loadScriptSteps(scriptOut);
+        List<ScriptStep> StepsOut = scriptOut.getSteps();
+        assertEquals(500, StepsOut.size());
+
+        dao.delete(id);
     }
 
     @ParameterizedTest

--- a/data_model/src/main/java/com/intuit/tank/project/Script.java
+++ b/data_model/src/main/java/com/intuit/tank/project/Script.java
@@ -69,11 +69,11 @@ public class Script extends OwnableEntity implements Comparable<Script> {
     /**
      * Check if Blob stream begins with gzip magic number, if true decompress
      * Deserialize Blob stream back into List of ScriptSteps
-     * 
+     *
      * @return the List of ScriptStep
      */
     @SuppressWarnings("unchecked")
-    public static List<ScriptStep> deserializeBlob(SerializedScriptStep serializedScriptStep) {
+    private static List<ScriptStep> deserializeBlob(SerializedScriptStep serializedScriptStep) {
         if (serializedScriptStep != null && serializedScriptStep.getSerialzedBlob() != null) {
             try ( InputStream input = serializedScriptStep.getSerialzedBlob().getBinaryStream() ) {
 
@@ -92,18 +92,11 @@ public class Script extends OwnableEntity implements Comparable<Script> {
         return null;
     }
 
-    // /**
-    // * @return the serializedScriptStep
-    // */
-    // public SerializedScriptStep getSerializedScriptStep() {
-    // boolean load = serializedScriptStep == null;
-    //
-    // return serializedScriptStep;
-    // }
     /**
      * @param serializedSteps
+     *          the serializedSteps to be decompressed/deserialized
      */
-    public void setSerializedSteps(SerializedScriptStep serializedSteps) {
+    public void deserializeSteps(SerializedScriptStep serializedSteps) {
         steps = deserializeBlob(serializedSteps);
     }
 

--- a/data_model/src/main/java/com/intuit/tank/project/Script.java
+++ b/data_model/src/main/java/com/intuit/tank/project/Script.java
@@ -79,12 +79,12 @@ public class Script extends OwnableEntity implements Comparable<Script> {
 
                 PushbackInputStream pb = new PushbackInputStream( input, 2 ); //we need a pushbackstream to look ahead
                 byte [] signature = new byte[2];
-                int len = pb.read( signature ); //read the signature
-                pb.unread( signature, 0, len ); //push back the signature to the stream
+                pb.read( signature ); //read the signature
+                pb.unread( signature ); //push back the signature to the stream
                 if( signature[ 0 ] == (byte) 0x1f && signature[ 1 ] == (byte) 0x8b ) //check if matches standard gzip magic number
                     return (List<ScriptStep>) new ObjectInputStream(new GZIPInputStream( pb )).readObject();
                 else
-                    return (List<ScriptStep>) new ObjectInputStream(pb).readObject();
+                    return (List<ScriptStep>) new ObjectInputStream( pb ).readObject();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/data_model/src/main/java/com/intuit/tank/project/SerializedScriptStep.java
+++ b/data_model/src/main/java/com/intuit/tank/project/SerializedScriptStep.java
@@ -44,13 +44,14 @@ public class SerializedScriptStep extends BaseEntity {
     private byte[] bytes;
 
     /**
-     * @param serialzedData
+     * Constructor
      */
     public SerializedScriptStep() {
     }
 
     /**
      * @param serialzedData
+     *          new constructor for a new script
      */
     public SerializedScriptStep(byte[] serialzedData) {
         this.bytes = serialzedData;
@@ -70,6 +71,14 @@ public class SerializedScriptStep extends BaseEntity {
      */
     public Blob getSerialzedBlob() {
         return serialzedData;
+    }
+
+    /**
+     * @param bytes
+     *          the bytes stored before Blob creation
+     */
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
     }
 
     /**

--- a/data_model/src/test/java/com/intuit/tank/project/ScriptTest.java
+++ b/data_model/src/test/java/com/intuit/tank/project/ScriptTest.java
@@ -166,23 +166,6 @@ public class ScriptTest {
     }
 
     /**
-     * Run the List<ScriptStep> deserializeBlob(SerializedScriptStep) method test.
-     *
-     * @throws Exception
-     *
-     * @generatedBy CodePro at 12/15/14 1:34 PM
-     */
-    @Test
-    public void testDeserializeBlob_2()
-        throws Exception {
-        SerializedScriptStep serializedScriptStep = null;
-
-        List<ScriptStep> result = Script.deserializeBlob(serializedScriptStep);
-
-        assertEquals(null, result);
-    }
-
-    /**
      * Run the boolean equals(Object) method test.
      *
      * @throws Exception
@@ -604,7 +587,7 @@ public class ScriptTest {
         fixture.setRuntime(1);
         SerializedScriptStep serializedSteps = new SerializedScriptStep();
 
-        fixture.setSerializedSteps(serializedSteps);
+        fixture.deserializeSteps(serializedSteps);
 
     }
 


### PR DESCRIPTION
Add compression to longBlob storage in RDS:
This really resolves (2) major issues:
- Every save to a script, including updates, created a new insert of the script.  The old one was abandoned and unreferenced. This causes excessive RDS disk space growth.
- Each script stored in the database has been a very large serialized list of steps. Passing the byte stream through the gzip stream compressor has reduced the storage size on the longBlobl storage space by +80%.

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.