### PR TITLE
Autoclose File Upload Resources with try-with-resources statement

### DIFF
--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2Impl.java
@@ -151,10 +151,8 @@ public class DataFileServiceV2Impl implements DataFileServiceV2 {
         Map<String, String> payload = new HashMap<>();
         datafileId = datafileId == null ? 0 : datafileId;
         contentEncoding = contentEncoding == null ? "" : contentEncoding;
-        BufferedReader bufferedReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
-                new BufferedReader(new InputStreamReader(new GZIPInputStream(file.getInputStream()))) :
-                new BufferedReader(new InputStreamReader(file.getInputStream()));
-        try (InputStream decompressed = IOUtils.toInputStream(IOUtils.toString(bufferedReader), StandardCharsets.UTF_8)) {
+        try (InputStream fileInputStream = file.getInputStream();
+             InputStream decompressed = "gzip".equalsIgnoreCase(contentEncoding) ? new GZIPInputStream(fileInputStream) : fileInputStream) {
             DataFileDao dao = new DataFileDao();
             DataFile dataFile = dao.findById(datafileId);
             if (dataFile == null) {
@@ -179,12 +177,6 @@ public class DataFileServiceV2Impl implements DataFileServiceV2 {
                 }
             }
             payload.put("datafileId", Integer.toString(dataFile.getId()));
-            try {
-                decompressed.close();
-            } catch (IOException e) {
-                LOGGER.error("Error uploading datafile: " + e.getMessage(), e);
-                throw new GenericServiceCreateOrUpdateException("datafiles", "new datafile via datafile upload", e);
-            }
         } catch (Exception e) {
             LOGGER.error("Error uploading datafile: " + e.getMessage(), e);
             throw new GenericServiceCreateOrUpdateException("datafiles", "new datafile via datafile upload", e);

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2Impl.java
@@ -151,8 +151,10 @@ public class DataFileServiceV2Impl implements DataFileServiceV2 {
         Map<String, String> payload = new HashMap<>();
         datafileId = datafileId == null ? 0 : datafileId;
         contentEncoding = contentEncoding == null ? "" : contentEncoding;
-        try (InputStream fileInputStream = file.getInputStream();
-             InputStream decompressed = "gzip".equalsIgnoreCase(contentEncoding) ? new GZIPInputStream(fileInputStream) : fileInputStream) {
+        try (BufferedReader bufferedReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
+                new BufferedReader(new InputStreamReader(new GZIPInputStream(file.getInputStream()))) :
+                new BufferedReader(new InputStreamReader(file.getInputStream()));
+                InputStream decompressed = IOUtils.toInputStream(IOUtils.toString(bufferedReader), StandardCharsets.UTF_8)) { // correctly handles compressed datafile content
             DataFileDao dao = new DataFileDao();
             DataFile dataFile = dao.findById(datafileId);
             if (dataFile == null) {

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
@@ -245,11 +245,9 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
         Map<String, String> payload = new HashMap<>();
         scriptId = scriptId == null ? 0 : scriptId;
         contentEncoding = contentEncoding == null ? "" : contentEncoding;
-        try (InputStream fileInputStream = file.getInputStream();
-             InputStreamReader inputStreamReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
-                     new InputStreamReader(new GZIPInputStream(fileInputStream)) :
-                     new InputStreamReader(fileInputStream);
-             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+        try (BufferedReader bufferedReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
+                new BufferedReader(new InputStreamReader(new GZIPInputStream(file.getInputStream()))) :
+                new BufferedReader(new InputStreamReader(file.getInputStream()))) {
             Script script = new ScriptDao().findById(scriptId);
             if (script == null){
                 script = new Script();

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2Impl.java
@@ -243,10 +243,13 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
     @Override
     public Map<String, String> uploadProxyScript(String name, Integer scriptId, String contentEncoding, MultipartFile file) throws IOException {
         Map<String, String> payload = new HashMap<>();
-        InputStream fileInputStream = file.getInputStream();
         scriptId = scriptId == null ? 0 : scriptId;
         contentEncoding = contentEncoding == null ? "" : contentEncoding;
-        try {
+        try (InputStream fileInputStream = file.getInputStream();
+             InputStreamReader inputStreamReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
+                     new InputStreamReader(new GZIPInputStream(fileInputStream)) :
+                     new InputStreamReader(fileInputStream);
+             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
             Script script = new ScriptDao().findById(scriptId);
             if (script == null){
                 script = new Script();
@@ -264,9 +267,6 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
                 script.setName(name);
             }
 
-            BufferedReader bufferedReader = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
-                    new BufferedReader(new InputStreamReader(new GZIPInputStream(fileInputStream))) :
-                    new BufferedReader(new InputStreamReader(fileInputStream));
             scriptProcessor.getScriptSteps(bufferedReader, new ArrayList<>());
             script = new ScriptDao().saveOrUpdate(script);
             sendMsg(script, ModificationType.UPDATE);
@@ -281,13 +281,6 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
         } catch (Exception e) {
             LOGGER.error("Error uploading script file: " + e.getMessage(), e);
             throw new GenericServiceCreateOrUpdateException("scripts", "new script via script upload", e);
-        } finally {
-            try {
-                fileInputStream.close();
-            } catch (IOException e) {
-                LOGGER.error("Error uploading script file: " + e.getMessage(), e);
-                throw new GenericServiceCreateOrUpdateException("scripts", "new script via script upload", e);
-            }
         }
         return payload;
     }
@@ -300,18 +293,14 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
     @Override
     public Map<String, String> updateTankScript(String  contentEncoding, MultipartFile file) throws IOException {
         Map<String, String> payload = new HashMap<>();
-        InputStream fileInputStream = file.getInputStream();
         contentEncoding = contentEncoding == null ? "" : contentEncoding;
 
-        try {
+        try (InputStream fileInputStream = file.getInputStream();
+             InputStream inputStream = "gzip".equalsIgnoreCase(contentEncoding) ? new GZIPInputStream(fileInputStream) : fileInputStream) {
             ScriptDao dao = new ScriptDao();
 
-            if (fileInputStream != null) {
-                if ("gzip".equalsIgnoreCase(contentEncoding)) {
-                    fileInputStream = new GZIPInputStream(fileInputStream);
-                }
-
-                ScriptTO scriptTo = ScriptServiceUtil.parseXMLtoScriptTO(fileInputStream);
+            if (inputStream != null) {
+                ScriptTO scriptTo = ScriptServiceUtil.parseXMLtoScriptTO(inputStream);
                 Script script = ScriptServiceUtil.transferObjectToScript(scriptTo);
                 if (script.getId() > 0) {
                     Script existing = dao.findById(script.getId());
@@ -329,13 +318,6 @@ public class ScriptServiceV2Impl implements ScriptServiceV2 {
         } catch (Exception e) {
             LOGGER.error("Error updating script file: " + e.getMessage(), e);
             throw new GenericServiceCreateOrUpdateException("scripts", e.getMessage(), e);
-        } finally {
-            try {
-                fileInputStream.close();
-            } catch (IOException e) {
-                LOGGER.error("Error updating script file: " + e.getMessage(), e);
-                throw new GenericServiceCreateOrUpdateException("scripts",  e.getMessage(), e);
-            }
         }
 
         return payload;


### PR DESCRIPTION
**Autoclose File Upload Resources with try-with-resources statement**
Updated resource management for file uploads (script/datafile uploads) to autoclose at the end of the statement to avoid any future memory leak issues

Please make sure these check boxes are checked before submitting
- [X] ** Squashed Commits **
- [X] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.