### PR TITLE
[SRE-30501] Remove logResponse String builder during all http requests

### DIFF
--- a/agent/agent_common/src/main/java/com/intuit/tank/http/BaseResponse.java
+++ b/agent/agent_common/src/main/java/com/intuit/tank/http/BaseResponse.java
@@ -47,6 +47,35 @@ public abstract class BaseResponse {
      * @return the responseLogMsg
      */
     public String getLogMsg() {
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append("RESPONSE HTTP CODE: ").append(this.httpCode).append(NEWLINE)
+                    .append("RESPONSE HTTP MSG: ").append(this.rspMessage).append(NEWLINE)
+                    .append("RESPONSE TIME: ").append(responseTime).append(NEWLINE)
+                    .append("RESPONSE SIZE: ").append(getResponseSize()).append(NEWLINE);
+            for (Entry<String, String> mapEntry : headers.entrySet()) {
+                sb.append("RESPONSE HEADER: ")
+                        .append((String) mapEntry.getKey()).append(" = ")
+                        .append((String) mapEntry.getValue()).append(NEWLINE);
+            }
+            for (Entry<String, String> entry : cookies.entrySet()) {
+                sb.append("RESPONSE COOKIE: ")
+                        .append(entry.getKey()).append(" = ")
+                        .append(entry.getValue()).append(NEWLINE);
+            }
+            if (response != null) {
+                String contentType = this.headers.get("Content-Type");
+                if (isDataType(contentType)) {
+                    sb.append("RESPONSE BODY: ").append(this.response).append(NEWLINE);
+                } else {
+                    sb.append("RESPONSE BODY: not logged because ")
+                            .append(contentType).append(" is not a data type.").append(NEWLINE);
+                }
+            }
+            this.responseLogMsg = sb.toString();
+        } catch (Exception ex) {
+            LOG.error("Error processing response: " + ex.getMessage(), ex);
+        }
         return responseLogMsg;
     }
 
@@ -189,40 +218,6 @@ public abstract class BaseResponse {
 
     public Map<String, String> getCookies() {
         return cookies;
-    }
-
-    /**
-     * Log the response object
-     */
-    public void logResponse() {
-        try {
-            StringBuilder sb = new StringBuilder();
-            // System.out.println("******** RESPONSE ***********");
-            sb.append("RESPONSE HTTP CODE: " + this.httpCode).append(NEWLINE);
-            sb.append("RESPONSE HTTP MSG: " + this.rspMessage).append(NEWLINE);
-            sb.append("RESPONSE TIME: " + responseTime).append(NEWLINE);
-            sb.append("RESPONSE SIZE: " + getResponseSize()).append(NEWLINE);
-            for (Entry<String, String> mapEntry : headers.entrySet()) {
-                sb.append("RESPONSE HEADER: " + (String) mapEntry.getKey() + " = " + (String) mapEntry.getValue()).append(NEWLINE);
-            }
-            for (Entry<String, String> entry : cookies.entrySet()) {
-                sb.append("RESPONSE COOKIE: " + entry.getKey() + " = " + entry.getValue()).append(NEWLINE);
-            }
-            if (response != null) {
-                String contentType = this.headers.get("Content-Type");
-                if (isDataType(contentType)) {
-                    sb.append("RESPONSE BODY: " + this.response).append(NEWLINE);
-                } else {
-                    sb.append("RESPONSE BODY: not logged because " + contentType + " is not a data type.").append(NEWLINE);
-                }
-            }
-            this.responseLogMsg = sb.toString();
-            LOG.debug("******** RESPONSE ***********");
-            LOG.debug(this.responseLogMsg);
-
-        } catch (Exception ex) {
-            LOG.error("Error processing response: " + ex.getMessage(), ex);
-        }
     }
 
     public static final boolean isDataType(String contentType) {

--- a/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpUtil.java
+++ b/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpUtil.java
@@ -52,18 +52,13 @@ public class TankHttpUtil {
         if (urlVariables != null && !urlVariables.isEmpty()) {
             return "?" + urlVariables.entrySet().stream()
                     .map(entry -> {
-                        try {
-                            if (StringUtils.isBlank(entry.getValue())) {
-                                return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name());
-                            } else {
-                                return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name())
-                                        + "="
-                                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name());
-                            }
-                        } catch (UnsupportedEncodingException ex) {
-                            LOG.warn("Unable to set query string value: " + ex.getMessage());
+                        if (StringUtils.isBlank(entry.getValue())) {
+                            return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8);
+                        } else {
+                            return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+                                    + "="
+                                    + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8);
                         }
-                        return "";
                     })
                     .collect(joining("&"));
         }

