### PR TITLE
Script Group - Enable script re-ordering in script groups

### DIFF
--- a/data_model/src/main/java/com/intuit/tank/project/ScriptGroup.java
+++ b/data_model/src/main/java/com/intuit/tank/project/ScriptGroup.java
@@ -125,12 +125,21 @@ public class ScriptGroup extends BaseEntity implements Comparable<ScriptGroup> {
     }
 
     /**
-     * @param steps
+     * @param step
      *            the scripts to set
      */
     public void addScriptGroupStep(ScriptGroupStep step) {
         step.setScriptGroup(this);
         this.steps.add(step);
+    }
+
+    /**
+     * @param step
+     *            the scripts to remove
+     */
+    public void removeScriptGroupStep(ScriptGroupStep step) {
+        step.setScriptGroup(null);
+        this.steps.remove(step);
     }
 
     /**

--- a/data_model/src/main/java/com/intuit/tank/project/ScriptGroupStep.java
+++ b/data_model/src/main/java/com/intuit/tank/project/ScriptGroupStep.java
@@ -133,6 +133,9 @@ public class ScriptGroupStep extends BaseEntity {
             return false;
         }
         ScriptGroupStep o = (ScriptGroupStep) obj;
+        if(o.getScript() != null && getScript() != null){
+            return new EqualsBuilder().append(o.getId(), getId()).append(o.getScript(), getScript()).isEquals();
+        }
         return new EqualsBuilder().append(o.getId(), getId()).isEquals();
     }
 

--- a/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
@@ -15,14 +15,10 @@ package com.intuit.tank.project;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ConversationScoped;
-import javax.faces.context.FacesContext;
-import javax.faces.context.PartialViewContext;
-import javax.faces.event.AjaxBehaviorEvent;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -334,7 +330,7 @@ public class WorkloadScripts implements Serializable {
     }
 
     public void deleteScriptGroupStep(ScriptGroupStep sgs) {
-        scriptGroup.getScriptGroupSteps().remove(sgs);
+        scriptGroup.removeScriptGroupStep(sgs);
         scriptSelectionModel.getSource().add(sgs.getScript());
         initScriptSelectionModel();
     }

--- a/web/web_ui/src/main/webapp/projects/projectview.xhtml
+++ b/web/web_ui/src/main/webapp/projects/projectview.xhtml
@@ -280,7 +280,9 @@
           <div class="vertical-spacer" />
           <div style="height: 150px; overflow: auto; border: 1px solid black;">
             <p:dataTable id="scriptStepTableId" value="#{workloadScripts.steps}" var="step"
-                         class="pad2" style="width:100%;" noDataLabel="Add Scripts using the selector above.">
+                         class="pad2" style="width:100%;" noDataLabel="Add Scripts using the selector above." draggableRows="true">
+
+              <p:ajax event="rowReorder" update=":editGroupForm:scriptStepTableId"/>
 
               <p:column styleClass="ellipsis min-column-size" style="width: 270px;">
                 <f:facet name="header">


### PR DESCRIPTION
**Script Group - Enable script re-ordering in script groups**

This change allows users to reorder scripts in the script group list per script group via drag and drop. This change also fixes the issue of duplicate scripts being added back to available scripts by updating the `equals` function to check against both ID and script. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.