### PR TITLE
Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/agent/agent_standalone/src/main/java/com/intuit/tank/standalone/agent/StandaloneAgentStartup.java
+++ b/agent/agent_standalone/src/main/java/com/intuit/tank/standalone/agent/StandaloneAgentStartup.java
@@ -43,6 +43,7 @@ public class StandaloneAgentStartup implements Runnable {
     private static String API_HARNESS_COMMAND = "./startAgent.sh";
     public static final String METHOD_SETTINGS = "/settings";
     public static final String METHOD_SUPPORT = "/support-files";
+    private static final String TANK_AGENT_DIR = "/opt/tank_agent";
     private static final long PING_TIME = 1000 * 60 * 5;// five minutes
 
     private String controllerBase;
@@ -74,24 +75,25 @@ public class StandaloneAgentStartup implements Runnable {
             try {
                 currentAvailability.setAvailabilityStatus(AgentAvailabilityStatus.DELEGATING);
                 sendAvailability();
-                LOG.info("Starting up: ControllerBaseUrl=" + controllerBase);
+                LOG.info("Starting up: ControllerBaseUrl={}", controllerBase);
                 URL url = new URL(controllerBase + SERVICE_RELATIVE_PATH + METHOD_SETTINGS);
-                LOG.info("Starting up: making call to tank service url to get settings.xml "
-                        + url.toExternalForm());
+                LOG.info("Starting up: making call to tank service url to get settings.xml {}", url.toExternalForm());
                 try ( InputStream settingsStream = url.openStream() ) {
                     String settings = IOUtils.toString(settingsStream, StandardCharsets.UTF_8);
-                    FileUtils.writeStringToFile(new File("settings.xml"), settings, StandardCharsets.UTF_8);
+                    FileUtils.writeStringToFile(new File(TANK_AGENT_DIR, "settings.xml"), settings, StandardCharsets.UTF_8);
                     LOG.info("got settings file...");
                 }
                 url = new URL(controllerBase + SERVICE_RELATIVE_PATH + METHOD_SUPPORT);
-                LOG.info("Making call to tank service url to get support files " + url.toExternalForm());
+                LOG.info("Making call to tank service url to get support files {}", url.toExternalForm());
                 try( ZipInputStream zip = new ZipInputStream(url.openStream()) ) {
                     ZipEntry entry = zip.getNextEntry();
                     while (entry != null) {
                         String name = entry.getName();
-                        LOG.info("Got file from controller: " + name);
-                        File f = new File(name);
-                        try ( FileOutputStream fout = FileUtils.openOutputStream(f) ){
+                        LOG.info("Got file from controller: {}", name);
+                        File file = new File(TANK_AGENT_DIR, name);
+                        if (!file.toPath().normalize().startsWith(TANK_AGENT_DIR)) // Protect "Zip Slip"
+                            throw new Exception("Bad zip entry");
+                        try ( FileOutputStream fout = FileUtils.openOutputStream(file) ){
                             IOUtils.copy(zip, fout);
                         }
                         entry = zip.getNextEntry();

--- a/api/src/main/java/com/intuit/tank/storage/FileSystemFileStorage.java
+++ b/api/src/main/java/com/intuit/tank/storage/FileSystemFileStorage.java
@@ -49,7 +49,12 @@ public class FileSystemFileStorage implements FileStorage, Serializable {
     @Override
     public void storeFileData(FileData fileData, InputStream input) {
         try {
-            File file = new File(FilenameUtils.normalize(basePath + "/" + fileData.getPath() + "/" + fileData.getFileName()));
+            String filename = fileData.getFileName();
+            // ensure that the filename has no path separators or parent directory references
+            if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+                throw new IllegalArgumentException("Invalid filename");
+            }
+            File file = new File(FilenameUtils.normalize(basePath + "/" + fileData.getPath() + "/" + filename));
             if (!file.toPath().normalize().startsWith(basePath)) // Protect "Zip Slip"
                 throw new Exception("Bad zip entry");
             if (!file.getParentFile().exists()) {

--- a/data_access/src/main/java/com/intuit/tank/dao/DataFileDao.java
+++ b/data_access/src/main/java/com/intuit/tank/dao/DataFileDao.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -109,7 +110,8 @@ public class DataFileDao extends BaseDao<DataFile> {
      */
     private void storeFile(InputStream is, DataFile df) throws IOException, IllegalAccessException {
         FileStorage fileStorage = FileStorageFactory.getFileStorage(new TankConfig().getDataFileStorageDir(), false);
-        String fileName = UUID.randomUUID().toString() + "_" + df.getPath();
+        String newPath = StringUtils.replaceEach(df.getPath(), new String[] { "\\", "/", ".." }, new String[] { "_", "_", "_" });
+        String fileName = newPath  + "_" + UUID.randomUUID();
         df.setFileName(fileName);
         FileData fd = DataFileUtil.getFileData(df);
         fileStorage.storeFileData(fd, is);


### PR DESCRIPTION
Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

For example, if a zip file contains a file entry ..\sneaky-file, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of c:\output\..\sneaky-file, which would cause the file to be written to c:\sneaky-file.

## Recommendation
Ensure that output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations.

The recommended way of writing an output file from a zip archive entry is to verify that the normalized full path of the output file starts with a prefix that matches the destination directory. Path normalization can be done with either java.io.File.getCanonicalFile() or java.nio.file.Path.normalize(). Prefix checking can be done with String.startsWith(..), but it is better to use java.nio.file.Path.startsWith(..), as the latter works on complete path segments.

Another alternative is to validate archive entries against a whitelist of expected files.

## Example
In this example, a file path taken from a zip archive item entry is combined with a destination directory. The result is used as the destination file path without verifying that the result is within the destination directory. If provided with a zip file containing an archive path like ..\sneaky-file, then this file would be written outside the destination directory.
```
void writeZipEntry(ZipEntry entry, File destinationDir) {
    File file = new File(destinationDir, entry.getName());
    FileOutputStream fos = new FileOutputStream(file); // BAD
    // ... write entry to fos ...
}
```
To fix this vulnerability, we need to verify that the normalized file still has destinationDir as its prefix, and throw an exception if this is not the case.
```
void writeZipEntry(ZipEntry entry, File destinationDir) {
    File file = new File(destinationDir, entry.getName());
    if (!file.toPath().normalize().startsWith(destinationDir.toPath()))
        throw new Exception("Bad zip entry");
    FileOutputStream fos = new FileOutputStream(file); // OK
    // ... write entry to fos ...
}
```

## References
Snyk: [Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability).
OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.