### PR TITLE
Tank V2 API: Add script update endpoint to import Tank XML scripts

### DIFF
--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
@@ -182,7 +182,7 @@ public class ScriptController {
             "        curl -v -X POST -H 'Content-Type: multipart/form-data' -H 'Content-Encoding: gzip' -F \"file=@<filename>.gz\" 'https://{tank-base-url}/v2/scripts/update'\n\n" +
             "Notes: \n\n " +
             " - This endpoint only accepts Tank script XML files for an existing Tank script to update. The script ID and script name in the file must match an existing script entry in Tank\n\n" +
-            " - This endpoint can be used to overwrite any Tank script by opening the Tank script XML file and changing the < id > and < name > keys to match the ID and script name of the existing Tank script \n\n", summary = "Import Tank XML script to Tank")
+            " - This endpoint can be used to overwrite any Tank script by opening the Tank script XML file and changing the < id > and < name > key values to match the ID and script name of the existing Tank script \n\n", summary = "Import Tank XML script to Tank")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Successfully updated script in Tank", content = @Content),
             @ApiResponse(responseCode = "400", description = "Script could not be updated", content = @Content)

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
@@ -174,15 +174,15 @@ public class ScriptController {
     }
 
     @RequestMapping(value = "/update", method = RequestMethod.POST, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
-    @Operation(description = "Update an existing Tank script by uploading a Tank script XML file \n\n " +
+    @Operation(description = "Update an existing Tank script by importing a Tank script XML file (supports gzip files) \n\n " +
             "Examples: \n\n" +
             "        curl -v -X POST -H 'Content-Type: multipart/form-data' -F \"file=@<filename>\" 'https://{tank-base-url}/v2/scripts/update' \n\n" +
             "\n\n" +
             "        gzip <filename>\n\n" +
             "        curl -v -X POST -H 'Content-Type: multipart/form-data' -H 'Content-Encoding: gzip' -F \"file=@<filename>.gz\" 'https://{tank-base-url}/v2/scripts/update'\n\n" +
             "Notes: \n\n " +
-            " - This endpoint only accepts Tank script XML files for an existing Tank script to update\n\n" +
-            " - You can use this endpoint to overwrite any Tank script by opening the Tank script XML file and changing the <id> and <name> keys to match the ID and script name of the target file \n\n", summary = "Import Tank XML script to Tank")
+            " - This endpoint only accepts Tank script XML files for an existing Tank script to update. The script ID and script name in the file must match an existing script entry in Tank\n\n" +
+            " - This endpoint can be used to overwrite any Tank script by opening the Tank script XML file and changing the < id > and < name > keys to match the ID and script name of the existing Tank script \n\n", summary = "Import Tank XML script to Tank")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Successfully updated script in Tank", content = @Content),
             @ApiResponse(responseCode = "400", description = "Script could not be updated", content = @Content)

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
@@ -160,7 +160,7 @@ public class ScriptController {
                              "Notes: \n\n " +
                              " - This endpoint only accepts XML script file recorded and produced by the Tank Proxy Package (see Tools tab in Tank)\n\n" +
                              " - Both script name and script id are optional parameters \n\n" +
-                             " - Passing in an existing Tank Script ID will overwrite the existing script in Tank, but will otherwise create a new Tank script", summary = "Upload script to Tank")
+                             " - Passing in an existing Tank Script ID will overwrite the existing script in Tank, but will otherwise create a new Tank script", summary = "Upload Tank Proxy script to Tank")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Successfully uploaded script file to Tank", content = @Content),
             @ApiResponse(responseCode = "400", description = "Script file could not be uploaded", content = @Content)
