### PR TITLE
Implement Retry for Agents Starting HttpServer

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
@@ -65,7 +65,7 @@ public class CommandListener {
                     LOG.info(LogUtil.getLogMessage("Attempt " + attempt + ": Port " + port + " is currently in use. Waiting..."));
                     try {
                         Thread.sleep(RETRY_SLEEP);
-                    } catch ( InterruptedException ie) { /*Ignore*/ }
+                    } catch (InterruptedException ignored) {}
                 } catch (IOException e) {
                     LOG.error(LogUtil.getLogMessage("Attempt " + attempt + ": Error starting httpServer: " + e), e);
                     throw new RuntimeException(e);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
@@ -13,9 +13,12 @@ package com.intuit.tank.harness;
  * #L%
  */
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 
 import com.google.common.collect.ImmutableMap;
 import com.sun.net.httpserver.HttpContext;
@@ -44,12 +47,18 @@ public class CommandListener {
     public synchronized static void startHttpServer(int port) {
         if (!started) {
             try {
+                LOG.info(LogUtil.getLogMessage("BEFORE STARTING SERVER - Starting httpserver on port " + port));
+                LOG.info(LogUtil.getLogMessage(AmazonUtil.getInstanceId() + "- Port In Use?: " + isPortInUse(port)));
+                if(isPortInUse(port)) {
+                    LOG.info(LogUtil.getLogMessage("PORT IN USE BY ANOTHER SERVICE"));
+                }
+                getServiceInfo(port);
                 HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
                 HttpContext context = server.createContext("/");
                 context.setHandler(CommandListener::handleRequest);
                 server.start();
                 System.out.println("Starting httpserver on port " + port);
-                LOG.info(LogUtil.getLogMessage("Starting httpserver on port " + port));
+                LOG.info(LogUtil.getLogMessage("AFTER STARTING SERVER - Starting httpserver on port " + port));
                 started = true;
             } catch (IOException e) {
                 LOG.error(LogUtil.getLogMessage("Error starting httpServer: " + e), e);
@@ -57,6 +66,35 @@ public class CommandListener {
             }
         }
     }
+
+    public static boolean isPortInUse(int port) {
+        boolean inUse = false;
+
+        try (ServerSocket ss = new ServerSocket(port)) {
+            ss.setReuseAddress(true);
+        } catch (IOException e) {
+            inUse = true;
+        }
+
+        return inUse;
+    }
+
+    public static void getServiceInfo(int port) {
+        String command = "sudo lsof -i tcp:" + port;
+        try {
+            Process process = Runtime.getRuntime().exec(command);
+            BufferedReader bufferedReader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                LOG.info(LogUtil.getLogMessage(line));
+            }
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     private static void handleRequest(HttpExchange exchange) {
         try {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
@@ -51,13 +51,14 @@ public class CommandListener {
                 LOG.info(LogUtil.getLogMessage(AmazonUtil.getInstanceId() + "- Port In Use?: " + isPortInUse(port)));
                 if(isPortInUse(port)) {
                     LOG.info(LogUtil.getLogMessage("PORT IN USE BY ANOTHER SERVICE"));
+                    getServiceInfo(port);
                 }
-                getServiceInfo(port);
                 HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
                 HttpContext context = server.createContext("/");
                 context.setHandler(CommandListener::handleRequest);
                 server.start();
                 System.out.println("Starting httpserver on port " + port);
+                getServiceInfo(port);
                 LOG.info(LogUtil.getLogMessage("AFTER STARTING SERVER - Starting httpserver on port " + port));
                 started = true;
             } catch (IOException e) {
@@ -80,12 +81,13 @@ public class CommandListener {
     }
 
     public static void getServiceInfo(int port) {
-        String command = "sudo lsof -i tcp:" + port;
+        String command = "lsof -i tcp:" + port;
         try {
             Process process = Runtime.getRuntime().exec(command);
             BufferedReader bufferedReader =
                     new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
+            LOG.info(LogUtil.getLogMessage("LIST OF RUNNING PROCESSES: "));
             while ((line = bufferedReader.readLine()) != null) {
                 LOG.info(LogUtil.getLogMessage(line));
             }

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
@@ -60,7 +60,6 @@ public class CommandListener {
                 System.out.println("Starting httpserver on port " + port);
                 getServiceInfo(port);
                 LOG.info(LogUtil.getLogMessage("AFTER STARTING SERVER - Starting httpserver on port " + port));
-                started = true;
             } catch (IOException e) {
                 LOG.error(LogUtil.getLogMessage("Error starting httpServer: " + e), e);
                 throw new RuntimeException(e);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/CommandListener.java
@@ -65,11 +65,7 @@ public class CommandListener {
                     LOG.info(LogUtil.getLogMessage("Attempt " + attempt + ": Port " + port + " is currently in use. Waiting..."));
                     try {
                         Thread.sleep(RETRY_SLEEP);
-                    } catch ( InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        LOG.error(LogUtil.getLogMessage("Attempt " + attempt + ": Error starting httpServer: " + e), e);
-                        throw new RuntimeException(e);
-                    }
+                    } catch ( InterruptedException ie) { /*Ignore*/ }
                 } catch (IOException e) {
                     LOG.error(LogUtil.getLogMessage("Attempt " + attempt + ": Error starting httpServer: " + e), e);
                     throw new RuntimeException(e);


### PR DESCRIPTION
**Implement Retry for Agents Starting HttpServer**
The most common reason for agents not being able to connect to the controller and requiring a restart (terminating that instance and spinning up a new one) observed so far is its inability to start its HttpServer. The cause has been pinpointed: another service is running on that port, and the agent fails to connect and throws an error, causing it to terminate. This has now been fixed to retry the call to start the httpserver, saving time in which the agent will come up (on average 40-60 seconds delay compare to terminating and restarting (4+ mins). This issue rarely occurs per job run, but the likelihood increases as the number of agents started at once increases (most likely will run into this when running 100+ agents at once). This change will allow the job to run with the same amount of agents it first began with, simply waiting for the failing agent to connect instead of terminating it. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.