### PR TITLE
Small fix for saving new linear project

### DIFF
--- a/data_model/src/main/java/com/intuit/tank/project/JobRegion.java
+++ b/data_model/src/main/java/com/intuit/tank/project/JobRegion.java
@@ -59,7 +59,7 @@ public class JobRegion extends BaseEntity implements RegionRequest, Comparable<J
 
     @NotNull
     @Column(name = "percentage", nullable = false)
-    private String percentage;
+    private String percentage = "0";
 
     /**
      * 


### PR DESCRIPTION
**Small fix for saving new linear project**
Sets a default value for nonlinear region percentages (similar to the new [numAgents](https://github.com/intuit/Tank/blob/cf7b7d817cc1f3ed0577b019edf309e19ce03457/data_model/src/main/java/com/intuit/tank/project/BaseJob.java#L72) field) to allow saving/save as for new linear projects that do not use nonlinear settings, passing the not-null check

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.