### PR TITLE
Reduce calls to `UUID.randomUUID`

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/logging/LogEvent.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/logging/LogEvent.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -67,7 +68,7 @@ public class LogEvent implements Serializable {
     private BaseRequest request;
     private Variables variables; // all static and dynamic parameters set by the user
     private String validationStatus; // if validation is not set then the field can contain value = "NA"
-    private String transactionId; // Transaction Id
+    private UUID transactionId; // Transaction Id
     private String stepGroupName; // Step group name
 
     public LogEvent() {
@@ -84,7 +85,7 @@ public class LogEvent implements Serializable {
     	Map<String, String> map = new TreeMap<>();
         appendField(map, LogFields.EventType, eventType.name());
         appendField(map, LogFields.SourceType, sourceType.name());
-        appendField(map, LogFields.TransactionId, transactionId);
+        appendField(map, LogFields.TransactionId, getTransactionId().toString());
         appendField(map, LogFields.LoggingKey, loggingKey);
         appendField(map, LogFields.TestPlanName, testPlan != null ? testPlan.getTestPlanName() : null);
         appendField(map, LogFields.GroupName, group != null ? group.getName() : null);
@@ -228,11 +229,11 @@ public class LogEvent implements Serializable {
         this.stepGroupName = stepGroupName;
     }
 
-    public String getTransactionId() {
-        return transactionId;
+    public UUID getTransactionId() {
+        return transactionId = (transactionId == null) ? UUID.randomUUID() : transactionId;
     }
 
-    public void setTransactionId(String transactionId) {
+    public void setTransactionId(UUID transactionId) {
         this.transactionId = transactionId;
     }
 

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -15,7 +15,6 @@ package com.intuit.tank.runner;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import com.intuit.tank.harness.StopBehavior;
 import org.apache.commons.lang3.StringUtils;
@@ -276,7 +275,6 @@ public class TestPlanRunner implements Runnable {
             }
             TestStep testStep = scriptSteps.get(i);
             logEvent.setStep(testStep);
-            logEvent.setTransactionId(UUID.randomUUID().toString());
             testStep.setParent(hdScriptUseCase);
             if (gotoGroup != null) {
                 if (testStep instanceof RequestStep) {

--- a/agent/apiharness/src/test/java/com/intuit/tank/harness/logging/LogEventTest.java
+++ b/agent/apiharness/src/test/java/com/intuit/tank/harness/logging/LogEventTest.java
@@ -21,6 +21,8 @@ import com.intuit.tank.logging.LoggingProfile;
 import com.intuit.tank.logging.SourceType;
 
 public class LogEventTest {
+    
+    private final UUID test_UUID = UUID.randomUUID();
 
     @Test
     public void testLogEvent_1() {
@@ -48,7 +50,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -79,7 +81,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -110,7 +112,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -151,7 +153,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -190,7 +192,7 @@ public class LogEventTest {
         fixture.setGroup(new HDScriptGroup());
         fixture.setJobId("");
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -230,7 +232,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -326,7 +328,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -356,7 +358,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -386,7 +388,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -418,7 +420,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -448,7 +450,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -478,7 +480,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("testInstanceId");
@@ -508,7 +510,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -538,7 +540,7 @@ public class LogEventTest {
         fixture.setJobId("testJobId");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -567,7 +569,7 @@ public class LogEventTest {
         fixture.setGroup(new HDScriptGroup());
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -597,7 +599,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -627,7 +629,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -657,7 +659,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -687,7 +689,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -719,7 +721,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -749,7 +751,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -781,7 +783,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -811,7 +813,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -843,7 +845,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -875,7 +877,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -907,7 +909,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -939,7 +941,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -971,7 +973,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -1002,7 +1004,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -1033,7 +1035,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId(UUID.randomUUID());
+        fixture.setTransactionId(test_UUID);
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");

--- a/agent/apiharness/src/test/java/com/intuit/tank/harness/logging/LogEventTest.java
+++ b/agent/apiharness/src/test/java/com/intuit/tank/harness/logging/LogEventTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
+import java.util.UUID;
 
 import com.intuit.tank.harness.MockResponse;
 import com.intuit.tank.harness.data.*;
@@ -47,7 +48,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -78,7 +79,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -109,7 +110,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -150,7 +151,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -189,7 +190,7 @@ public class LogEventTest {
         fixture.setGroup(new HDScriptGroup());
         fixture.setJobId("");
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -229,7 +230,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -325,7 +326,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -355,7 +356,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -385,7 +386,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -417,7 +418,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -447,7 +448,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -477,7 +478,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("testInstanceId");
@@ -507,7 +508,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -537,7 +538,7 @@ public class LogEventTest {
         fixture.setJobId("testJobId");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -566,7 +567,7 @@ public class LogEventTest {
         fixture.setGroup(new HDScriptGroup());
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -596,7 +597,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -626,7 +627,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -656,7 +657,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -686,7 +687,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -718,7 +719,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -748,7 +749,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -780,7 +781,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -810,7 +811,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -842,7 +843,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -874,7 +875,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -906,7 +907,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -938,7 +939,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -970,7 +971,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -1001,7 +1002,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");
@@ -1010,10 +1011,10 @@ public class LogEventTest {
         fixture.setMessage("");
         fixture.setIteration("");
         fixture.setScript(new HDScript());
-        String transactionId = "testTransactionId";
+        UUID transactionId = UUID.fromString("45c8356b-6ae8-408b-96f3-9038cc358439");
         fixture.setTransactionId(transactionId);
 
-        assertEquals("testTransactionId", fixture.getTransactionId());
+        assertEquals(transactionId, fixture.getTransactionId());
     }
 
     @Test
@@ -1032,7 +1033,7 @@ public class LogEventTest {
         fixture.setJobId("");
         fixture.setRequest(new MockRequest());
         fixture.setLoggingKey("");
-        fixture.setTransactionId("");
+        fixture.setTransactionId(UUID.randomUUID());
         fixture.setStepGroupName("");
         fixture.setSourceType(SourceType.agent);
         fixture.setInstanceId("");


### PR DESCRIPTION
## Reduce calls to `UUID.randomUUID`

Agent tracing has shown that `UUID.randomUUID` makes up 20% of the heap allocation during test runs. The LoveEvent.transactionID is being updated for every script step independent of usage. These code changes reduce the `UUID.randomUUID` call to the use cases in which the value is utilized.

![image](https://github.com/user-attachments/assets/2538f468-f6fa-45c8-a270-22cd38175c43)

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.