### PR TITLE
Fix Step StopBehavior to exit script at end of step

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -375,7 +375,7 @@ public class TestPlanRunner implements Runnable {
             if (shouldStop(StopBehavior.END_OF_STEP)) {
                 LOG.info(LogUtil.getLogMessage("Stop command received. Stop set to end of step. End of step "
                         + testStep.getStepIndex() + " reached. Exiting..."));
-                break;
+                return;
             }
         }
     }

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -371,7 +371,7 @@ public class TestPlanRunner implements Runnable {
             if (shouldStop(StopBehavior.END_OF_STEP)) {
                 LOG.info(LogUtil.getLogMessage("Stop command received. Stop set to end of step. End of step "
                         + testStep.getStepIndex() + " reached. Exiting..."));
-                return;
+                break;
             }
         }
     }

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -198,6 +198,10 @@ public class TestPlanRunner implements Runnable {
                             }
                             try {
                                 runScriptSteps(hdScriptUseCase);
+                                // If command is stop and stop behavior is end of step, exit the loop.
+                                if (shouldStop(StopBehavior.END_OF_STEP)) {
+                                    return;
+                                }
                             } catch (GotoScriptException e) {
                                 i = 0;
                                 gotoGroup = e.getGotoTarget();


### PR DESCRIPTION
**Fix Step StopBehavior to exit script at end of step**

This fixes a flaw in the Step StopBehavior logic where after being sent a stop command to a job configured with `Stop Behavior` : `Step`, the user would continue executing the remaining steps in the test plan instead of returning and exiting at the end of step. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.