### PR TITLE
Revert "Bump com.h2database:h2 from 1.4.200 to 2.2.220"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.2.220</version>
+        <version>1.4.200</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Reverts intuit/Tank#260

Version bump to 2.2.220 will require extensive updates to the codebase to accommodate version changes (currently fails data-access tests) 

JIRA: https://jira.intuit.com/browse/SRE-28367  