--- a/agent/agent_common/src/test/java/com/intuit/tank/http/BaseResponseTest.java
+++ b/agent/agent_common/src/test/java/com/intuit/tank/http/BaseResponseTest.java
@@ -448,13 +448,11 @@ public class BaseResponseTest {
         fixture.responseByteArray = new byte[] {};
         fixture.rspMessage = "";
         fixture.responseLogMsg = "";
-
-        fixture.logResponse();
         assertEquals("RESPONSE HTTP CODE: 1\n" +
                 "RESPONSE HTTP MSG: \n" +
                 "RESPONSE TIME: 1\n" +
                 "RESPONSE SIZE: 0\n" +
-                "RESPONSE BODY: not logged because null is not a data type.\n", fixture.responseLogMsg);
+                "RESPONSE BODY: not logged because null is not a data type.\n", fixture.getLogMsg());
     }
 
     @Test
@@ -465,14 +463,13 @@ public class BaseResponseTest {
         fixture.cookies = new HashMap<String, String>();
         fixture.cookies.put("testHeadersKey", "testHeadersValue");
         fixture.response = "testResponse";
-        fixture.logResponse();
         assertEquals("RESPONSE HTTP CODE: -1\n" +
                 "RESPONSE HTTP MSG: \n" +
                 "RESPONSE TIME: -1\n" +
                 "RESPONSE SIZE: 12\n" +
                 "RESPONSE HEADER: Content-Type = text/html\n" +
                 "RESPONSE COOKIE: testHeadersKey = testHeadersValue\n" +
-                "RESPONSE BODY: testResponse\n", fixture.responseLogMsg);
+                "RESPONSE BODY: testResponse\n", fixture.getLogMsg());
     }
 
 }

