### PR TITLE
[SRE-31553] Fix APIMonitor Retry Loop Bug

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -73,6 +73,7 @@ public class APIMonitor implements Runnable {
                     sendTps(tpsInfo);
                 }
                 if (!isLocal) setInstanceStatus(newStatus.getInstanceId(), newStatus);
+                causeUnknownError();
                 APITestHarness.getInstance().checkAgentThreads();
                 Thread.sleep(reportInterval);
             } catch (Exception t) {
@@ -146,6 +147,10 @@ public class APIMonitor implements Runnable {
                 LOG.error("Error sending status to controller: " + e.toString(), e);
             }
         }
+    }
+
+    private static void causeUnknownError() throws IllegalArgumentException {
+        throw new IllegalArgumentException("throwing unknown error in APIMonitor");
     }
 
     private static void setInstanceStatus(String instanceId, CloudVmStatus VmStatus) throws URISyntaxException, JsonProcessingException {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -73,7 +73,6 @@ public class APIMonitor implements Runnable {
                     sendTps(tpsInfo);
                 }
                 if (!isLocal) setInstanceStatus(newStatus.getInstanceId(), newStatus);
-                causeUnknownError();
                 APITestHarness.getInstance().checkAgentThreads();
             } catch (Exception t) {
                 LOG.error(LogUtil.getLogMessage("Unable to send status metrics | " + t.getMessage()), t);
@@ -150,10 +149,6 @@ public class APIMonitor implements Runnable {
                 LOG.error("Error sending status to controller: " + e.toString(), e);
             }
         }
-    }
-
-    private static void causeUnknownError() throws IllegalArgumentException {
-        throw new IllegalArgumentException("throwing unknown error in APIMonitor");
     }
 
     private static void setInstanceStatus(String instanceId, CloudVmStatus VmStatus) throws URISyntaxException, JsonProcessingException {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APIMonitor.java
@@ -75,9 +75,12 @@ public class APIMonitor implements Runnable {
                 if (!isLocal) setInstanceStatus(newStatus.getInstanceId(), newStatus);
                 causeUnknownError();
                 APITestHarness.getInstance().checkAgentThreads();
-                Thread.sleep(reportInterval);
             } catch (Exception t) {
                 LOG.error(LogUtil.getLogMessage("Unable to send status metrics | " + t.getMessage()), t);
+            } finally {
+                try {
+                    Thread.sleep(reportInterval);
+                } catch ( InterruptedException ie) { /*Ignore*/ }
             }
         }
     }


### PR DESCRIPTION
The placement of the `Thread.sleep` within the try-catch block instead of in a `finally` block of the APIMonitor `run()` method leads to a retry loop whenever any exception is thrown - resulting in an explosion of calls from the affected agent to the controller, spiking CPU and memory for both. This fixes this bug by moving the sleep to where it needs to be. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.