### PR TITLE
Nonlinear Workload - Remove 1.0 user/sec Ramp Rate Limit per Agent

### DIFF
--- a/web/web_ui/src/main/webapp/projects/projectview.xhtml
+++ b/web/web_ui/src/main/webapp/projects/projectview.xhtml
@@ -132,7 +132,6 @@
                              value="#{usersAndTimes.endRate}"
                              styleClass="formInput inputWidthSmall" required="true"
                              requiredMessage="Agent User Ramp Rate cannot be empty." rendered="#{usersAndTimes.incrementStrategy == 'standard'}">
-                  <f:validateDoubleRange minimum = "0.001" maximum = "1.000" />
                 </h:inputText>
                 <p:ajax event="save" update=":mainForm:endRateTF" rendered="#{usersAndTimes.incrementStrategy == 'standard'}" />
               </p:inplace>


### PR DESCRIPTION
**Nonlinear Workload - Remove 1.0 user/sec Ramp Rate Limit per Agent**
Updates UI to allow entry of ramp rates above 1.0 user/sec

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.