### PR TITLE
[SRE 23283] SaveAs Icon in table view creates empty Script

### DIFF
--- a/web/web_support/src/main/java/com/intuit/tank/script/ScriptBean.java
+++ b/web/web_support/src/main/java/com/intuit/tank/script/ScriptBean.java
@@ -15,6 +15,7 @@ package com.intuit.tank.script;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
@@ -164,8 +165,13 @@ public class ScriptBean extends SelectableBean<Script> implements Serializable, 
     public List<Script> getEntityList(ViewFilterType viewFilter) {
         VersionContainer<Script> container = scriptLoader.getVersionContainer(viewFilter);
         this.version = container.getVersion();
-        List<Script> all = new ScriptDao().findFiltered(viewFilter);
-        return all;
+        ScriptDao scriptDao = new ScriptDao();
+        List<Script> all = scriptDao.findFiltered(viewFilter);
+        List<Script> scriptsWithSteps = all
+                .stream()
+                .map(script -> scriptDao.loadScriptSteps(script))
+                .collect(Collectors.toList());
+        return scriptsWithSteps;
     }
 
     /**

--- a/web/web_support/src/main/java/com/intuit/tank/script/ScriptBean.java
+++ b/web/web_support/src/main/java/com/intuit/tank/script/ScriptBean.java
@@ -167,6 +167,7 @@ public class ScriptBean extends SelectableBean<Script> implements Serializable, 
         this.version = container.getVersion();
         ScriptDao scriptDao = new ScriptDao();
         List<Script> all = scriptDao.findFiltered(viewFilter);
+        // adds script steps; needed when doing a 'save as'
         List<Script> scriptsWithSteps = all
                 .stream()
                 .map(script -> scriptDao.loadScriptSteps(script))


### PR DESCRIPTION
title: SaveAs Icon in table view creates empty Script

The ScriptBean was not populating the script steps. When a script was copied ('save as'), these steps were not being copied over to the new script.

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.