@@ -170,6 +170,26 @@ public class ScriptController {
                                                @RequestParam(required = false) @Parameter(description = "Existing Script ID (optional)", required = false) Integer id,
                                                @RequestParam(value = "file", required = true) @Parameter(schema = @Schema(type = "string", format = "binary", description = "Script file")) MultipartFile file) throws IOException{
         Map<String, String> response = scriptService.uploadProxyScript(name, id, contentEncoding, file);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = "/update", method = RequestMethod.POST, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+    @Operation(description = "Update an existing Tank script by uploading a Tank script XML file \n\n " +
+            "Examples: \n\n" +
+            "        curl -v -X POST -H 'Content-Type: multipart/form-data' -F \"file=@<filename>\" 'https://{tank-base-url}/v2/scripts/update' \n\n" +
+            "\n\n" +
+            "        gzip <filename>\n\n" +
+            "        curl -v -X POST -H 'Content-Type: multipart/form-data' -H 'Content-Encoding: gzip' -F \"file=@<filename>.gz\" 'https://{tank-base-url}/v2/scripts/update'\n\n" +
+            "Notes: \n\n " +
+            " - This endpoint only accepts Tank script XML files for an existing Tank script to update\n\n" +
+            " - You can use this endpoint to overwrite any Tank script by opening the Tank script XML file and changing the <id> and <name> keys to match the ID and script name of the target file \n\n", summary = "Import Tank XML script to Tank")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Successfully updated script in Tank", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Script could not be updated", content = @Content)
+    })
+    public ResponseEntity<Map<String, String>> updateTankScript(@RequestHeader(value = HttpHeaders.CONTENT_ENCODING, required = false) @Parameter(description = "Content-Encoding", required = false) String contentEncoding,
+                                                            @RequestParam(value = "file", required = true) @Parameter(schema = @Schema(type = "string", format = "binary", description = "Script file")) MultipartFile file) throws IOException{
+        Map<String, String> response = scriptService.updateTankScript(contentEncoding, file);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2.java
@@ -125,6 +125,21 @@ public interface ScriptServiceV2 {
      */
     public Map<String, String> uploadProxyScript(String name, Integer scriptId, String contentEncoding, MultipartFile file) throws IOException;
 
+    /**
+     * Update an existing Tank script with a Tank XML file
+     *
+     * @param contentEncoding
+     *           content encoding of file (checks for gzip file)
+     *
+     * @param file
+     *            Tank script XML file to be uploaded
+     *
+     * @throws GenericServiceCreateOrUpdateException
+     *         if there are errors uploading script
+     *
+     * @return scriptId with upload status JSON payload
+     */
+    public Map<String, String> updateTankScript(String contentEncoding, MultipartFile file) throws IOException;
 
     /**
      * Deletes a script associated with scriptID

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
@@ -13,6 +13,7 @@ import com.intuit.tank.harness.data.HDWorkload;
 import com.intuit.tank.project.BaseEntity;
 import com.intuit.tank.project.Script;
 import com.intuit.tank.project.ExternalScript;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceBadRequestException;
 import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceDeleteException;
 import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
 import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
@@ -34,10 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
@@ -318,25 +316,25 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
                 if (script.getId() > 0) {
                     Script existing = dao.findById(script.getId());
                     if (existing == null) {
-                        throw new GenericServiceCreateOrUpdateException("scripts", "Error updating script: Script passed with unknown id.", null);
+                        throw new GenericServiceBadRequestException("scripts", "updating script", "updating script - Cannot update a script that does not exist (script id " + script.getId() + ")");
                     }
                     if (!existing.getName().equals(script.getName())) {
-                        throw new GenericServiceCreateOrUpdateException("scripts", "Error updating script: Cannot change the name of an existing Script.", null);
+                        throw new GenericServiceBadRequestException("scripts", "updating script", "updating script - Cannot change the name of the existing script " + existing.getName());
                     }
                     script.setSerializedScriptStepId(existing.getSerializedScriptStepId());
                 }
                 script = dao.saveOrUpdate(script);
-                payload.put("message", "Script with script ID " + script.getId() + " updated successfully");
+                payload.put("message", "Script " + script.getName() + " with script ID " + script.getId() + " updated successfully");
             }
         } catch (Exception e) {
             LOGGER.error("Error updating script file: " + e.getMessage(), e);
-            throw new GenericServiceCreateOrUpdateException("scripts", "updating script via Tank script upload", e);
+            throw new GenericServiceCreateOrUpdateException("scripts", e.getMessage(), e);
         } finally {
             try {
                 fileInputStream.close();
             } catch (IOException e) {
                 LOGGER.error("Error updating script file: " + e.getMessage(), e);
-                throw new GenericServiceCreateOrUpdateException("scripts", "updating script via Tank script upload", e);
+                throw new GenericServiceCreateOrUpdateException("scripts",  e.getMessage(), e);
             }
         }
 

--- a/rest-mvc/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
+++ b/rest-mvc/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
@@ -182,6 +182,18 @@ public class ScriptControllerTest {
     }
 
     @Test
+    public void testUpdateScript() throws IOException {
+        Map<String, String> payload = new HashMap<>();
+        payload.put("message", "Script with script ID 7 updated successfully");
+        when(scriptService.updateTankScript("gzip", null)).thenReturn(payload);
+        ResponseEntity<Map<String, String>> result = scriptController.updateTankScript("gzip",null);
+        Map<String, String> response = result.getBody();
+        assertTrue(response.get("message").contains("Script with script ID 7 updated successfully"));
+        assertEquals(201, result.getStatusCodeValue());
+        verify(scriptService).updateTankScript( "gzip", null);
+    }
+
+    @Test
     public void testDeleteScript() {
         when(scriptService.deleteScript(1)).thenReturn("");
         ResponseEntity<String> result = scriptController.deleteScript(1);

--- a/rest-mvc/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
+++ b/rest-mvc/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
@@ -14,6 +14,7 @@ import com.intuit.tank.api.model.v1.script.ExternalScriptTO;
 import com.intuit.tank.api.model.v1.script.ScriptDescriptionContainer;
 import com.intuit.tank.api.model.v1.script.ExternalScriptContainer;
 import com.intuit.tank.api.model.v1.script.ScriptDescription;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceBadRequestException;
 import com.intuit.tank.rest.mvc.rest.services.scripts.ScriptServiceV2;
 import com.intuit.tank.rest.mvc.rest.util.ResponseUtil;
 import com.intuit.tank.rest.mvc.rest.util.ScriptServiceUtil;
@@ -24,14 +25,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.MediaType;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
@@ -169,28 +170,88 @@ public class ScriptControllerTest {
 
     @Test
     public void testUploadScript() throws IOException {
+        MultipartFile mockMultipartFile = mock(MultipartFile.class);
+        when(mockMultipartFile.getOriginalFilename()).thenReturn("testScript.xml");
+
         Map<String, String> payload = new HashMap<>();
         payload.put("scriptId", "7");
         payload.put("message", "Script with new script ID 7 has been uploaded");
-        when(scriptService.uploadProxyScript("testName", 0, "gzip", null)).thenReturn(payload);
-        ResponseEntity<Map<String, String>> result = scriptController.uploadScript("gzip", "testName", 0, null);
+        when(scriptService.uploadProxyScript("testName", 0, "gzip", mockMultipartFile)).thenReturn(payload);
+        ResponseEntity<Map<String, String>> result = scriptController.uploadScript("gzip", "testName", 0, mockMultipartFile);
         Map<String, String> response = result.getBody();
         assertEquals("7", response.get("scriptId"));
         assertTrue(response.get("message").contains("uploaded"));
         assertEquals(201, result.getStatusCodeValue());
-        verify(scriptService).uploadProxyScript("testName", 0, "gzip", null);
+        verify(scriptService).uploadProxyScript("testName", 0, "gzip", mockMultipartFile);
+
+        when(scriptService.uploadProxyScript("testName", 0, "", mockMultipartFile)).thenReturn(payload);
+        result = scriptController.uploadScript("", "testName", 0, mockMultipartFile);
+        response = result.getBody();
+        assertEquals("7", response.get("scriptId"));
+        assertTrue(response.get("message").contains("uploaded"));
+        assertEquals(201, result.getStatusCodeValue());
+        verify(scriptService).uploadProxyScript("testName", 0, "", mockMultipartFile);
+
+        // File Not Found
+        when(scriptService.uploadProxyScript("testName", 0, "", mockMultipartFile))
+                .thenThrow(new IOException("Error updating script file: script.xml (No such file or directory)"));
+        Exception exception = assertThrows(IOException.class, () -> {
+            scriptController.uploadScript("", "testName", 0, mockMultipartFile);
+        });
+        assertEquals("Error updating script file: script.xml (No such file or directory)", exception.getMessage());
     }
 
     @Test
-    public void testUpdateScript() throws IOException {
+    public void testUpdateTankScript() throws IOException {
+        MultipartFile mockMultipartFile = mock(MultipartFile.class);
+        when(mockMultipartFile.getOriginalFilename()).thenReturn("testScript.xml");
+
         Map<String, String> payload = new HashMap<>();
         payload.put("message", "Script with script ID 7 updated successfully");
-        when(scriptService.updateTankScript("gzip", null)).thenReturn(payload);
-        ResponseEntity<Map<String, String>> result = scriptController.updateTankScript("gzip",null);
+        when(scriptService.updateTankScript("gzip",  mockMultipartFile)).thenReturn(payload);
+        ResponseEntity<Map<String, String>> result = scriptController.updateTankScript("gzip",mockMultipartFile);
         Map<String, String> response = result.getBody();
         assertTrue(response.get("message").contains("Script with script ID 7 updated successfully"));
         assertEquals(201, result.getStatusCodeValue());
-        verify(scriptService).updateTankScript( "gzip", null);
+        verify(scriptService).updateTankScript( "gzip", mockMultipartFile);
+
+        when(scriptService.updateTankScript("", mockMultipartFile)).thenReturn(payload);
+        result = scriptController.updateTankScript("", mockMultipartFile);
+        response = result.getBody();
+        assertTrue(response.get("message").contains("Script with script ID 7 updated successfully"));
+        assertEquals(201, result.getStatusCodeValue());
+        verify(scriptService).updateTankScript( "", mockMultipartFile);
+
+        // File Not Found
+        when(scriptService.updateTankScript("",  mockMultipartFile))
+                .thenThrow(new IOException("Error updating script file: script.xml (No such file or directory)"));
+        Exception exception = assertThrows(IOException.class, () -> {
+            scriptController.updateTankScript("", mockMultipartFile);
+        });
+        assertEquals("Error updating script file: script.xml (No such file or directory)", exception.getMessage());
+
+        MultipartFile notFoundMultipartFile = mock(MultipartFile.class);
+        when(notFoundMultipartFile.getOriginalFilename()).thenReturn("testNonexistentScript.xml");
+
+        // Script does not exist
+        when(scriptService.updateTankScript("", notFoundMultipartFile))
+                .thenThrow(new GenericServiceBadRequestException("scripts", "updating script", "Cannot update a script that does not exist (script id 99)"));
+        exception = assertThrows(GenericServiceBadRequestException.class, () -> {
+            scriptController.updateTankScript("", notFoundMultipartFile);
+        });
+        assertEquals("Cannot update a script that does not exist (script id 99)", exception.getMessage());
+
+        MultipartFile changeNameMultipartFile = mock(MultipartFile.class);
+        when(changeNameMultipartFile.getOriginalFilename()).thenReturn("testChangeNameScript.xml");
+
+        // Can't change name of script
+        when(scriptService.updateTankScript("", changeNameMultipartFile))
+                .thenThrow(new GenericServiceBadRequestException("scripts", "updating script", "Cannot change the name of the existing script testScript"));
+        exception = assertThrows(GenericServiceBadRequestException.class, () -> {
+            scriptController.updateTankScript("", changeNameMultipartFile);
+        });
+        assertEquals("Cannot change the name of the existing script testScript", exception.getMessage());
+
     }
 
     @Test


### PR DESCRIPTION
**Tank API V2: Add script update endpoint to import Tank XML scripts**

`/v2/scripts/update`

This endpoint mirrors the functionality of importing Tank XML scripts to update existing scripts. It supports both XML and `.gzip` files. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.