### PR TITLE
Script Group AJAX Fix- set component to not load dynamically

### DIFF
--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/filters/FilterServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/filters/FilterServiceV2Impl.java
@@ -7,6 +7,7 @@
  */
 package com.intuit.tank.rest.mvc.rest.services.filters;
 
+import com.intuit.tank.common.ScriptUtil;
 import com.intuit.tank.dao.ScriptDao;
 import com.intuit.tank.dao.ScriptFilterDao;
 import com.intuit.tank.dao.ScriptFilterGroupDao;
@@ -127,6 +128,7 @@ public class FilterServiceV2Impl implements FilterServiceV2 {
                 }
                 if (!filterIds.isEmpty()) {
                     ScriptFilterUtil.applyFilters(filterIds, script);
+                    ScriptUtil.setScriptStepLabels(script);
                     script = new ScriptDao().saveOrUpdate(script);
                     sendMsg(script, ModificationType.UPDATE);
                     return "Filters applied";

--- a/rest-mvc/src/main/resources/application.yml
+++ b/rest-mvc/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   config:
     use-legacy-processing: true
+  servlet:
+    multipart:
+      max-file-size: 200MB
+      max-request-size: 200MB
   codec:
     max-in-memory-size: 200MB
   main:
@@ -37,10 +41,6 @@ server:
       cookie:
         secure: true
         http-only: true
-    multipart:
-      enabled: true
-      max-file-size: 200MB
-      max-request-size: 200MB
   tomcat:
     accesslog:
       request-attributes-enabled: true

--- a/web/web_ui/src/main/webapp/projects/projectview.xhtml
+++ b/web/web_ui/src/main/webapp/projects/projectview.xhtml
@@ -171,7 +171,7 @@
     </h:form>
 
 
-    <p:dialog id="editScriptGroupID" appendTo="@(body)" dynamic="true" widgetVar="editScriptGroup" width="600"
+    <p:dialog id="editScriptGroupID" appendTo="@(body)" dynamic="false" widgetVar="editScriptGroup" width="600"
       height="550" header="Edit Script Group #{workloadScripts.scriptGroup.name}" modal="true" resizable="true"
       showEffect="puff" position="center">
       <h:form id="editGroupForm">


### PR DESCRIPTION
**Script Group AJAX Fix- set component to not load dynamically**

The intial fix for the script group dialogue component issue, where ajax calls are reloading cached Javascript files and stalling the page. Setting the component to not load dynamically will ensure all components are loaded beforehand to successfully complete the AJAX calls. This fix will only affect that specific component. 

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [X] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.