### PR TITLE
Fix: Handle Controller Restarts

### DIFF
--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
@@ -272,10 +272,11 @@ public class JobManager implements Serializable {
      * @return AgentData
      */
     private AgentData findAgent(String instanceId) {
+        String instanceUrl;
         for (VMRegion region : tankConfig.getVmManagerConfig().getRegions()) {
-            String instanceUrl = new AmazonInstance(region).findDNSName(instanceId);
-            if (StringUtils.isNotEmpty(instanceUrl)) {
-                instanceUrl = "http://" + instanceUrl + ":" + tankConfig.getAgentConfig().getAgentPort();
+            Optional<String> instanceUrlOptional = new AmazonInstance(region).findDNSName(instanceId);
+            if (instanceUrlOptional.isPresent()) {
+                instanceUrl = "http://" + instanceUrlOptional.get() + ":" + tankConfig.getAgentConfig().getAgentPort();
                 return new AgentData("0", instanceId, instanceUrl, 0, region, "zone");
             }
         }

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
@@ -272,7 +272,7 @@ public class JobManager implements Serializable {
      * @return AgentData
      */
     private AgentData findAgent(String instanceId) {
-        for (VMRegion region : tankConfig.getVmManagerConfig().getConfiguredRegions()) {
+        for (VMRegion region : tankConfig.getVmManagerConfig().getRegions()) {
             String instanceUrl = new AmazonInstance(region).findDNSName(instanceId);
             if (StringUtils.isNotEmpty(instanceUrl)) {
                 instanceUrl = "http://" + instanceUrl + ":" + tankConfig.getAgentConfig().getAgentPort();

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
@@ -43,16 +43,7 @@ import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 
 import jakarta.annotation.Nonnull;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -559,20 +550,22 @@ public class AmazonInstance implements IEnvironmentInstance {
 
     }
 
-    public String findDNSName(String instanceId) {
+    public Optional<String> findDNSName(String instanceId) {
         try {
-            return ec2client.describeInstances().reservations().stream()
+            Optional<String> dnsName =  ec2client.describeInstances().reservations().stream()
                     .flatMap(reservationDescription -> reservationDescription.instances().stream())
                     .filter(instance -> instanceId.equals(instance.instanceId()))
                     .findFirst()
                     .map(instance -> (StringUtils.isNotEmpty(instance.publicDnsName()))
                             ? instance.publicDnsName()
-                            : instance.privateDnsName())
-                    .toString();
+                            : instance.privateDnsName());
+            if (dnsName.isPresent()) {
+                return dnsName;
+            }
         } catch (Exception e) {
             LOG.error("Error getting public dns in " + vmRegion + ": " + e.getMessage());
         }
-        return null;
+        return Optional.empty();
     }
 
 }


### PR DESCRIPTION
**Fix: Handle Controller Restarts**
When the Tank controller restarts, it maintains connectivity to its running agents via `findAgent()` which creates an `ec2client` per region to pull instance data. This allows the controller to pull each agent's instance URL to send agent commands (start, stop, pause, and kill). Previously, it only did this for a single region (`getConfiguredRegions()`) - the region the controller was in - resulting in failed calls to agents in other regions. This fixes this issue by looping through all available agent regions (`getRegions()`), and thus has no issue in connecting to any running agents after a controller restart. 



Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.