### PR TITLE
Ensure Tank Jobs correctly stop when Simulation Time is met

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -95,6 +95,7 @@ public class APITestHarness {
     private CountDownLatch doneSignal;
     private Semaphore semaphore;
     private boolean loggedSimTime;
+    private volatile boolean simulationTimeMet = false;
     private int currentUsers = 0;
     private Vector<TankResult> results = new Vector<TankResult>();
     private ValidationStatus validationFailures;
@@ -704,16 +705,23 @@ public class APITestHarness {
     }
 
     public boolean hasMetSimulationTime() {
-        if (agentRunData.getSimulationTimeMillis() > 0) {
+        if (!simulationTimeMet && agentRunData.getSimulationTimeMillis() > 0) {
             if (System.currentTimeMillis() > getSimulationEndTimeMillis()) {
                 if (!loggedSimTime) {
                     LOG.info(new ObjectMessage(ImmutableMap.of("Message", "Simulation time met")));
                     loggedSimTime = true;
                 }
+                simulationTimeMet = true;
                 return true;
             }
         }
-        return false;
+        return simulationTimeMet;
+    }
+
+    public void checkSimulationTime() {
+        if (!simulationTimeMet) {
+            hasMetSimulationTime();
+        }
     }
 
     public long getStartTime() {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -108,6 +108,7 @@ public class TestPlanStarter implements Runnable {
                 LOG.info(LogUtil.getLogMessage("Linear - Starting ramp of additional " + (numThreads - threadsStarted)
                         + " users for plan " + plan.getTestPlanName() + "..."));
                 while (!done) {
+                    APITestHarness.getInstance().checkSimulationTime();
                     if ((threadsStarted - numInitialUsers) % agentRunData.getUserInterval() == 0) {
                         try {
                             Thread.sleep(rampDelay);
@@ -192,6 +193,7 @@ public class TestPlanStarter implements Runnable {
 
                 // start rest of users sleeping between each interval
                 while (!done) {
+                    APITestHarness.getInstance().checkSimulationTime();
 
                     // add additional accumulated fractional users to the total users during ramp time to support main loop
                     double currentUsers = calculateTotalUsers(rampTimer);


### PR DESCRIPTION
**Ensure Tank Jobs correctly stop when Simulation Time is met**
Sometimes, Tank jobs running at higher user/sec ramp rates ignore the check for simulation time and continue running nonetheless - this extra check ensures the jobs stop after simulation time is met by checking against a volatile boolean variable which is checked at the beginning of each loop. 

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.