### PR TITLE
Remove redirect map caching old redirect data

### DIFF
--- a/proxy-parent/proxy-extension/src/main/java/com/intuit/tank/handler/BufferingHttpRequestHandler.java
+++ b/proxy-parent/proxy-extension/src/main/java/com/intuit/tank/handler/BufferingHttpRequestHandler.java
@@ -151,17 +151,17 @@ public class BufferingHttpRequestHandler implements HttpRequestHandler {
     }
 
     private Transaction storeRequest(final BufferedRequest brq) throws MessageFormatException {
-        Request r = new Request();
-        r.setBody(brq.getDecodedContent());
-        r.setFirstLine(brq.getStartLine());
-        r.setProtocol(brq.isSsl() ? Protocol.https : Protocol.http);
+        Request request = new Request();
+        request.setBody(brq.getDecodedContent());
+        request.setFirstLine(brq.getStartLine());
+        request.setProtocol(brq.isSsl() ? Protocol.https : Protocol.http);
 
         NamedValue[] headers = brq.getHeaders();
         for (NamedValue namedValue : headers) {
-            r.getHeaders().add(new Header(namedValue.getName(), namedValue.getValue()));
+            request.getHeaders().add(new Header(namedValue.getName(), namedValue.getValue()));
         }
 
-        return application.setRequestForCurrentTransaction(r, brq);
+        return application.setRequestForCurrentTransaction(request);
     }
 
     private void handleResponse(final BufferedRequest request,
@@ -184,7 +184,7 @@ public class BufferingHttpRequestHandler implements HttpRequestHandler {
                 }
                 interceptor.processResponse(request, brs);
 
-                storeResponse(transaction, brs, request);
+                storeResponse(transaction, brs);
                 MessageUtils.stream(brs, response);
             } catch (SizeLimitExceededException slee) {
                 InputStream buffered = new ByteArrayInputStream(brs
@@ -214,12 +214,12 @@ public class BufferingHttpRequestHandler implements HttpRequestHandler {
                         }
 
                     });
-            storeResponse(transaction, brs, request);
+            storeResponse(transaction, brs);
         }
 
     }
 
