### PR TITLE
DescribeInstances Rewrite

### DIFF
--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
@@ -254,7 +254,7 @@ public class JobManager implements Serializable {
      * @return List of InstanceUrls
      */
     protected List<String> getInstanceUrl(List<String> instanceIds) {
-        return instanceIds.stream()
+        return instanceIds.parallelStream()
                 .filter(StringUtils::isNotEmpty)
                 .map(instanceId -> jobInfoMapLocalCache.values().stream()
                         .flatMap(info -> info.agentData.stream())

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/IEnvironmentInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/IEnvironmentInstance.java
@@ -58,7 +58,7 @@ public interface IEnvironmentInstance {
      *            the instanceIds to describe
      * @return list of VmInformation objects
      */
-    public List<VMInformation> describeInstances(String... instanceIds);
+    public List<VMInformation> describeInstances(List<String> instanceIds);
 
     /**
      * Finds instances of the specified type that are currently running.

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
@@ -115,13 +115,11 @@ public class AmazonInstance implements IEnvironmentInstance {
      * {@inheritDoc}
      */
     @Override
-    public List<VMInformation> describeInstances(String... instanceIds) {
-        HashSet<String> ids = new HashSet<String>(Arrays.asList(instanceIds));
-
+    public List<VMInformation> describeInstances(List<String> instanceIds) {
         return ec2client.describeInstances().reservations().stream()
                 .flatMap(reservationDescription -> reservationDescription.instances()
                         .stream()
-                        .filter(instance -> ids.contains(instance.instanceId()))
+                        .filter(instance -> instanceIds.contains(instance.instanceId()))
                         .map(instance -> AmazonDataConverter.instanceToVmInformation(reservationDescription.requesterId(), instance, vmRegion)))
                 .collect(Collectors.toList());
     }
@@ -368,7 +366,7 @@ public class AmazonInstance implements IEnvironmentInstance {
     @Override
     public void killInstances(List<String> instanceIds) {
         // Filter instanceId list to only instances in the client defined region.
-        List<VMInformation> instancesInRegion = describeInstances(instanceIds.toArray(new String[instanceIds.size()]));
+        List<VMInformation> instancesInRegion = describeInstances(instanceIds);
         List<String> instanceIdsInRegion = instancesInRegion.stream().map(VMInformation::getInstanceId).collect(Collectors.toList());
 
         if (!instanceIdsInRegion.isEmpty()) {
@@ -485,13 +483,9 @@ public class AmazonInstance implements IEnvironmentInstance {
                         DescribeInstancesResponse describeInstances =
                                 ec2client.describeInstances(
                                         DescribeInstancesRequest.builder().instanceIds(instanceId).build());
-                        for (Reservation reservation : describeInstances.reservations()) {
-                            for (Instance instance : reservation.instances()) {
-                                if (address.publicIp().equals(instance.publicIpAddress())) {
-                                    associated = true;
-                                }
-                            }
-                        }
+                        associated = describeInstances.reservations().stream()
+                                .flatMap(reservation -> reservation.instances().stream())
+                                .anyMatch(instance -> address.publicIp().equals(instance.publicIpAddress()));
                         if (associated) {
                             LOG.info(instanceId + " associated with " + address.publicIp());
                         } else if (count % 5 == 0) {
@@ -518,7 +512,8 @@ public class AmazonInstance implements IEnvironmentInstance {
     @Override
     public void reboot(List<VMInformation> instances) {
         List<String> instanceIds = instances.stream()
-                .map(VMInformation::getInstanceId).collect(Collectors.toCollection(() -> new ArrayList<>(instances.size())));
+                .map(VMInformation::getInstanceId)
+                .collect(Collectors.toCollection(() -> new ArrayList<>(instances.size())));
         ec2client.rebootInstances(RebootInstancesRequest.builder().instanceIds(instanceIds).build());
     }
 
@@ -528,7 +523,7 @@ public class AmazonInstance implements IEnvironmentInstance {
     public void stopInstances(List<String> instanceIds) {
 
         // Filter instanceId list to only instances in the client defined region.
-        List<VMInformation> instancesInRegion = describeInstances(instanceIds.toArray(new String[instanceIds.size()]));
+        List<VMInformation> instancesInRegion = describeInstances(instanceIds);
         List<String> instanceIdsInRegion = instancesInRegion.stream().map(VMInformation::getInstanceId).collect(Collectors.toList());
 
         if (!instanceIdsInRegion.isEmpty()) {
@@ -564,16 +559,14 @@ public class AmazonInstance implements IEnvironmentInstance {
 
     public String findDNSName(String instanceId) {
         try {
-            DescribeInstancesRequest describeInstancesRequest =
-                    DescribeInstancesRequest.builder().instanceIds(instanceId).build();
-            DescribeInstancesResponse response = ec2client.describeInstances(describeInstancesRequest);
-            if (response.reservations() != null && response.reservations().size() == 1) {
-                Instance instance = response.reservations().get(0).instances().get(0);
-                if (StringUtils.isNotEmpty(instance.publicDnsName())) {
-                    return instance.publicDnsName();
-                }
-                return instance.privateDnsName();
-            }
+            return ec2client.describeInstances().reservations().stream()
+                    .flatMap(reservationDescription -> reservationDescription.instances().stream())
+                    .filter(instance -> instanceId.equals(instance.instanceId()))
+                    .findFirst()
+                    .map(instance -> (StringUtils.isNotEmpty(instance.publicDnsName()))
+                            ? instance.publicDnsName()
+                            : instance.privateDnsName())
+                    .toString();
         } catch (Exception e) {
             LOG.error("Error getting public dns in " + vmRegion + ": " + e.getMessage());
         }


### PR DESCRIPTION
## DescribeInstances Rewrite

`findDNSName` was calling describeInstances on instances in the wrong region causing 400s.
These changes resolve that issue and cleanup up the other `describeInstances` usage in AmazonInstance.java

![image](https://github.com/intuit/Tank/assets/12751614/9d9bc2e0-b8f2-4b58-96fc-4cc58b40a7d8)


Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.