### PR TITLE
[SRE-27144] Short-term fix for agents stuck in pending

### DIFF
--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/AgentWatchdog.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/AgentWatchdog.java
@@ -127,14 +127,15 @@ public class AgentWatchdog implements Runnable {
      */
     @Override
     public void run() {
-        LOG.info("Starting WatchDog: " + this.toString());
+        String jobId = instanceRequest.getJobId();
+        LOG.info("Starting WatchDog: " + this.toString() + " for job " + jobId);
         AWSXRay.getGlobalRecorder().beginNoOpSegment(); //jdbcInterceptor will throw SegmentNotFoundException,RuntimeException without this
         try {
             startedInstances = new ArrayList<VMInformation>(vmInfo);
             reportedInstances = new ArrayList<VMInformation>();
             while (restartCount <= maxRestarts && !stopped) {
                 checkForReportingInstances();
-                LOG.info(startedInstances.size() + " instances started. " + reportedInstances.size() + " instances reported. Waiting for remaining " + startedInstances.size() + " agents to report back...");
+                LOG.info("Job " + jobId + ": " + startedInstances.size() + " instances started. " + reportedInstances.size() + " instances reported. Waiting for remaining " + startedInstances.size() + " agents to report back...");
                 // When runningInstances is empty all instances have reported back.
                 // If not, check if its time for a restart.
                 if (!startedInstances.isEmpty()) {
@@ -142,12 +143,11 @@ public class AgentWatchdog implements Runnable {
                         relaunch(startedInstances);
                         startTime = System.currentTimeMillis();
                     }
-                    LOG.info("Waiting for " + startedInstances.size() + " agents to report: "
+                    LOG.info("Job " + jobId + ": " + "Waiting for " + startedInstances.size() + " agents to report: "
                             + getInstanceIdList(startedInstances));
                     Thread.sleep(sleepTime);
-                    continue;
                 } else {
-                    LOG.info("All Agents Reported back.");
+                    LOG.info("All Agents Reported back for job " + jobId + ".");
                     vmTracker.publishEvent(new JobEvent(instanceRequest.getJobId(),
                             "All Agents Reported Back and are ready to start load.", JobLifecycleEvent.AGENT_REPORTED));
                     stopped = true;
@@ -174,7 +174,7 @@ public class AgentWatchdog implements Runnable {
         }
         for (CloudVmStatus status : vmStatusForJob.getStatuses()) {
             // Checks the state of Tank job.
-            if (status.getVmStatus() == VMStatus.running) {
+            if (status.getVmStatus().equals(VMStatus.pending)) { // agent reported back ready, only relaunch "starting" agents
                 VMInformation removedInstance = removeInstance(startedInstances, status.getInstanceId());
                 if (removedInstance != null) {
                     addInstance(reportedInstances, removedInstance);
@@ -194,7 +194,8 @@ public class AgentWatchdog implements Runnable {
      */
     private void relaunch(ArrayList<VMInformation> instances) {
         restartCount++;
-        LOG.info("Restart Count: " + restartCount);
+        String jobId = instanceRequest.getJobId();
+        LOG.info("Restart Count for job " + jobId + ": " + restartCount);
         if (restartCount > maxRestarts) {
             stopped = true;
             String msg = "Have "
@@ -205,7 +206,7 @@ public class AgentWatchdog implements Runnable {
             // TODO Do we have to kill jobs here?
             throw new RuntimeException("Killing jobs and exiting");
         }
-        String msg = "Have " + instances.size() + " agents that failed to start or report correctly. Relaunching. "
+        String msg = "Have " + instances.size() + " agents that failed to start or report correctly for job " + jobId + ". Relaunching. "
                 + getInstanceIdList(instances);
         vmTracker.publishEvent(new JobEvent(instanceRequest.getJobId(), msg, JobLifecycleEvent.AGENT_REBOOTED));
         LOG.info(msg);
@@ -224,7 +225,7 @@ public class AgentWatchdog implements Runnable {
                 dao.saveOrUpdate(image);
             }
         }
-        LOG.info("Setting number of instances to relaunch to: " + instances.size());
+        LOG.info("Setting number of instances to relaunch to: " + instances.size() + " for job " + jobId);
         instanceRequest.setNumberOfInstances(instances.size());
         instances.clear();
         // Create and send instance start request
@@ -235,7 +236,7 @@ public class AgentWatchdog implements Runnable {
             // Add directly to started instances since these are restarted from scratch
             startedInstances.add(newInfo);
             vmTracker.setStatus(createCloudStatus(instanceRequest, newInfo));
-            LOG.info("Added image (" + newInfo.getInstanceId() + ") to VMImage table");
+            LOG.info("Added image (" + newInfo.getInstanceId() + ") to VMImage table for job " + jobId);
             try {
                 dao.addImageFromInfo(instanceRequest.getJobId(), newInfo,
                         instanceRequest.getRegion());
@@ -243,7 +244,7 @@ public class AgentWatchdog implements Runnable {
                 LOG.warn("Error persisting VM Image: " + e);
             }
         }
-        LOG.info("At end of relaunch"
+        LOG.info("At end of relaunch for job " + jobId
                 + " startedInstances: " + startedInstances.size()
                 + " reportedInstances: " + reportedInstances.size());
     }

--- a/tank_vmManager/src/test/java/com/intuit/tank/vmManager/AgentWatchdogTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/vmManager/AgentWatchdogTest.java
@@ -50,15 +50,15 @@ public class AgentWatchdogTest {
     }
 
     @Test
-    public void alreadyRunningRunTest(@Mock VMTracker vmTrackerMock, @Mock CloudVmStatusContainer cloudVmStatusContainerMock) {
+    public void alreadyPendingRunTest(@Mock VMTracker vmTrackerMock, @Mock CloudVmStatusContainer cloudVmStatusContainerMock) {
         when(cloudVmStatusContainerMock.getEndTime()).thenReturn(null);
-        CloudVmStatus vmstatus = new CloudVmStatus("i-123456789", "123", "sg-123456", JobStatus.Running, VMImageType.AGENT, VMRegion.STANDALONE, VMStatus.running, new ValidationStatus(), 1, 1, new Date(), new Date());
+        CloudVmStatus vmstatus = new CloudVmStatus("i-123456789", "123", "sg-123456", JobStatus.Running, VMImageType.AGENT, VMRegion.STANDALONE, VMStatus.pending, new ValidationStatus(), 1, 1, new Date(), new Date());
         Set<CloudVmStatus> set = Stream.of(vmstatus).collect(Collectors.toCollection(HashSet::new));
         when(cloudVmStatusContainerMock.getStatuses()).thenReturn(set);
         when(vmTrackerMock.getVmStatusForJob(null)).thenReturn(cloudVmStatusContainerMock);
 
         VMInformation vmInformation = new VMInformation();
-        vmInformation.setState("running");
+        vmInformation.setState("pending");
         vmInformation.setInstanceId("i-123456789");
         List<VMInformation> vmInfo = Collections.singletonList( vmInformation );
 //        when(amazonInstanceMock.describeInstances(Mockito.anyString())).thenReturn(vmInfo);
@@ -76,19 +76,17 @@ public class AgentWatchdogTest {
     }
 
     @Test
-    public void progressToRunningRunTest(@Mock VMTracker vmTrackerMock, @Mock CloudVmStatusContainer cloudVmStatusContainerMock) {
+    public void progressToPendingRunTest(@Mock VMTracker vmTrackerMock, @Mock CloudVmStatusContainer cloudVmStatusContainerMock) {
         when(cloudVmStatusContainerMock.getEndTime()).thenReturn(null);
         CloudVmStatus vmstatusStarting = new CloudVmStatus("i-123456789", "123", "sg-123456", JobStatus.Starting, VMImageType.AGENT, VMRegion.STANDALONE, VMStatus.starting, new ValidationStatus(), 1, 1, new Date(), new Date());
         CloudVmStatus vmstatusPending = new CloudVmStatus("i-123456789", "123", "sg-123456", JobStatus.Starting, VMImageType.AGENT, VMRegion.STANDALONE, VMStatus.pending, new ValidationStatus(), 1, 1, new Date(), new Date());
-        CloudVmStatus vmstatusRunning = new CloudVmStatus("i-123456789", "123", "sg-123456", JobStatus.Running, VMImageType.AGENT, VMRegion.STANDALONE, VMStatus.running, new ValidationStatus(), 1, 1, new Date(), new Date());
         Set<CloudVmStatus> setStarting = Stream.of(vmstatusStarting).collect(Collectors.toCollection(HashSet::new));
         Set<CloudVmStatus> setPending = Stream.of(vmstatusPending).collect(Collectors.toCollection(HashSet::new));
-        Set<CloudVmStatus> setRunning = Stream.of(vmstatusRunning).collect(Collectors.toCollection(HashSet::new));
-        when(cloudVmStatusContainerMock.getStatuses()).thenReturn(setStarting).thenReturn(setPending).thenReturn(setRunning);
+        when(cloudVmStatusContainerMock.getStatuses()).thenReturn(setStarting).thenReturn(setPending);
         when(vmTrackerMock.getVmStatusForJob(null)).thenReturn(cloudVmStatusContainerMock);
 
         VMInformation vmInformation = new VMInformation();
-        vmInformation.setState("running");
+        vmInformation.setState("pending");
         vmInformation.setInstanceId("i-123456789");
         List<VMInformation> vmInfo = Collections.singletonList( vmInformation );
 //        when(amazonInstanceMock.describeInstances(Mockito.anyString())).thenReturn(vmInfo);
@@ -101,7 +99,7 @@ public class AgentWatchdogTest {
 //        verify(amazonInstanceMock, times(1)).describeInstances("i-123456789");
         verify(amazonInstanceMock, never()).killInstances(Mockito.anyList());
         verify(amazonInstanceMock, never()).reboot(Mockito.anyList());
-        verify(cloudVmStatusContainerMock, times(3)).getEndTime();
-        verify(cloudVmStatusContainerMock, times(3)).getStatuses();
+        verify(cloudVmStatusContainerMock, times(2)).getEndTime();
+        verify(cloudVmStatusContainerMock, times(2)).getStatuses();
     }
 }


### PR DESCRIPTION
**Short-term fix for agents stuck in pending**

As part of this [RCA Action Item](https://jira.intuit.com/browse/SRE-27028), a small temporary fix in the agent retry logic has been implemented and tested in QA-Tank.

Agents in `pending` status will no longer be relaunched by the agent retry logic. These agents have already reported back to the controller and wait for a start command from the controller while in `pending` status. They will no longer be terminated if the process from agent initialization to receiving this start command takes more than three minutes. Instead, agents that are still stuck in `starting` status and have not reported back to the controller will be relaunched. 

This is a short-term solution that has been validated to be working in QA-Tank, and will eventually be overhauled as part of  [updating agent retry logic](https://jira.intuit.com/browse/SRE-26928). This change also updates existing AgentWatchdog logs with `jobId` values and adds two new logs to the controller (JobManager) to track agent behavior between registering agents and making the start call. 

Reference: [Investigating Delay in Agent Start-Up](https://docs.google.com/document/d/1Yxgk0cC9Wny_f3L4JPzYtzRpTix-Yz2Lodxv4n8yLyM/edit?usp=sharing) 

**Example of the fix relaunching an agent stuck in `starting` to start the job**:
<img width="2267" alt="Better Relaunch Example" src="https://github.com/intuit/Tank/assets/31355049/a779a20b-4999-4bfa-9fcd-306b8e8c5d83">




Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.