### PR TITLE
Increase Decimal Precision of Max Users/Sec Per Agent

### DIFF
--- a/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
+++ b/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
@@ -71,7 +71,7 @@ public abstract class BaseJob extends BaseEntity {
     @Column(name = "num_agents", columnDefinition = "INT(11) NOT NULL DEFAULT '1'")
     private int numAgents = 1;
 
-    @Column(name = "target_rate_per_agent", columnDefinition="DECIMAL(10,2) NOT NULL DEFAULT '1.00'")
+    @Column(name = "target_rate_per_agent", columnDefinition="DECIMAL(10,4) NOT NULL DEFAULT '1.00'")
     private Double targetRatePerAgent = 1.00;
 
     @Column(name = "logging_profile")

--- a/web/web_ui/src/main/webapp/META-INF/context.xml
+++ b/web/web_ui/src/main/webapp/META-INF/context.xml
@@ -5,5 +5,18 @@
         auth="Container"
         type="jakarta.enterprise.inject.spi.BeanManager"
         factory="org.jboss.weld.resources.ManagerObjectFactory" />
+    <Resource name="jdbc/watsDS"
+              auth="Container"
+              type="javax.sql.DataSource"
+              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+              maxWait="10000"
+              username="root"  password="password"
+              testOnBorrow="true"
+              validationQuery="SELECT 1"
+              removeAbandonedOnBorrow="true"
+              removeAbandonedOnMaintenance="true"
+              removeAbandonedTimeout="60"
+              driverClassName="com.mysql.cj.jdbc.Driver"
+              url="jdbc:mysql://localhost:3306/tank?serverTimezone=UTC"/>
 </Context>
 

--- a/web/web_ui/src/main/webapp/META-INF/context.xml
+++ b/web/web_ui/src/main/webapp/META-INF/context.xml
@@ -5,18 +5,5 @@
         auth="Container"
         type="jakarta.enterprise.inject.spi.BeanManager"
         factory="org.jboss.weld.resources.ManagerObjectFactory" />
-    <Resource name="jdbc/watsDS"
-              auth="Container"
-              type="javax.sql.DataSource"
-              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-              maxWait="10000"
-              username="root"  password="password"
-              testOnBorrow="true"
-              validationQuery="SELECT 1"
-              removeAbandonedOnBorrow="true"
-              removeAbandonedOnMaintenance="true"
-              removeAbandonedTimeout="60"
-              driverClassName="com.mysql.cj.jdbc.Driver"
-              url="jdbc:mysql://localhost:3306/tank?serverTimezone=UTC"/>
 </Context>
 


### PR DESCRIPTION
**Increase Decimal Precision of Max Users/Sec Per Agent**
Increases Decimal Precision for Max Users/Sec Per Agent from 2 to 4 decimal points to avoid any rounding issues for precise calculations - previously rounded up to 2 decimal points resulting in an extra agent

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.