### PR TITLE
Reverting XML namespaces from V2 back to V1

### DIFF
--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/agent/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/agent/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.agent;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/domain/agent/v2";
+    public static final String NAMESPACE_V1 = "urn:tank/domain/agent/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/datafiles/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/datafiles/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.datafiles;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/domain/datafiles/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/domain/datafile/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/filters/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/filters/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.filters;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/filters/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/filter/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/jobs/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/jobs/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.jobs;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/jobs/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/job/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/projects/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/projects/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.projects;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/domain/projects/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/domain/project/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/projects/adapter/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/projects/adapter/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.projects.adapter;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/domain/projects/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/domain/v1";
 
     private Namespace() {
     }

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/scripts/Namespace.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/models/scripts/Namespace.java
@@ -9,7 +9,7 @@ package com.intuit.tank.rest.mvc.rest.models.scripts;
 
 public class Namespace {
 
-    public static final String NAMESPACE_V1 = "urn:tank/domain/scripts/v2";
+    public static final String NAMESPACE_V1 = "urn:wats/domain/script/v1";
 
     private Namespace() {
     }


### PR DESCRIPTION
title: - Reverting XML namespaces from V2 back to V1

Tank tools currently running the V1 API are expecting NAMESPACE_V1 from Tank XML files, while the namespace for several models has been updated to V2. To remediate this issue, it will need to be reverted back to V1 to work with the current V1 tools. It will be kept at V1 since a namespace version update is not needed for continued functionality. 

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.