### PR TITLE
Set Initializing Agents Before Load Start Configurable Per Job

### DIFF
--- a/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequest.java
+++ b/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequest.java
@@ -94,6 +94,12 @@ public interface JobRequest extends Serializable {
     public abstract boolean isUseEips();
 
     /**
+     *
+     * @return
+     */
+    public abstract boolean isUseTwoStep();
+
+    /**
      * @return the userIntervalIncrement
      */
     public abstract int getUserIntervalIncrement();

--- a/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequestImpl.java
+++ b/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequestImpl.java
@@ -50,6 +50,7 @@ public final class JobRequestImpl implements Serializable, JobRequest {
     private int baselineVirtualUsers;
     private long simulationTime;
     private boolean useEips;
+    private boolean useTwoStep;
     private int userIntervalIncrement;
     private String reportingMode = TankConstants.RESULTS_NONE;
     private String loggingProfile = LoggingProfile.STANDARD.name();
@@ -85,6 +86,13 @@ public final class JobRequestImpl implements Serializable, JobRequest {
      */
     public boolean isUseEips() {
         return useEips;
+    }
+
+    /**
+     * @return the useTwoStep
+     */
+    public boolean isUseTwoStep() {
+        return useTwoStep;
     }
 
     /**
@@ -310,6 +318,7 @@ public final class JobRequestImpl implements Serializable, JobRequest {
                 .append("stopBehavior", StopBehavior.fromString(stopBehavior).getDisplay())
                 .append("simulationTime", simulationTime)
                 .append("useEips", useEips)
+                .append("useTwoStep", useTwoStep)
                 .append("baselineVirtualUsers", baselineVirtualUsers)
                 .append("userIntervalIncrement", userIntervalIncrement)
                 .append("endRate", endRate)
@@ -419,6 +428,12 @@ public final class JobRequestImpl implements Serializable, JobRequest {
         @SuppressWarnings("unchecked")
         public GeneratorT withUseEips(boolean aValue) {
             instance.useEips = aValue;
+            return (GeneratorT) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public GeneratorT withUseTwoStep(boolean aValue) {
+            instance.useTwoStep = aValue;
             return (GeneratorT) this;
         }
 

--- a/api/src/test/java/com/intuit/tank/vm/vmManager/JobRequestImplCpTest.java
+++ b/api/src/test/java/com/intuit/tank/vm/vmManager/JobRequestImplCpTest.java
@@ -171,6 +171,7 @@ public class JobRequestImplCpTest {
                 .append("stopBehavior", StopBehavior.fromString(request.getStopBehavior()).getDisplay())
                 .append("simulationTime", request.getSimulationTime())
                 .append("useEips", request.isUseEips())
+                .append("useTwoStep", request.isUseTwoStep())
                 .append("baselineVirtualUsers", request.getBaselineVirtualUsers())
                 .append("userIntervalIncrement", "0")
                 .append("endRate", "0.0")

--- a/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
+++ b/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
@@ -107,6 +107,9 @@ public abstract class BaseJob extends BaseEntity {
     @Column(name = "use_eips")
     private Boolean useEips;
 
+    @Column(name = "use_two_step")
+    private Boolean useTwoStep;
+
     /**
      * 
      */
@@ -137,6 +140,7 @@ public abstract class BaseJob extends BaseEntity {
         this.numAgents = copy.numAgents;
         this.vmInstanceType = copy.vmInstanceType;
         this.useEips = copy.useEips;
+        this.useTwoStep = copy.useTwoStep;
         this.tankClientClass = copy.getTankClientClass();
     }
 
@@ -187,6 +191,21 @@ public abstract class BaseJob extends BaseEntity {
      */
     public void setUseEips(boolean useEips) {
         this.useEips = useEips;
+    }
+
+    /**
+     * @return two-step job start setting
+     */
+    public boolean isUseTwoStep() {
+        return useTwoStep != null ? useTwoStep : false;
+    }
+
+    /**
+     * @param useTwoStep
+     *            enable/disable two-step job starts
+     */
+    public void setUseTwoStep(boolean useTwoStep) {
+        this.useTwoStep = useTwoStep;
     }
 
     /**

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatter.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatter.java
@@ -80,6 +80,7 @@ public class JobDetailFormatter {
             addProperty(sb, "Tank Http Client", config.getAgentConfig().getTankClientName(proposedJobInstance.getTankClientClass()));
             addProperty(sb, "Agent VM Type", getVmDetails(config, proposedJobInstance.getVmInstanceType()));
             addProperty(sb, "Assign Elastic Ips", Boolean.toString(proposedJobInstance.isUseEips()));
+            addProperty(sb, "Enable Two-Step Job Start", Boolean.toString(proposedJobInstance.isUseTwoStep()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)) {
                 addProperty(sb, "Number of Agents", Integer.toString(proposedJobInstance.getNumAgents()));
             } else {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/WorkLoadFactory.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/WorkLoadFactory.java
@@ -136,6 +136,7 @@ public class WorkLoadFactory {
                 .withStopBehavior(job.getStopBehavior())
                 .withReportingMode(job.getReportingMode())
                 .withUseEips(job.isUseEips())
+                .withUseTwoStep(job.isUseTwoStep())
                 .withVmInstanceType(job.getVmInstanceType())
                 .withnumUsersPerAgent(job.getNumUsersPerAgent())
                 .withNumAgents(job.getNumAgents())

--- a/web/web_support/src/main/java/com/intuit/tank/job/ActJobNodeBean.java
+++ b/web/web_support/src/main/java/com/intuit/tank/job/ActJobNodeBean.java
@@ -42,6 +42,7 @@ public class ActJobNodeBean extends JobNodeBean {
         this.setActiveUsers(String.valueOf(job.getBaselineVirtualUsers()));
         this.setTotalUsers(String.valueOf(job.getTotalVirtualUsers()));
         this.setTargetRampRate(String.valueOf(job.getTargetRampRate() * job.getNumAgents()));
+        this.setUseTwoStep(job.isUseTwoStep());
         this.jobDetails = job.getJobDetails();
         this.estimatedNonlinearSteadyStateUsers = estimateNonlinearSteadyStateUsers(job.getTargetRampRate(), job.getRampTime(), job.getNumAgents());
         this.setStartTime(job.getStartTime());

--- a/web/web_support/src/main/java/com/intuit/tank/job/JobNodeBean.java
+++ b/web/web_support/src/main/java/com/intuit/tank/job/JobNodeBean.java
@@ -50,6 +50,7 @@ public abstract class JobNodeBean implements Serializable {
     private Date startTime;
     private Date endTime;
     private boolean hasRights = false;
+    private Boolean useTwoStep = false;
     private Map<Date, List<UserDetail>> statusDetailMap;
     // private Map<Date, Map<String, TPSInfo>> tpsInfoMap;
     private int tps;
@@ -227,6 +228,21 @@ public abstract class JobNodeBean implements Serializable {
      */
     public void setTargetRampRate(String targetRampRate) {
         this.targetRampRate = targetRampRate;
+    }
+
+    /**
+     * @return two-step job start setting
+     */
+    public boolean isUseTwoStep() {
+        return useTwoStep != null ? useTwoStep : false;
+    }
+
+    /**
+     * @param useTwoStep
+     *            two-step job start setting
+     */
+    public void setUseTwoStep(boolean useTwoStep) {
+        this.useTwoStep = useTwoStep;
     }
 
     /**

--- a/web/web_support/src/main/java/com/intuit/tank/job/JobQueueAction.java
+++ b/web/web_support/src/main/java/com/intuit/tank/job/JobQueueAction.java
@@ -63,7 +63,9 @@ public class JobQueueAction {
         AWSXRay.getCurrentSegment().putAnnotation("job.action", "startAgents");
         AWSXRay.getCurrentSegment().putAnnotation("jobId", node.getJobId());
         if (node instanceof ActJobNodeBean) {
-            controller.startAgents(node.getId());
+            if(node.isUseTwoStep()) {
+                controller.startAgents(node.getId());
+            }
         }
     }
 

--- a/web/web_support/src/main/java/com/intuit/tank/project/JobDetailFormatter.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/JobDetailFormatter.java
@@ -86,6 +86,7 @@ public class JobDetailFormatter {
             addProperty(sb, "Tank Http Client", config.getAgentConfig().getTankClientName(proposedJobInstance.getTankClientClass()));
             addProperty(sb, "Agent VM Type", getVmDetails(config, proposedJobInstance.getVmInstanceType()));
             addProperty(sb, "Assign Elastic Ips", Boolean.toString(proposedJobInstance.isUseEips()));
+            addProperty(sb, "Enable Two-Step Job Start", Boolean.toString(proposedJobInstance.isUseTwoStep()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)) {
                 addProperty(sb, "Number of Agents", Integer.toString(proposedJobInstance.getNumAgents()));
             } else {

--- a/web/web_support/src/main/java/com/intuit/tank/project/JobMaker.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/JobMaker.java
@@ -265,6 +265,22 @@ public class JobMaker implements Serializable {
     }
 
     /**
+     *
+     * @return
+     */
+    public boolean isUseTwoStep() {
+        return projectBean.getJobConfiguration().isUseTwoStep();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public void setUseTwoStep(boolean b) {
+        projectBean.getJobConfiguration().setUseTwoStep(b);
+    }
+
+    /**
      * 
      * @param location
      */
@@ -311,6 +327,7 @@ public class JobMaker implements Serializable {
             proposedJobInstance.setCreator(securityContext.getCallerPrincipal().getName());
             proposedJobInstance.setScheduledTime(new Date());
             proposedJobInstance.setUseEips(isUseEips());
+            proposedJobInstance.setUseTwoStep((isUseTwoStep()));
             proposedJobInstance.setTankClientClass(getTankClientClass());
             proposedJobInstance.setLocation(getLocation());
             proposedJobInstance.setVmInstanceType(getVmInstanceType());

--- a/web/web_ui/src/main/webapp/agents/index.xhtml
+++ b/web/web_ui/src/main/webapp/agents/index.xhtml
@@ -108,8 +108,9 @@
             <h:outputText value="#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Jobs Running" rendered="#{not node.allSubNodesCompleted() and node.type eq 'project'}" />
             <h:outputText value="Completed" rendered="#{node.allSubNodesCompleted() and node.type eq 'project'}" />
             <h:outputText value="#{node.status}" rendered="#{not node.hasSubNodes() and node.type eq 'job'}" />
-            <h:outputText value="#{node.status} (#{node.getTotalSubNodesReady()}/#{node.getCurrentSubNodes().size()} Agents Ready)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status eq 'Starting'}" />
-            <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status ne 'Starting'}" />
+            <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes() and node.type eq 'job' and not node.useTwoStep}" />
+            <h:outputText value="#{node.status} (#{node.getTotalSubNodesReady()}/#{node.getCurrentSubNodes().size()} Agents Ready)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status eq 'Starting' and node.useTwoStep}" />
+            <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status ne 'Starting' and node.useTwoStep}" />
             <h:outputText value="#{node.status}" rendered="#{node.type eq 'vm'}" />
           </p:column>
 
@@ -189,7 +190,7 @@
                 disabled="#{!node.isRunnable() or !jobQueueManager.canControlJob(node)}" ajax="true"
                 update=":mainForm:jobTableId" />
               <p:commandButton id="btnStart" action="#{jobQueueAction.startAgents(node)}" value="L" title="Start Load"
-                               onerror="window.location.reload()" rendered="#{node.type ne 'project'}"
+                               onerror="window.location.reload()" rendered="#{node.type ne 'project' and node.useTwoStep}"
                                disabled="#{!node.isStartable() or !jobQueueManager.canControlJob(node)}" ajax="true"
                                update=":mainForm:jobTableId" />
               <p:commandButton id="btnKill" action="#{jobQueueAction.kill(node)}" value="K" title="Kill"

--- a/web/web_ui/src/main/webapp/projects/addWorkloadToJobQueue.xhtml
+++ b/web/web_ui/src/main/webapp/projects/addWorkloadToJobQueue.xhtml
@@ -3,6 +3,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:f="http://xmlns.jcp.org/jsf/core"
   xmlns:h="http://xmlns.jcp.org/jsf/html"
+  xmlns:ts="http://xmlns.jcp.org/jsf/composite/tag"
   xmlns:p="http://primefaces.org/ui">
 
   <div id="addWorkloads">
@@ -115,6 +116,24 @@
             <div class="formInputDiv">
               <p:selectBooleanCheckbox id="useEipsCB"
                 value="#{jobMaker.useEips}" />
+            </div>
+          </div>
+
+          <div class="formRow">
+            <div class="formLabelDiv">
+              <h:outputLabel for="useTwoStepCB"
+                             value="Enable Two-Step Job Start"
+                             styleClass="formLabel required" />
+              <ts:tip tipId="TwoStepTip"
+                      text="Enabling Two Step Job Start will configure the job to start in a two step process: launching all the agents/load injectors before waiting on the command to start load.
+                            This mode will also enable the `(L) - Start Load` job command in the UI. Running the job with `(R) - Run` will launch and check in the agents for the job. Once all agents are ready to drive load, denoted by
+                            a new 'ready' agent status, the job will wait for the start load command (L) to start load. This feature is particularly useful in the context of gate rush/spike testing where load start times need to be exact.
+                            Note: Agents will need to receive the start load command within 5-10 minutes of checking in to ensure agent connectivity."/>
+            </div>
+            <div class="formInputDiv">
+              <p:selectBooleanCheckbox id="useTwoStepCB"
+                                       value="#{jobMaker.useTwoStep}" />
+
             </div>
           </div>
         </h:panelGroup>

--- a/web/web_ui/src/main/webapp/projects/projectjobqueue.xhtml
+++ b/web/web_ui/src/main/webapp/projects/projectjobqueue.xhtml
@@ -113,8 +113,9 @@
         style="width:#{projectJobQueueManager.tablePrefs.getSize('statusColumn')}px;"
         rendered="#{projectJobQueueManager.tablePrefs.isVisible('statusColumn')}">
         <h:outputText value="#{node.status}" rendered="#{not node.hasSubNodes()}" />
-        <h:outputText value="#{node.status} (#{node.getTotalSubNodesReady()}/#{node.getCurrentSubNodes().size()} Agents Ready)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status eq 'Starting'}" />
-        <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status ne 'Starting'}" />
+        <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes()} and not node.useTwoStep}" />
+        <h:outputText value="#{node.status} (#{node.getTotalSubNodesReady()}/#{node.getCurrentSubNodes().size()} Agents Ready)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status eq 'Starting' and node.useTwoStep}" />
+        <h:outputText value="#{node.status} (#{node.getTotalSubNodesRunning()}/#{node.getCurrentSubNodes().size()} Agents Running)" rendered="#{node.hasSubNodes() and node.type eq 'job' and node.status eq 'Starting' and node.useTwoStep}" />
       </p:column>
 
       <p:column id="regionColumn" headerText="Region" styleClass="ellipsis min-column-size"
