### PR TITLE
focus logging eventLog creation on local usage

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -228,13 +228,10 @@ public class APITestHarness {
 
     private String getLocalInstanceId() {
         isLocal = true;
-        String iId = "local-instance";
         try {
-            iId = InetAddress.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e1) {
-            // cannot determine instanceid
-        }
-        return iId;
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException ignored) {}
+        return "local-instance";
     }
 
     /**
@@ -524,7 +521,7 @@ public class APITestHarness {
             }
             agentRunData.setProjectName(hdWorkload.getName());
             agentRunData.setTankhttpClientClass(tankHttpClientClass);
-            Object httpClient = ((TankHttpClient) Class.forName(tankHttpClientClass).newInstance()).createHttpClient();
+            Object httpClient = ((TankHttpClient) Class.forName(tankHttpClientClass).getDeclaredConstructor().newInstance()).createHttpClient();
             List<TestPlanStarter> testPlans = new ArrayList<TestPlanStarter>();
             for (HDTestPlan plan : hdWorkload.getPlans()) {
                 if (plan.getUserPercentage() > 0) {
@@ -873,6 +870,13 @@ public class APITestHarness {
      */
     public ResultsReporter getResultsReporter() {
         return resultsReporter;
+    }
+
+    /**
+     * @return the isLocal
+     */
+    public boolean isLocal() {
+        return isLocal;
     }
 
     /**

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/logging/ThreadLocalLogEvent.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/logging/ThreadLocalLogEvent.java
@@ -32,7 +32,7 @@ public class ThreadLocalLogEvent extends ThreadLocal<LogEvent> {
         logEvent.setJobId(APITestHarness.getInstance().getAgentRunData().getJobId());
         logEvent.setInstanceId(APITestHarness.getInstance().getAgentRunData().getInstanceId());
         logEvent.setSourceType(SourceType.agent);
-        HostInfo hostInfo = new HostInfo();
+        HostInfo hostInfo = new HostInfo(APITestHarness.getInstance().isLocal());
         logEvent.setPublicIp(hostInfo.getPublicIp());
         logEvent.setHostname(hostInfo.getPublicHostname());
         logEvent.setThreadId(Thread.currentThread().getName() + " " + Thread.currentThread().getId());
@@ -41,12 +41,14 @@ public class ThreadLocalLogEvent extends ThreadLocal<LogEvent> {
         ThreadContext.put("projectName", APITestHarness.getInstance().getAgentRunData().getProjectName());
         ThreadContext.put("instanceId", APITestHarness.getInstance().getAgentRunData().getInstanceId());
         ThreadContext.put("publicIp", hostInfo.getPublicIp());
-        ThreadContext.put("location", AmazonUtil.getZone());
-        ThreadContext.put("httpHost", AmazonUtil.getControllerBaseUrl());
         ThreadContext.put("loggingProfile", APITestHarness.getInstance().getAgentRunData().getActiveProfile().getDisplayName());
         ThreadContext.put("env", APITestHarness.getInstance().getTankConfig().getInstanceName());
-        ThreadContext.put("useEips", String.valueOf(AmazonUtil.usingEip()));
-        ThreadContext.put("stopBehavior", AmazonUtil.getStopBehavior().getDisplay());
+        if (!APITestHarness.getInstance().isLocal()) {
+            ThreadContext.put("location", AmazonUtil.getZone());
+            ThreadContext.put("httpHost", AmazonUtil.getControllerBaseUrl());
+            ThreadContext.put("useEips", String.valueOf(AmazonUtil.usingEip()));
+            ThreadContext.put("stopBehavior", AmazonUtil.getStopBehavior().getDisplay());
+        }
 
         return logEvent;
 

--- a/api/src/main/java/com/intuit/tank/harness/HostInfo.java
+++ b/api/src/main/java/com/intuit/tank/harness/HostInfo.java
@@ -37,11 +37,19 @@ public class HostInfo implements Serializable {
     public String publicHostname;
 
     public HostInfo() {
-        try {
-            publicHostname = AmazonUtil.getPublicHostName();
-            publicIp = AmazonUtil.getPublicIp();
-        } catch (IOException e) {
-            LOG.debug("Cannot find hostname from amazon. trying local...");
+        this(false);
+    }
+    public HostInfo(boolean isLocal) {
+        if (!isLocal) {
+            try {
+                publicHostname = AmazonUtil.getPublicHostName();
+                publicIp = AmazonUtil.getPublicIp();
+            } catch (IOException e) {
+                LOG.debug("Cannot find hostname from amazon. trying local...");
+                publicHostname = UNKNOWN;
+                publicIp = UNKNOWN;
+            }
+        } else {
             try {
                 publicIp = InetAddress.getLocalHost().getHostAddress();
                 Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -56,6 +64,7 @@ public class HostInfo implements Serializable {
                     }
                 }
             } catch (Exception e1) {
+                LOG.debug("Cannot find hostname from local lookup...");
                 publicHostname = UNKNOWN;
                 publicIp = UNKNOWN;
             }


### PR DESCRIPTION
## focus logging eventLog creation on local usage

Agent debugger takes a very long time to prepare a script to run. The majority of that time is just setting up the logevent. The PR reduces that time. 

Best measure with the TEST `APITestHarnessTest.testRunConcurrentTestPlan()`
> before: 22 sec (46 sec on work network)
> after: 10 sec

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.