-    private void storeResponse(Transaction transaction, MutableBufferedResponse brs, BufferedRequest request)
+    private void storeResponse(Transaction transaction, MutableBufferedResponse brs)
             throws MessageFormatException {
 
         Response response = new Response();
@@ -231,7 +231,7 @@ public class BufferingHttpRequestHandler implements HttpRequestHandler {
         }
         try {
             if (transaction != null) {
-                application.setResponseForCurrentTransaction(transaction, response, request);
+                application.setResponseForCurrentTransaction(transaction, response);
             }
         } catch (JAXBException e) {
             // TODO Auto-generated catch block

--- a/proxy-parent/proxy-extension/src/test/java/com/intuit/tank/entity/ApplicationTest.java
+++ b/proxy-parent/proxy-extension/src/test/java/com/intuit/tank/entity/ApplicationTest.java
@@ -1,17 +1,15 @@
 package com.intuit.tank.entity;
 
-import com.intuit.tank.conversation.Protocol;
-import com.intuit.tank.conversation.Request;
-import com.intuit.tank.conversation.Response;
-import com.intuit.tank.conversation.Transaction;
+import com.intuit.tank.conversation.*;
 import com.intuit.tank.proxy.config.ProxyConfiguration;
 import com.intuit.tank.proxy.table.TransactionRecordedListener;
 import com.intuit.tank.test.TestGroups;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.owasp.proxy.http.MessageFormatException;
-import org.owasp.proxy.http.MutableBufferedRequest;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class ApplicationTest {
@@ -19,31 +17,33 @@ public class ApplicationTest {
     // Mocks
     private ProxyConfiguration _proxyConfigurationMock;
     private TransactionRecordedListener _transactionRecordedListenerMock;
-    private MutableBufferedRequest _mutableBufferedRequestMock;
 
     // Stubs
     private Transaction _transactionStub;
     private Request _requestStub;
+    private Request _requestWithHeaderStub;
     private Response _responseStub;
+    private final Header headerStub = new Header("Referer", "https://c11.perf.qbo.intuit.com/qbo11/login");
     private final String startLineStub = "GET /test/servlet/PartnerGatewayServlet?dest=logmein&widgetLogin=true&smartLogin=true&destUrl=!1&userStrId=rtanizawa_iamtestpass HTTP/1.1";
     private final String foundResponseFirstLineStub = "HTTP/1.1 302 Moved Temporarily";
-    private final String hostStub = "iop-e2e1.onlinepayroll.intuit.com";
 
     private Application _sut;
-
 
     @BeforeEach
     public void SetUp() {
         _proxyConfigurationMock = mock(ProxyConfiguration.class);
         _transactionRecordedListenerMock = mock(TransactionRecordedListener.class);
-        _mutableBufferedRequestMock = mock(MutableBufferedRequest.class);
 
         _transactionStub = new Transaction();
         _requestStub = new Request();
+        _requestWithHeaderStub = new Request();
         _responseStub = new Response();
 
         _requestStub.setProtocol(Protocol.https);
         _requestStub.setFirstLine(startLineStub);
+        _requestWithHeaderStub.setProtocol(Protocol.https);
+        _requestWithHeaderStub.setFirstLine(startLineStub);
+        _requestWithHeaderStub.addHeader(headerStub);
         _responseStub.setFirstLine(foundResponseFirstLineStub);
         _transactionStub.setRequest(_requestStub);
 
@@ -59,11 +59,9 @@ public class ApplicationTest {
     public void setResponseForCurrentTransaction_Given_302_HappyPath_Processes_Transaction() throws Exception {
         // Arrange
         when(_proxyConfigurationMock.isFollowRedirects()).thenReturn(true);
-        when(_mutableBufferedRequestMock.getHeader("Host")).thenReturn(hostStub);
-        when(_mutableBufferedRequestMock.getStartLine()).thenReturn(startLineStub);
 
         // Act
-        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub, _mutableBufferedRequestMock);
+        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub);
 
         // Assert
         verify(_transactionRecordedListenerMock, times(1)).transactionProcessed(any(Transaction.class), anyBoolean());
@@ -74,11 +72,9 @@ public class ApplicationTest {
     public void setResponseForCurrentTransaction_Given_302_With_Redirect_Configuration_Disabled_Still_Processes_Transaction() throws Exception {
         // Arrange
         when(_proxyConfigurationMock.isFollowRedirects()).thenReturn(false);
-        when(_mutableBufferedRequestMock.getHeader("Host")).thenReturn(hostStub);
-        when(_mutableBufferedRequestMock.getStartLine()).thenReturn(startLineStub);
 
         // Act
-        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub, _mutableBufferedRequestMock);
+        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub);
 
         // Assert
         verify(_transactionRecordedListenerMock, times(1)).transactionProcessed(any(Transaction.class), anyBoolean());
@@ -89,14 +85,116 @@ public class ApplicationTest {
     public void setResponseForCurrentTransaction_Given_MessageFormatException_Still_Processes_Transaction() throws Exception {
         // Arrange
         when(_proxyConfigurationMock.isFollowRedirects()).thenReturn(true);
-        when(_mutableBufferedRequestMock.getHeader("Host")).thenReturn(hostStub);
-        when(_mutableBufferedRequestMock.getStartLine()).thenThrow(MessageFormatException.class);
 
         // Act
-        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub, _mutableBufferedRequestMock);
+        _sut.setResponseForCurrentTransaction(_transactionStub, _responseStub);
 
         // Assert
         verify(_transactionRecordedListenerMock, times(1)).transactionProcessed(any(Transaction.class), anyBoolean());
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Request_Embeds_Expected_Request() {
+        // Arrange
+        Request expectedRequest = _transactionStub.getRequest();
+
+        // Act
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestStub);
+        Request actualRequest = actualTransaction.getRequest();
+
+        // Assert
+        assertEquals(expectedRequest, actualRequest);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Request_Embeds_Expected_FirstLine() {
+        // Arrange
+        Request expectedRequest = _requestWithHeaderStub;
+        String expectedFirstLine = expectedRequest.getFirstLine();
+
+        // Act
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestStub);
+        Request actualRequest = actualTransaction.getRequest();
+        String actualFirstLine = actualRequest.getFirstLine();
+
+        // Assert
+        assertEquals(expectedFirstLine, actualFirstLine);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Request_Embeds_Expected_Header() {
+        // Arrange
+        Request expectedRequest = _requestWithHeaderStub;
+        List<Header> expectedHeadersList = expectedRequest.getHeaders();
+        int expectedHeaderIndex = expectedHeadersList.indexOf(headerStub);
+        Header expectedHeader = expectedHeadersList.get(expectedHeaderIndex);
+
+        // Act
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestWithHeaderStub);
+        Request actualRequest = actualTransaction.getRequest();
+        List<Header> actualHeadersList = actualRequest.getHeaders();
+        int actualHeaderIndex = actualHeadersList.indexOf(headerStub);
+        Header actualHeader = actualHeadersList.get(actualHeaderIndex);
+
+        // Assert
+        assertEquals(expectedHeader, actualHeader);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Multiple_Requests_Embeds_Expected_Request() {
+        // Arrange
+        Request expectedRequest = _transactionStub.getRequest();
+
+        // Act
+        _sut.setRequestForCurrentTransaction(_requestWithHeaderStub);
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestStub);
+
+        Request actualRequest = actualTransaction.getRequest();
+
+        // Assert
+        assertEquals(expectedRequest, actualRequest);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Multiple_Requests_Embeds_Expected_FirstLine() {
+        // Arrange
+        Request expectedRequest = _requestWithHeaderStub;
+        String expectedFirstLine = expectedRequest.getFirstLine();
+
+        // Act
+        _sut.setRequestForCurrentTransaction(_requestStub);
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestWithHeaderStub);
+        Request actualRequest = actualTransaction.getRequest();
+        String actualFirstLine = actualRequest.getFirstLine();
+
+        // Assert
+        assertEquals(expectedFirstLine, actualFirstLine);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void setRequestForCurrentTransaction_Given_Multiple_Requests_Embeds_Expected_Header() {
+        // Arrange
+        Request expectedRequest = _requestWithHeaderStub;
+        List<Header> expectedHeadersList = expectedRequest.getHeaders();
+        int expectedHeaderIndex = expectedHeadersList.indexOf(headerStub);
+        Header expectedHeader = expectedHeadersList.get(expectedHeaderIndex);
+
+        // Act
+        _sut.setRequestForCurrentTransaction(_requestStub);
+        Transaction actualTransaction = _sut.setRequestForCurrentTransaction(_requestWithHeaderStub);
+        Request actualRequest = actualTransaction.getRequest();
+        List<Header> actualHeadersList = actualRequest.getHeaders();
+        int actualHeaderIndex = actualHeadersList.indexOf(headerStub);
+        Header actualHeader = actualHeadersList.get(actualHeaderIndex);
+
+        // Assert
+        assertEquals(expectedHeader, actualHeader);
     }
 }
 


### PR DESCRIPTION
**Redirect Proxy Mislabeled**: 
- Redirect Map cached old redirect information causing mislabeling in the proxy recorder
- Remove unnecessary Buffered request parameter

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.