### PR TITLE
Fix Stop during Initial Ramp for Nonlinear Workload

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -338,9 +338,6 @@ public class TestPlanStarter implements Runnable {
                         if (APITestHarness.getInstance().hasMetSimulationTime()) {
                             APITestHarness.getInstance().setCommand(AgentCommand.stop);
                             return;
-                        }
-                        else if (APITestHarness.getInstance().getCmd() == AgentCommand.stop) {
-                            return;
                         } else {
                             try {
                                 Thread.sleep(1000);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -292,6 +292,7 @@ public class TestPlanStarter implements Runnable {
 
             while (System.currentTimeMillis() - startTime < (rampTimeMillis + totalPauseDuration)) { // time elapsed + any pause duration = total ramp time
                 try {
+                    // if paused, check if simulation time has been met and stop ramp accordingly
                     if (APITestHarness.getInstance().getCmd() == AgentCommand.pause_ramp
                             || APITestHarness.getInstance().getCmd() == AgentCommand.pause) {
                         if (APITestHarness.getInstance().hasMetSimulationTime()) {
@@ -301,6 +302,15 @@ public class TestPlanStarter implements Runnable {
                             throw new InterruptedException();
                         }
                     }
+                    // check for stop/kill command during initial ramp
+                    if (APITestHarness.getInstance().getCmd() == AgentCommand.stop
+                            || APITestHarness.getInstance().getCmd() == AgentCommand.kill
+                            || APITestHarness.getInstance().hasMetSimulationTime()
+                            || APITestHarness.getInstance().isDebug()) {
+                        done = true;
+                        break;
+                    }
+
                     // each agent ramp 0 to X user/sec by adding users to the total users over the initial ramp
                     if(initialRampTimeElapsed <= rampTimeMillis) {
                         double currentUsers = calculateTotalUsers((double) initialRampTimeInterval / 1000); // calculate total expected users at current time
@@ -327,6 +337,9 @@ public class TestPlanStarter implements Runnable {
                             || APITestHarness.getInstance().getCmd() == AgentCommand.pause) {
                         if (APITestHarness.getInstance().hasMetSimulationTime()) {
                             APITestHarness.getInstance().setCommand(AgentCommand.stop);
+                            return;
+                        }
+                        else if (APITestHarness.getInstance().getCmd() == AgentCommand.stop) {
                             return;
                         } else {
                             try {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -292,7 +292,6 @@ public class TestPlanStarter implements Runnable {
 
             while (System.currentTimeMillis() - startTime < (rampTimeMillis + totalPauseDuration)) { // time elapsed + any pause duration = total ramp time
                 try {
-                    // if paused, check if simulation time has been met and stop ramp accordingly
                     if (APITestHarness.getInstance().getCmd() == AgentCommand.pause_ramp
                             || APITestHarness.getInstance().getCmd() == AgentCommand.pause) {
                         if (APITestHarness.getInstance().hasMetSimulationTime()) {


### PR DESCRIPTION
**Fix Stop during Initial Ramp for Nonlinear Workload**
Simple fix for an issue where stopping a nonlinear job during the initial ramp (the duration of time until the ramp rate reaches the target ramp rate) will continue running the job due to the no checks for agent stop command - this results in the initial ramp ignoring the stop command and continuing to ramp up until target ramp rate is reached (enters main loop). It also resulted in unexpected behavior when stopping a paused job during the initial ramp - this exits the pause state and continues ramping up before entering the main loop and stopping. 

Adding the check for the agent stop command in the initial ramp method now stops the ramp as expected, whether the job is  running or paused. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.