### PR TITLE
Script Groups: Add Selected scripts to script list in correct order

### DIFF
--- a/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
@@ -335,7 +335,8 @@ public class WorkloadScripts implements Serializable {
 
     public void deleteScriptGroupStep(ScriptGroupStep sgs) {
         scriptGroup.getScriptGroupSteps().remove(sgs);
-        scriptSelectionModel.getSource().add(0, sgs.getScript());
+        scriptSelectionModel.getSource().add(sgs.getScript());
+        initScriptSelectionModel();
     }
 
     public List<ScriptGroupStep> getSteps() {

--- a/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
@@ -109,7 +109,7 @@ public class WorkloadScripts implements Serializable {
 
     public void addToTarget() {
         if(!selectedAvailableScripts.isEmpty()) {
-            scriptSelectionModel.getTarget().addAll(0, selectedAvailableScripts);
+            scriptSelectionModel.getTarget().addAll(selectedAvailableScripts);
             scriptSelectionModel.getSource().removeAll(selectedAvailableScripts);
         }
     }
@@ -335,6 +335,7 @@ public class WorkloadScripts implements Serializable {
 
     public void deleteScriptGroupStep(ScriptGroupStep sgs) {
         scriptGroup.getScriptGroupSteps().remove(sgs);
+        scriptSelectionModel.getSource().add(0, sgs.getScript());
     }
 
     public List<ScriptGroupStep> getSteps() {


### PR DESCRIPTION
**Script Groups: Add Selected scripts to script list in correct order**

This PR fixes a bug where under Script Groups, Selected scripts are being added to the list of project scripts in inverse order such that the last selected script becomes the first script added. This has been changed such that Selected scripts are added to the list of project scripts in the order they are selected. 

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.