### PR TITLE
APIHarness changes to support java11

### DIFF
--- a/agent/apiharness/pom.xml
+++ b/agent/apiharness/pom.xml
@@ -23,50 +23,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>tank-api</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springdoc</groupId>
-          <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>script-engine</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>data-access</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>tank-vm-manager</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>tank-script-processor</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.projectlombok</groupId>
-          <artifactId>lombok</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>harness-data</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -110,6 +66,7 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -150,7 +150,7 @@ public class APIMonitor implements Runnable {
 
     private static void setInstanceStatus(String instanceId, CloudVmStatus VmStatus) throws URISyntaxException, JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writer().withDefaultPrettyPrinter().writeValueAsString(VmStatus);
+        String json = objectMapper.writerFor(CloudVmStatus.class).withDefaultPrettyPrinter().writeValueAsString(VmStatus);
         String token = APITestHarness.getInstance().getTankConfig().getAgentConfig().getAgentToken();
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(new URI(APITestHarness.getInstance().getTankConfig().getControllerBase() + "/instance/status/" + instanceId))

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -157,7 +157,7 @@ public class APIMonitor implements Runnable {
                 .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                 .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                 .header(HttpHeaders.AUTHORIZATION, "bearer "+token)
-                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .PUT(HttpRequest.BodyPublishers.ofString(json))
                 .build();
         client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
     }

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -156,7 +156,7 @@ public class APIMonitor implements Runnable {
                 .uri(new URI(APITestHarness.getInstance().getTankConfig().getControllerBase() + "/v2/agent/instance/status/" + instanceId))
                 .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                 .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .header(HttpHeaders.AUTHORIZATION, "bearer="+token)
+                .header(HttpHeaders.AUTHORIZATION, "bearer "+token)
                 .POST(HttpRequest.BodyPublishers.ofString(json))
                 .build();
         client.sendAsync(request, HttpResponse.BodyHandlers.ofString());

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -153,7 +153,7 @@ public class APIMonitor implements Runnable {
         String json = objectMapper.writerFor(CloudVmStatus.class).withDefaultPrettyPrinter().writeValueAsString(VmStatus);
         String token = APITestHarness.getInstance().getTankConfig().getAgentConfig().getAgentToken();
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(new URI(APITestHarness.getInstance().getTankConfig().getControllerBase() + "/instance/status/" + instanceId))
+                .uri(new URI(APITestHarness.getInstance().getTankConfig().getControllerBase() + "/v2/agent/instance/status/" + instanceId))
                 .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                 .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                 .header(HttpHeaders.AUTHORIZATION, "bearer="+token)

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -303,7 +303,8 @@ public class APITestHarness {
             while (count < FIBONACCI.length) {
                 try {
                     ObjectMapper objectMapper = new ObjectMapper();
-                    String json = objectMapper.writer().withDefaultPrettyPrinter().writeValueAsString(data);
+                    String json = objectMapper.writerFor(AgentTestStartData.class)
+                            .withDefaultPrettyPrinter().writeValueAsString(data);
                     HttpRequest request = HttpRequest.newBuilder()
                             .uri(new URI(baseUrl + "/request"))
                             .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
@@ -312,7 +313,7 @@ public class APITestHarness {
                             .POST(BodyPublishers.ofString(json))
                             .build();
                     HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-                    startData = objectMapper.reader().readValue(response.body());
+                    startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
                     break;
                 } catch (Exception e) {
                     LOG.error("Error sending ready: " + e, e);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.text.DateFormat;
@@ -29,12 +30,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.zip.GZIPInputStream;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.intuit.tank.http.TankHttpClient;
 import com.intuit.tank.vm.api.enumerated.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.ContentType;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,7 +48,6 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.message.ObjectMessage;
 
-import com.intuit.tank.rest.mvc.rest.clients.AgentClient;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
 import com.intuit.tank.vm.vmManager.models.VMStatus;
 import com.intuit.tank.vm.vmManager.models.ValidationStatus;
@@ -258,7 +261,6 @@ public class APITestHarness {
         CommandListener.startHttpServer(tankConfig.getAgentConfig().getAgentPort());
         baseUrl = (baseUrl == null) ? AmazonUtil.getControllerBaseUrl() : baseUrl;
         token = (token == null) ? AmazonUtil.getAgentToken() : token;
-        AgentClient agentClient = new AgentClient(baseUrl, token);
         String instanceUrl = null;
         int retryCount = 0;
         while (instanceUrl == null) {
@@ -300,7 +302,17 @@ public class APITestHarness {
             LOG.info(LogUtil.getLogMessage("Sending AgentData to controller: " + data.toString()));
             while (count < FIBONACCI.length) {
                 try {
-                    startData = agentClient.agentReady(data);
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    String json = objectMapper.writer().withDefaultPrettyPrinter().writeValueAsString(data);
+                    HttpRequest request = HttpRequest.newBuilder()
+                            .uri(new URI(baseUrl + "/request"))
+                            .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
+                            .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                            .header(HttpHeaders.AUTHORIZATION, "bearer="+token)
+                            .POST(BodyPublishers.ofString(json))
+                            .build();
+                    HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+                    startData = objectMapper.reader().readValue(response.body());
                     break;
                 } catch (Exception e) {
                     LOG.error("Error sending ready: " + e, e);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -306,7 +306,7 @@ public class APITestHarness {
                     String json = objectMapper.writerFor(AgentData.class)
                             .withDefaultPrettyPrinter().writeValueAsString(data);
                     HttpRequest request = HttpRequest.newBuilder()
-                            .uri(new URI(baseUrl + "/request"))
+                            .uri(new URI(baseUrl + "/v2/agent/request"))
                             .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                             .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                             .header(HttpHeaders.AUTHORIZATION, "bearer="+token)

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -309,12 +309,14 @@ public class APITestHarness {
                             .uri(new URI(baseUrl + "/v2/agent/request"))
                             .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                             .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                            .header(HttpHeaders.AUTHORIZATION, "bearer="+token)
+                            .header(HttpHeaders.AUTHORIZATION, "bearer "+token)
                             .POST(BodyPublishers.ofString(json))
                             .build();
                     HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-                    startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
-                    break;
+                    if (response.statusCode() == 200) {
+                        startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
+                        break;
+                    }
                 } catch (Exception e) {
                     LOG.error("Error sending ready: " + e, e);
                     try {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -306,17 +306,15 @@ public class APITestHarness {
                     String json = objectMapper.writerFor(AgentData.class)
                             .withDefaultPrettyPrinter().writeValueAsString(data);
                     HttpRequest request = HttpRequest.newBuilder()
-                            .uri(new URI(baseUrl + "/v2/agent/request"))
+                            .uri(new URI(baseUrl + "/v2/agent/ready"))
                             .header(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
                             .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                             .header(HttpHeaders.AUTHORIZATION, "bearer "+token)
                             .POST(BodyPublishers.ofString(json))
                             .build();
                     HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-                    if (response.statusCode() == 200) {
-                        startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
-                        break;
-                    }
+                    startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
+                    break;
                 } catch (Exception e) {
                     LOG.error("Error sending ready: " + e, e);
                     try {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -303,7 +303,7 @@ public class APITestHarness {
             while (count < FIBONACCI.length) {
                 try {
                     ObjectMapper objectMapper = new ObjectMapper();
-                    String json = objectMapper.writerFor(AgentTestStartData.class)
+                    String json = objectMapper.writerFor(AgentData.class)
                             .withDefaultPrettyPrinter().writeValueAsString(data);
                     HttpRequest request = HttpRequest.newBuilder()
                             .uri(new URI(baseUrl + "/request"))

--- a/web/web_support/pom.xml
+++ b/web/web_support/pom.xml
@@ -42,10 +42,10 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>WebConversation</artifactId>
+      <artifactId>tank-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tank-vm-manager</artifactId>


### PR DESCRIPTION
## In order to do comparison testing (java11/java17/java21)

The APIHarness needs to do httpclient communication to the controller without the spring clients.



Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.