### PR TITLE
Thread Buildup Fix - Reduce total active threads to only agent threads

### DIFF
--- a/api/src/main/java/com/intuit/tank/harness/AmazonUtil.java
+++ b/api/src/main/java/com/intuit/tank/harness/AmazonUtil.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.message.ObjectMessage;
  */
 public class AmazonUtil {
 
-    private static HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build();
+    private static final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build();
 
     private static final Logger LOG = LogManager.getLogger(AmazonUtil.class);
     private static final String BASE = "http://169.254.169.254/latest";


### PR DESCRIPTION
**Thread Buildup Fix - Reduce total active threads to only agent threads**

Currently, when running a job, each agent instance is spinning up numerous additional threads per user thread, resulting in a total of up to 10x-15x times the amount of active threads requested. This resulted in an overhead of unnecessary active threads during job runs, and in some cases, caused agents to crash for certain EC2 instance types when ran long enough:

<img width="600" alt="Screenshot 2023-10-25 at 10 25 14 AM" src="https://github.com/intuit/Tank/assets/31355049/342adc8e-ae04-44ed-9477-85b4393ff994">






The root cause of these unnecessary additional threads was found to be due to a call from the `LogUtil` class to `AmazonUtil` creating a new `HttpClient` object each time it was called and subsequently spinning up around 7-8 helper threads in the process for each call for each agent/user thread (see above). The logging util class is used throughout the agent code. 

This is fixed by moving the `HttpClient` object to be a static member of `AmazonUtil`, so that it is created once and reused for all calls. This greatly improves the performance of jobs by now limiting the total number of threads run to only agent threads:

<img width="600" alt="Screenshot 2023-10-25 at 10 41 28 AM" src="https://github.com/intuit/Tank/assets/31355049/fc4c8167-fdfc-4b04-9d25-ce8318dcbf2a">






Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.