### PR TITLE
Updating lucene version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <version.junit>5.11.4</version.junit>
     <version.mockito>5.14.2</version.mockito>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.lucene>10.0.0</version.lucene>
+    <version.lucene>9.8.0</version.lucene>
     <version.jaxb>4.0.2</version.jaxb>
     <version.spring-webflux>6.2.1</version.spring-webflux>
     <version.wiremock>3.10.0</version.wiremock>


### PR DESCRIPTION
Follow up to https://github.com/intuit/Tank/pull/364, updates lucene version to 9.8.0 since the 10.0.0 library version requires java 21 instead of 17


Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.