@@ -193,7 +194,7 @@
             onerror="window.location.reload()" disabled="#{!node.isRunnable() or !projectJobQueueManager.canControlJob(node)}"
             ajax="true" update=":mainForm:projectTabPanelID:jobTableId" />
           <p:commandButton id="btnStart" action="#{jobQueueAction.startAgents(node)}" value="L" title="Start Load"
-                           onerror="window.location.reload()" rendered="#{node.type ne 'project'}"
+                           onerror="window.location.reload()" rendered="#{node.type ne 'project' and node.useTwoStep}"
                            disabled="#{!node.isStartable() or !projectJobQueueManager.canControlJob(node)}" ajax="true"
                            update=":mainForm:projectTabPanelID:jobTableId" />
           <p:commandButton oncomplete="PF('confirmJobQueueKill').show();" value="K" ajax="true"


### PR DESCRIPTION
**Set Initializing Agents Before Load Start Configurable Per Job**
Added `Enable Two-Step Job Start` job option that will toggle the two-step process of initializing agents before start load (https://github.com/intuit/Tank/pull/294). 

<img width="462" alt="Screenshot 2024-02-02 at 10 39 36 AM" src="https://github.com/intuit/Tank/assets/31355049/e5f31899-3c47-4964-a586-b8df51fb033e">


This is set to `false` by default meaning new projects will create jobs that will run and start load as expected. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.