### PR TITLE
Pull SSO client secret from SSM

### DIFF
--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -90,7 +90,6 @@ public class TankOidcAuthorization {
     private String getClientSecret(OidcSsoConfig oidcSsoConfig) {
         String clientKey = oidcSsoConfig.getClientSecret();
         if (clientKey.startsWith("/")) {
-            LOG.info("client key: " + clientKey);
             try (SsmClient ssmClient = SsmClient.builder().build()) {
                 GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
                 return response.parameter().value();
@@ -98,7 +97,6 @@ public class TankOidcAuthorization {
                 LOG.info("Error retrieving client secret from SSM", e);
             }
         }
-        LOG.info("returning default");
         return oidcSsoConfig.getClientSecret();
     }
 

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -97,7 +97,7 @@ public class TankOidcAuthorization {
                 LOG.error("Error retrieving client secret from SSM", e);
             }
         }
-        return "";
+        return oidcSsoConfig.getClientSecret();
     }
 
     private Map<Object, Object> getOidcRequestParameters(OidcSsoConfig oidcSsoConfig, String authorizationCode) {

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -92,7 +92,7 @@ public class TankOidcAuthorization {
         if (clientKey.startsWith("/")) {
             LOG.info("Found Client Key");
             try (SsmClient ssmClient = SsmClient.builder().build()) {
-                GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
+                GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).withDecryption(true).build());
                 return response.parameter().value();
             } catch (Exception e) {
                 LOG.error("Error retrieving client secret from SSM", e);

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -89,7 +89,7 @@ public class TankOidcAuthorization {
      */
     private String getClientSecret(OidcSsoConfig oidcSsoConfig) {
         String clientKey = oidcSsoConfig.getClientSecret();
-        if (StringUtils.isNotEmpty(clientKey)) {
+        if (clientKey.startsWith("/")) {
             try (SsmClient ssmClient = SsmClient.builder().build()) {
                 GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
                 return response.parameter().value();

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -90,13 +90,15 @@ public class TankOidcAuthorization {
     private String getClientSecret(OidcSsoConfig oidcSsoConfig) {
         String clientKey = oidcSsoConfig.getClientSecret();
         if (clientKey.startsWith("/")) {
+            LOG.info("client key: " + clientKey);
             try (SsmClient ssmClient = SsmClient.builder().build()) {
                 GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
                 return response.parameter().value();
             } catch (Exception e) {
-                LOG.error("Error retrieving client secret from SSM", e);
+                LOG.info("Error retrieving client secret from SSM", e);
             }
         }
+        LOG.info("returning default");
         return oidcSsoConfig.getClientSecret();
     }
 

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -90,13 +90,15 @@ public class TankOidcAuthorization {
     private String getClientSecret(OidcSsoConfig oidcSsoConfig) {
         String clientKey = oidcSsoConfig.getClientSecret();
         if (clientKey.startsWith("/")) {
+            LOG.info("Found Client Key");
             try (SsmClient ssmClient = SsmClient.builder().build()) {
                 GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
                 return response.parameter().value();
             } catch (Exception e) {
-                LOG.info("Error retrieving client secret from SSM", e);
+                LOG.error("Error retrieving client secret from SSM", e);
             }
         }
+        LOG.info("Returning Default");
         return oidcSsoConfig.getClientSecret();
     }
 

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -6,11 +6,16 @@ import com.intuit.tank.auth.sso.models.Token;
 import com.intuit.tank.http.WebHttpClient;
 import com.intuit.tank.vm.settings.OidcSsoConfig;
 import com.intuit.tank.vm.settings.TankConfig;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import jakarta.inject.Inject;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+
 import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.util.Base64;
@@ -78,6 +83,23 @@ public class TankOidcAuthorization {
         return userInfo;
     }
 
+    /**
+     * Request the client-secret parameter from SSM
+     * @return The OIDC SSO client secret for the controller
+     */
+    private String getClientSecret(OidcSsoConfig oidcSsoConfig) {
+        String clientKey = oidcSsoConfig.getClientSecret();
+        if (StringUtils.isNotEmpty(clientKey)) {
+            try (SsmClient ssmClient = SsmClient.builder().build()) {
+                GetParameterResponse response = ssmClient.getParameter(GetParameterRequest.builder().name(clientKey).build());
+                return response.parameter().value();
+            } catch (Exception e) {
+                LOG.error("Error retrieving client secret from SSM", e);
+            }
+        }
+        return "";
+    }
+
     private Map<Object, Object> getOidcRequestParameters(OidcSsoConfig oidcSsoConfig, String authorizationCode) {
         if(Objects.requireNonNull(oidcSsoConfig).getConfiguration() == null) {
             throw new IllegalArgumentException("Missing OIDC SSO Config");
@@ -86,7 +108,7 @@ public class TankOidcAuthorization {
         Map<Object, Object> requestParameters = new HashMap<>();
 
         requestParameters.put(OidcConstants.CLIENT_ID_KEY, oidcSsoConfig.getClientId());
-        requestParameters.put(OidcConstants.CLIENT_SECRET_KEY, oidcSsoConfig.getClientSecret());
+        requestParameters.put(OidcConstants.CLIENT_SECRET_KEY, getClientSecret(oidcSsoConfig));
         requestParameters.put(OidcConstants.CONTENT_TYPE_KEY, OidcConstants.CONTENT_TYPE_VALUE);
         requestParameters.put(OidcConstants.GRANT_TYPE_KEY, OidcConstants.GRANT_TYPE_VALUE);
         requestParameters.put(OidcConstants.GRANT_CODE_KEY, authorizationCode);

--- a/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
+++ b/web/web_support/src/main/java/com/intuit/tank/auth/sso/TankOidcAuthorization.java
@@ -99,7 +99,7 @@ public class TankOidcAuthorization {
             }
         }
         LOG.info("Returning Default");
-        return oidcSsoConfig.getClientSecret();
+        return clientKey;
     }
 
     private Map<Object, Object> getOidcRequestParameters(OidcSsoConfig oidcSsoConfig, String authorizationCode) {


### PR DESCRIPTION
**Pull SSO client secret from SSM**
Adds option to store client secret in SSM to be pulled on SSO login - returns the default value for client secret key from `settings.xml` file if set to value not matching SSM key path (`/*`)

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.