### PR TITLE
Nonlinear Workload - Calculate Number of Agents based on Total Ramp Rate and Max Users/Sec per Agent

### DIFF
--- a/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequest.java
+++ b/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequest.java
@@ -63,6 +63,11 @@ public interface JobRequest extends Serializable {
     public abstract int getNumAgents();
 
     /**
+     * @return the targetRatePerAgent
+     */
+    public abstract double getTargetRatePerAgent();
+
+    /**
      * @return the location
      */
     public abstract String getLocation();

--- a/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequestImpl.java
+++ b/api/src/main/java/com/intuit/tank/vm/vmManager/JobRequestImpl.java
@@ -62,6 +62,7 @@ public final class JobRequestImpl implements Serializable, JobRequest {
     private String vmInstanceType;
     private int numUsersPerAgent;
     private int numAgents;
+    private double targetRatePerAgent;
     private int startRate;
     private double endRate;
     private String scriptsXmlUrl;
@@ -224,6 +225,21 @@ public final class JobRequestImpl implements Serializable, JobRequest {
      */
     public void setNumAgents(int numAgents) {
         this.numAgents = numAgents;
+    }
+
+    /**
+     * @return the targetRatePerAgent
+     */
+    public double getTargetRatePerAgent() {
+        return targetRatePerAgent;
+    }
+
+    /**
+     * @param targetRatePerAgent
+     *            the targetRatePerAgent to set
+     */
+    public void setTargetRatePerAgent(double targetRatePerAgent) {
+        this.targetRatePerAgent = targetRatePerAgent;
     }
 
     /**
@@ -411,6 +427,12 @@ public final class JobRequestImpl implements Serializable, JobRequest {
         @SuppressWarnings("unchecked")
         public GeneratorT withNumAgents(int aValue) {
             instance.numAgents = aValue;
+            return (GeneratorT) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public GeneratorT withTargetRatePerAgent(double aValue) {
+            instance.targetRatePerAgent = aValue;
             return (GeneratorT) this;
         }
 

--- a/api/src/main/java/com/intuit/tank/vm/vmManager/JobVmCalculator.java
+++ b/api/src/main/java/com/intuit/tank/vm/vmManager/JobVmCalculator.java
@@ -13,6 +13,8 @@ package com.intuit.tank.vm.vmManager;
  * #L%
  */
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -31,6 +33,29 @@ public class JobVmCalculator {
             return 0;
         }
         return (int) Math.ceil((double) numberOfUsers / (double) numUsersPerAgent);
+    }
+
+    /**
+     *
+     * @param targetRate
+     * @param targetRatePerAgent
+     * @return
+     */
+    public static Map<Integer, Double> getMachinesForAgentByTargetRate(double targetRate, Double targetRatePerAgent) {
+        Map<Integer, Double> agentAllocation = new HashMap<>();
+        if (targetRate <= 0.0 || targetRatePerAgent <= 0.0) {
+            return agentAllocation;
+        }
+
+        // divide the (target rate) by the (target rate per agent) to get the number of agents needed (always round up)
+        BigDecimal targetRateBD = BigDecimal.valueOf(targetRate);
+        BigDecimal targetRatePerAgentBD = BigDecimal.valueOf(targetRatePerAgent);
+        int numAgents = targetRateBD.divide(targetRatePerAgentBD, 2, RoundingMode.CEILING).setScale(0, RoundingMode.CEILING).intValue();
+
+        // adjusts the rate per agent if needed due to rounding up (always less than or equal to the initial rate per agent)
+        double ratePerAgent = targetRate / numAgents;
+
+        return Map.of(numAgents, ratePerAgent);
     }
 
     /**

--- a/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
+++ b/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
@@ -71,6 +71,9 @@ public abstract class BaseJob extends BaseEntity {
     @Column(name = "num_agents", columnDefinition = "INT(11) NOT NULL DEFAULT '1'")
     private int numAgents = 1;
 
+    @Column(name = "target_rate_per_agent", columnDefinition="DECIMAL(10,2) NOT NULL DEFAULT '1.00'")
+    private Double targetRatePerAgent = 1.00;
+
     @Column(name = "logging_profile")
     private String loggingProfile = LoggingProfile.STANDARD.name();
 
@@ -138,6 +141,7 @@ public abstract class BaseJob extends BaseEntity {
         this.executionTime = copy.executionTime;
         this.numUsersPerAgent = copy.numUsersPerAgent;
         this.numAgents = copy.numAgents;
+        this.targetRatePerAgent = copy.targetRatePerAgent;
         this.vmInstanceType = copy.vmInstanceType;
         this.useEips = copy.useEips;
         this.useTwoStep = copy.useTwoStep;
@@ -370,6 +374,21 @@ public abstract class BaseJob extends BaseEntity {
      */
     public void setNumAgents(int numAgents) {
         this.numAgents = numAgents;
+    }
+
+    /**
+     * @return the targetRatePerAgent
+     */
+    public Double getTargetRatePerAgent() {
+        return targetRatePerAgent;
+    }
+
+    /**
+     * @param targetRatePerAgent
+     *            the targetRatePerAgent to set
+     */
+    public void setTargetRatePerAgent(Double targetRatePerAgent) {
+        this.targetRatePerAgent = targetRatePerAgent;
     }
 
     /**

--- a/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatter.java
+++ b/rest-mvc/src/main/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatter.java
@@ -82,7 +82,8 @@ public class JobDetailFormatter {
             addProperty(sb, "Assign Elastic Ips", Boolean.toString(proposedJobInstance.isUseEips()));
             addProperty(sb, "Enable Two-Step Job Start", Boolean.toString(proposedJobInstance.isUseTwoStep()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)) {
-                addProperty(sb, "Number of Agents", Integer.toString(proposedJobInstance.getNumAgents()));
+                addProperty(sb, "Number of Agents", Integer.toString(JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).keySet().iterator().next()));
+                addProperty(sb, "Max Users/Sec Per Agent", Double.toString(JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).values().iterator().next()));
             } else {
                 addProperty(sb, "Max Users per Agent", Integer.toString(proposedJobInstance.getNumUsersPerAgent()));
             }
@@ -110,8 +111,7 @@ public class JobDetailFormatter {
             }
             addProperty(sb, "Ramp Time", TimeUtil.toTimeString(proposedJobInstance.getRampTime()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)){
-                addProperty(sb, "Agent User Ramp Rate (users/sec)", String.format("%.2f", proposedJobInstance.getTargetRampRate()));
-                addProperty(sb, "Total User Ramp Rate (users/sec)", String.format("%.2f", proposedJobInstance.getTargetRampRate() * proposedJobInstance.getNumAgents()));
+                addProperty(sb, "Target Users Per Second",String.format("%.2f", proposedJobInstance.getTargetRampRate()));
                 addProperty(sb, "Estimated Steady State Concurrent Users",
                         String.format("%.2f", proposedJobInstance.getTargetRampRate() *
                                 ((double) proposedJobInstance.getRampTime() / 1000) *
@@ -148,7 +148,8 @@ public class JobDetailFormatter {
 
                 // Calculate number of agents per region split for nonlinear workloads
                 Set<RegionRequest> regionRequests = new HashSet<>(regions);
-                Map<RegionRequest, Integer> regionAllocation = JobVmCalculator.getMachinesForAgentByUserPercentage(proposedJobInstance.getNumAgents(), regionRequests);
+                int numAgents = JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).keySet().iterator().next();
+                Map<RegionRequest, Integer> regionAllocation = JobVmCalculator.getMachinesForAgentByUserPercentage(numAgents, regionRequests);
 
                 int regionPercentage = 0;
                 for (JobRegion r : regions) {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
@@ -171,7 +171,7 @@ public class JobManager implements Serializable {
                 ret.setTotalAgents(jobInfo.numberOfMachines);
                 ret.setIncrementStrategy(jobInfo.jobRequest.getIncrementStrategy());
                 ret.setUserIntervalIncrement(jobInfo.jobRequest.getUserIntervalIncrement());
-                ret.setTargetRampRate(jobInfo.jobRequest.getEndRate());
+                ret.setTargetRampRate(jobInfo.jobRequest.getTargetRatePerAgent());
                 jobInfo.agentData.add(agentData);
                 CloudVmStatus status = vmTracker.getStatus(agentData.getInstanceId());
                 if(status != null) {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/WorkLoadFactory.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/WorkLoadFactory.java
@@ -16,6 +16,7 @@ package com.intuit.tank.perfManager.workLoads;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.intuit.tank.vm.vmManager.*;
 import jakarta.inject.Inject;
 
 import com.intuit.tank.vm.api.enumerated.IncrementStrategy;
@@ -39,11 +40,6 @@ import com.intuit.tank.vm.api.enumerated.TerminationPolicy;
 import com.intuit.tank.vm.api.enumerated.VMRegion;
 import com.intuit.tank.vm.api.service.v1.project.ProjectServiceUrlBuilder;
 import com.intuit.tank.vm.scheduleManager.AgentDispatcher;
-import com.intuit.tank.vm.vmManager.JobRequest;
-import com.intuit.tank.vm.vmManager.JobRequestImpl;
-import com.intuit.tank.vm.vmManager.Notification;
-import com.intuit.tank.vm.vmManager.RegionRequest;
-import com.intuit.tank.vm.vmManager.VMChannel;
 import com.intuit.tank.vm.vmManager.JobRequestImpl.Builder;
 
 public class WorkLoadFactory {
@@ -139,7 +135,8 @@ public class WorkLoadFactory {
                 .withUseTwoStep(job.isUseTwoStep())
                 .withVmInstanceType(job.getVmInstanceType())
                 .withnumUsersPerAgent(job.getNumUsersPerAgent())
-                .withNumAgents(job.getNumAgents())
+                .withNumAgents(JobVmCalculator.getMachinesForAgentByTargetRate(job.getTargetRampRate(), job.getTargetRatePerAgent()).keySet().iterator().next())
+                .withTargetRatePerAgent(JobVmCalculator.getMachinesForAgentByTargetRate(job.getTargetRampRate(), job.getTargetRatePerAgent()).values().iterator().next())
                 .withSimulationTime(job.getSimulationTime()).withStatus(job.getStatus())
                 .withTerminationPolicy(job.getTerminationPolicy())
                 .withUserIntervalIncrement(job.getUserIntervalIncrement())

--- a/web/web_support/src/main/java/com/intuit/tank/project/JobDetailFormatter.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/JobDetailFormatter.java
@@ -88,7 +88,8 @@ public class JobDetailFormatter {
             addProperty(sb, "Assign Elastic Ips", Boolean.toString(proposedJobInstance.isUseEips()));
             addProperty(sb, "Enable Two-Step Job Start", Boolean.toString(proposedJobInstance.isUseTwoStep()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)) {
-                addProperty(sb, "Number of Agents", Integer.toString(proposedJobInstance.getNumAgents()));
+                addProperty(sb, "Number of Agents", Integer.toString(JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).keySet().iterator().next()));
+                addProperty(sb, "Max Users/Sec Per Agent", Double.toString(JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).values().iterator().next()));
             } else {
                 addProperty(sb, "Max Users per Agent", Integer.toString(proposedJobInstance.getNumUsersPerAgent()));
             }
@@ -116,8 +117,7 @@ public class JobDetailFormatter {
             }
             addProperty(sb, "Ramp Time", TimeUtil.toTimeString(proposedJobInstance.getRampTime()));
             if(proposedJobInstance.getIncrementStrategy().equals(IncrementStrategy.standard)){
-                addProperty(sb, "Agent User Ramp Rate (users/sec)",String.format("%.2f", proposedJobInstance.getTargetRampRate()));
-                addProperty(sb, "Total User Ramp Rate (users/sec)", String.format("%.2f", proposedJobInstance.getTargetRampRate() * proposedJobInstance.getNumAgents()));
+                addProperty(sb, "Target Users Per Second",String.format("%.2f", proposedJobInstance.getTargetRampRate()));
                 addProperty(sb, "Estimated Steady State Concurrent Users",
                         String.format("%.2f", proposedJobInstance.getTargetRampRate() *
                                 ((double) proposedJobInstance.getRampTime() / 1000) *
@@ -154,7 +154,8 @@ public class JobDetailFormatter {
 
                 // Calculate number of agents per region split for nonlinear workloads
                 Set<RegionRequest> regionRequests = new HashSet<>(regions);
-                Map<RegionRequest, Integer> regionAllocation = JobVmCalculator.getMachinesForAgentByUserPercentage(proposedJobInstance.getNumAgents(), regionRequests);
+                int numAgents = JobVmCalculator.getMachinesForAgentByTargetRate(proposedJobInstance.getTargetRampRate(), proposedJobInstance.getTargetRatePerAgent()).keySet().iterator().next();
+                Map<RegionRequest, Integer> regionAllocation = JobVmCalculator.getMachinesForAgentByUserPercentage(numAgents, regionRequests);
 
                 int regionPercentage = 0;
                 for (JobRegion r : regions) {

--- a/web/web_support/src/main/java/com/intuit/tank/project/JobMaker.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/JobMaker.java
@@ -238,6 +238,17 @@ public class JobMaker implements Serializable {
         }
     }
 
+    public double getTargetRatePerAgent() {
+        return (projectBean.getJobConfiguration().getTargetRatePerAgent() != null) ?
+                projectBean.getJobConfiguration().getTargetRatePerAgent() : 1.00 ;
+    }
+
+    public void setTargetRatePerAgent(double targetRatePerAgent) {
+        if (targetRatePerAgent > 0.0) {
+            projectBean.getJobConfiguration().setTargetRatePerAgent(targetRatePerAgent);
+        }
+    }
+
     public int getNumAgents() {
         return projectBean.getJobConfiguration().getNumAgents();
     }

--- a/web/web_ui/src/main/webapp/META-INF/context.xml
+++ b/web/web_ui/src/main/webapp/META-INF/context.xml
@@ -5,5 +5,18 @@
         auth="Container"
         type="jakarta.enterprise.inject.spi.BeanManager"
         factory="org.jboss.weld.resources.ManagerObjectFactory" />
+    <Resource name="jdbc/watsDS"
+              auth="Container"
+              type="javax.sql.DataSource"
+              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+              maxWait="10000"
+              username="root"  password="password"
+              testOnBorrow="true"
+              validationQuery="SELECT 1"
+              removeAbandonedOnBorrow="true"
+              removeAbandonedOnMaintenance="true"
+              removeAbandonedTimeout="60"
+              driverClassName="com.mysql.cj.jdbc.Driver"
+              url="jdbc:mysql://localhost:3306/tank?serverTimezone=UTC"/>
 </Context>
 

--- a/web/web_ui/src/main/webapp/META-INF/context.xml
+++ b/web/web_ui/src/main/webapp/META-INF/context.xml
@@ -5,18 +5,5 @@
         auth="Container"
         type="jakarta.enterprise.inject.spi.BeanManager"
         factory="org.jboss.weld.resources.ManagerObjectFactory" />
-    <Resource name="jdbc/watsDS"
-              auth="Container"
-              type="javax.sql.DataSource"
-              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-              maxWait="10000"
-              username="root"  password="password"
-              testOnBorrow="true"
-              validationQuery="SELECT 1"
-              removeAbandonedOnBorrow="true"
-              removeAbandonedOnMaintenance="true"
-              removeAbandonedTimeout="60"
-              driverClassName="com.mysql.cj.jdbc.Driver"
-              url="jdbc:mysql://localhost:3306/tank?serverTimezone=UTC"/>
 </Context>
 

--- a/web/web_ui/src/main/webapp/projects/addWorkloadToJobQueue.xhtml
+++ b/web/web_ui/src/main/webapp/projects/addWorkloadToJobQueue.xhtml
@@ -95,15 +95,15 @@
               <h:outputLabel for="numUsersPerInstance"
                              value="Max Users Per Agent"
                              styleClass="formLabel required" rendered="#{usersAndTimes.incrementStrategy == 'increasing'}"/>
-              <h:outputLabel for="numAgents"
-                             value="Number of Agents"
+              <h:outputLabel for="targetRatePerAgent"
+                             value="Max Users/Sec Per Agent"
                              styleClass="formLabel required" rendered="#{usersAndTimes.incrementStrategy == 'standard'}"/>
             </div>
             <div class="formInputDiv">
               <p:inputText id="numUsersPerInstance"
                            value="#{jobMaker.numUsersPerAgent}" rendered="#{usersAndTimes.incrementStrategy == 'increasing'}"/>
-              <p:inputText id="numAgents"
-                           value="#{jobMaker.numAgents}" rendered="#{usersAndTimes.incrementStrategy == 'standard'}"/>
+              <p:inputText id="targetRatePerAgent"
+                           value="#{jobMaker.targetRatePerAgent}" rendered="#{usersAndTimes.incrementStrategy == 'standard'}"/>
             </div>
           </div>
 

--- a/web/web_ui/src/main/webapp/projects/projectview.xhtml
+++ b/web/web_ui/src/main/webapp/projects/projectview.xhtml
@@ -123,7 +123,7 @@
           <div class="formRow">
             <div class="formLabelDiv">
               <h:outputText value="Total Users" styleClass="formLabel" rendered="#{usersAndTimes.incrementStrategy == 'increasing'}"/>
-              <h:outputText value="Agent User Ramp Rate (users/sec)" styleClass="formLabel" rendered="#{usersAndTimes.incrementStrategy == 'standard'}"/>
+              <h:outputText value="Target Users Per Second" styleClass="formLabel" rendered="#{usersAndTimes.incrementStrategy == 'standard'}"/>
             </div>
             <div class="formInputDiv">
               <h:outputText value="#{usersAndTimes.totalUsers}" id="totalUsersTF" rendered="#{usersAndTimes.incrementStrategy == 'increasing'}"/>
@@ -131,14 +131,13 @@
                 <h:inputText id="endRateTF"
                              value="#{usersAndTimes.endRate}"
                              styleClass="formInput inputWidthSmall" required="true"
-                             requiredMessage="Agent User Ramp Rate cannot be empty." rendered="#{usersAndTimes.incrementStrategy == 'standard'}">
+                             requiredMessage="Target Users Per Second cannot be empty." rendered="#{usersAndTimes.incrementStrategy == 'standard'}">
                 </h:inputText>
                 <p:ajax event="save" update=":mainForm:endRateTF" rendered="#{usersAndTimes.incrementStrategy == 'standard'}" />
               </p:inplace>
               <ts:tip tipId="targetRampTip"
-                      text="Agent User Ramp Rate dictates the ending ramp rate in users/sec set for each agent for the nonlinear user ramp. This
-                            will inject users at regular intervals from the starting rate of 0 users/sec to the target rate of up to 1 user/sec for the provided ramp duration.
-                            The Total User Ramp Rate of the job is determined by the Agent User Ramp Rate times the Number of Agents i.e 1 user/sec * 10 agents = 10 users/sec" rendered="#{usersAndTimes.incrementStrategy == 'standard'}" />
+                      text="Target Users Per Second dictates the target user ramp rate in users/sec set for the nonlinear user ramp. This
+                            will inject users at regular intervals from the starting rate of 0 users/sec to the target rate of X user/sec during the provided ramp duration." rendered="#{usersAndTimes.incrementStrategy == 'standard'}" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Nonlinear Workload - Automatically Calculate Number of Agents based on Total Ramp Rate and Max Users/Sec per Agent**

This change improves the user experience of setting up nonlinear workload jobs. Currently, the user inputs the ramp rate per agent and the number of agents they want for the job, which requires the person to work backward to find the total ramp rate. This change allows the user to set the total TPS (user/sec ramp) for the entire job, along with a max user/sec ramp rate per agent and lets the controller automatically calculate the number of agents needed for the job. This follows the same pattern as we have for linear jobs, where the user inputs the total users for the job and max users per agent.

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.