--- a/agent/agent_common/src/test/java/com/intuit/tank/http/TankHttpUtilTest.java
+++ b/agent/agent_common/src/test/java/com/intuit/tank/http/TankHttpUtilTest.java
@@ -187,38 +187,6 @@ public class TankHttpUtilTest {
      * @generatedBy CodePro at 12/16/14 3:57 PM
      */
     @Test
-    public void testGetQueryString_4()
-        throws Exception {
-        Map<String, String> urlVariables = new HashMap();
-
-        String result = TankHttpUtil.getQueryString(urlVariables);
-        assertNotNull(result);
-    }
-
-    /**
-     * Run the String getQueryString(Map<String,String>) method test.
-     *
-     * @throws Exception
-     *
-     * @generatedBy CodePro at 12/16/14 3:57 PM
-     */
-    @Test
-    public void testGetQueryString_5()
-        throws Exception {
-        Map<String, String> urlVariables = new HashMap();
-
-        String result = TankHttpUtil.getQueryString(urlVariables);
-        assertNotNull(result);
-    }
-
-    /**
-     * Run the String getQueryString(Map<String,String>) method test.
-     *
-     * @throws Exception
-     *
-     * @generatedBy CodePro at 12/16/14 3:57 PM
-     */
-    @Test
     public void testGetQueryString_6()
         throws Exception {
         Map<String, String> urlVariables = null;

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -160,7 +160,7 @@ public class TestPlanStarter implements Runnable {
                 }
                 done = true;
             } catch (final Throwable t) {
-                LOG.error(LogUtil.getLogMessage("Linear - TestPlanStarter Unknown Error:"), t);
+                LOG.error(LogUtil.getLogMessage("Linear - TestPlanStarter Error:" + t.getMessage()), t);
                 throwUnchecked(t);
             }
         } else { // Nonlinear Workload
@@ -257,7 +257,7 @@ public class TestPlanStarter implements Runnable {
                 }
                 done = true;
             } catch (final Throwable t) {
-                LOG.error(LogUtil.getLogMessage("Nonlinear - TestPlanStarter Unknown Error:"), t);
+                LOG.error(LogUtil.getLogMessage("Nonlinear - TestPlanStarter Error:" + t.getMessage()), t);
                 throwUnchecked(t);
             }
         }

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -305,6 +305,11 @@ public class TestPlanRunner implements Runnable {
             String validation = TankConstants.HTTP_CASE_FAIL;
             try {
                 validation = tsr.execute();
+            } catch (Error e) {
+                if(e instanceof OutOfMemoryError){
+                    throw (OutOfMemoryError) e;
+                }
+                throw new Error(e);
             } catch (Exception e) {
                 if (e instanceof RuntimeException) {
                     throw (RuntimeException) e;

--- a/agent/http_client_3/src/main/java/com/intuit/tank/httpclient3/TankHttpClient3.java
+++ b/agent/http_client_3/src/main/java/com/intuit/tank/httpclient3/TankHttpClient3.java
@@ -54,7 +54,6 @@ import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
 import org.apache.commons.httpclient.methods.multipart.PartSource;
 import org.apache.commons.httpclient.methods.multipart.StringPart;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.HttpHeaders;
@@ -269,7 +268,7 @@ public class TankHttpClient3 implements TankHttpClient {
             // check for no content headers
             if (method.getStatusCode() != 203 && method.getStatusCode() != 202 && method.getStatusCode() != 204) {
                 try ( InputStream is = method.getResponseBodyAsStream() ) {
-                    responseBody = IOUtils.toByteArray(is);
+                    responseBody = is.readAllBytes();
                 } catch (IOException | NullPointerException e) {
                     LOG.warn(request.getLogUtil().getLogMessage("could not get response body: " + e));
                 }
@@ -358,14 +357,15 @@ public class TankHttpClient3 implements TankHttpClient {
 
             String contentEncoding = response.getHttpHeader("Content-Encoding");
             bResponse = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
-                    IOUtils.toByteArray(new GZIPInputStream(new ByteArrayInputStream(bResponse))) :
+                    new GZIPInputStream(new ByteArrayInputStream(bResponse)).readAllBytes() :
                     bResponse;
             response.setResponseBody(bResponse);
 
         } catch (Exception ex) {
             LOG.warn("Unable to get response: " + ex.getMessage());
         } finally {
-            response.logResponse();
+            LOG.debug("******** RESPONSE ***********");
+            LOG.debug(response.getLogMsg());
         }
     }
 

--- a/agent/http_client_3/src/main/java/com/intuit/tank/httpclient3/TankHttpClient3.java
+++ b/agent/http_client_3/src/main/java/com/intuit/tank/httpclient3/TankHttpClient3.java
@@ -364,8 +364,10 @@ public class TankHttpClient3 implements TankHttpClient {
         } catch (Exception ex) {
             LOG.warn("Unable to get response: " + ex.getMessage());
         } finally {
-            LOG.debug("******** RESPONSE ***********");
-            LOG.debug(response.getLogMsg());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("******** RESPONSE ***********");
+                LOG.debug(response.getLogMsg());
+            }
         }
     }
 

--- a/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
+++ b/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import jakarta.annotation.Nonnull;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.*;
@@ -293,7 +292,7 @@ public class TankHttpClient4 implements TankHttpClient {
             // check for no content headers
             if (response.getStatusLine().getStatusCode() != 203 && response.getStatusLine().getStatusCode() != 202 && response.getStatusLine().getStatusCode() != 204) {
                 try ( InputStream is = response.getEntity().getContent() ) {
-                    responseBody = IOUtils.toByteArray(is);
+                    responseBody = is.readAllBytes();
                 } catch (IOException | NullPointerException e) {
                     LOG.warn(request.getLogUtil().getLogMessage("could not get response body: " + e));
                 }
@@ -385,7 +384,8 @@ public class TankHttpClient4 implements TankHttpClient {
         } catch (Exception ex) {
             LOG.warn("Unable to get response: " + ex.getMessage());
         } finally {
-            response.logResponse();
+            LOG.debug("******** RESPONSE ***********");
+            LOG.debug(response.getLogMsg());
         }
     }
 

--- a/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
+++ b/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
@@ -384,8 +384,10 @@ public class TankHttpClient4 implements TankHttpClient {
         } catch (Exception ex) {
             LOG.warn("Unable to get response: " + ex.getMessage());
         } finally {
-            LOG.debug("******** RESPONSE ***********");
-            LOG.debug(response.getLogMsg());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("******** RESPONSE ***********");
+                LOG.debug(response.getLogMsg());
+            }
         }
     }
 

--- a/agent/http_client_5/src/main/java/com/intuit/tank/httpclient5/TankHttpClient5.java
+++ b/agent/http_client_5/src/main/java/com/intuit/tank/httpclient5/TankHttpClient5.java
@@ -400,8 +400,10 @@ public class TankHttpClient5 implements TankHttpClient {
         } catch (Exception ex) {
             LOG.warn(request.getLogUtil().getLogMessage("Unable to get response: " + ex.getMessage()));
         } finally {
-            LOG.debug("******** RESPONSE ***********");
-            LOG.debug(response.getLogMsg());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("******** RESPONSE ***********");
+                LOG.debug(response.getLogMsg());
+            }
         }
     }
 

