### PR TITLE
Enable Connection Manager Sharing in Apache Http 4.5

### DIFF
--- a/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
+++ b/agent/http_client_4/src/main/java/com/intuit/tank/httpclient4/TankHttpClient4.java
@@ -101,6 +101,7 @@ public class TankHttpClient4 implements TankHttpClient {
         UserTokenHandler userTokenHandler = (httpContext) -> httpContext.getAttribute(HttpClientContext.USER_TOKEN);
         // default this implementation will create no more than than 2 concurrent connections per given route and no more 20 connections in total
         return HttpClients.custom()
+                .setConnectionManagerShared(true)
                 .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                 .setUserTokenHandler(userTokenHandler)
                 .evictIdleConnections(1L, TimeUnit.MINUTES)


### PR DESCRIPTION
### Enable Connection Manager Sharing in Apache Http 4.5
To avoid the client closing the connection pool prematurely

If the connection manager is shared its life-cycle is expected to be managed by the caller and it will not be shut down if the client is closed.

```
Connection pool shut down
```

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.