--- a/agent/http_client_5/src/main/java/com/intuit/tank/httpclient5/TankHttpClient5.java
+++ b/agent/http_client_5/src/main/java/com/intuit/tank/httpclient5/TankHttpClient5.java
@@ -27,7 +27,6 @@ import java.util.zip.GZIPInputStream;
 
 import jakarta.annotation.Nonnull;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hc.client5.http.UserTokenHandler;
@@ -393,7 +392,7 @@ public class TankHttpClient5 implements TankHttpClient {
 
             String contentEncoding = response.getHttpHeader("content-ecncoding");
             bResponse = StringUtils.equalsIgnoreCase(contentEncoding, "gzip") ?
-                    IOUtils.toByteArray(new GZIPInputStream(new ByteArrayInputStream(bResponse))) :
+                    new GZIPInputStream(new ByteArrayInputStream(bResponse)).readAllBytes() :
                     bResponse;
 
             response.setResponseBody(bResponse);
@@ -401,7 +400,8 @@ public class TankHttpClient5 implements TankHttpClient {
         } catch (Exception ex) {
             LOG.warn(request.getLogUtil().getLogMessage("Unable to get response: " + ex.getMessage()));
         } finally {
-            response.logResponse();
+            LOG.debug("******** RESPONSE ***********");
+            LOG.debug(response.getLogMsg());
         }
     }
 


### PR DESCRIPTION
Remove logResponse String builder during all http requests

This change only creates the response log message only if using with Agent Debugger Tool and if Log Level is set to `DEBUG` instead of creating it by default on each step - decreasing the memory allocated for the log message string per agent thread. It also now correctly logs error messages from `TestPlanStarter`, including catching OOM exceptions.

**BEFORE**
![Screenshot 2024-03-26 at 6 02 29 PM](https://github.com/intuit/Tank/assets/31355049/e81b01b3-01d8-4b5e-a622-0528f7848ca4)


**AFTER**
![Screenshot 2024-03-26 at 6 02 40 PM](https://github.com/intuit/Tank/assets/31355049/b5f8f93b-39a8-4dce-a3d0-2a6533e9c741)






Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.