### PR TITLE
Restore commons.fileupload

### DIFF
--- a/agent/agent_common/pom.xml
+++ b/agent/agent_common/pom.xml
@@ -15,18 +15,19 @@
 
 
   <dependencies>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>api</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
     </dependency>
-
     <dependency>
       <groupId>jakarta.xml.ws</groupId>
       <artifactId>jakarta.xml.ws-api</artifactId>

--- a/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpUtil.java
+++ b/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpUtil.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.fileupload.MultipartStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,7 +20,6 @@ import org.apache.logging.log4j.Logger;
 import com.intuit.tank.http.binary.BinaryResponse;
 import com.intuit.tank.http.json.JsonResponse;
 import com.intuit.tank.http.xml.XMLResponse;
-import org.apache.tomcat.util.http.fileupload.MultipartStream;
 
 import static java.util.stream.Collectors.joining;
 

--- a/api/src/main/java/com/intuit/tank/storage/S3FileStorage.java
+++ b/api/src/main/java/com/intuit/tank/storage/S3FileStorage.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -15,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import com.intuit.tank.vm.settings.CloudCredentials;
 import com.intuit.tank.vm.settings.CloudProvider;
 import com.intuit.tank.vm.settings.TankConfig;
-import org.apache.tomcat.util.http.fileupload.IOUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -306,28 +306,6 @@
       <artifactId>weld-servlet-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-catalina</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-coyote</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-jasper</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
 
@@ -542,6 +520,11 @@
         <groupId>com.metaparadigm</groupId>
         <artifactId>json-rpc</artifactId>
         <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/rest-mvc/impl/pom.xml
+++ b/rest-mvc/impl/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>tank-script-processor</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/util/ScriptServiceUtil.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/util/ScriptServiceUtil.java
@@ -14,9 +14,9 @@ import com.intuit.tank.project.ScriptStep;
 import com.intuit.tank.script.models.*;
 import com.intuit.tank.script.RequestDataPhase;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -329,7 +329,7 @@ public class ScriptServiceUtil {
             JAXBContext ctx = JAXBContext.newInstance(ScriptTO.class.getPackage().getName());
             return (ScriptTO) ctx.createUnmarshaller().unmarshal(xmlSource);
         } catch (ParserConfigurationException | JAXBException | SAXException e) {
-            LOG.error("Error unmarshalling script: " + e.getMessage() , e);
+            LOG.error("Error unmarshalling script: {}", e.getMessage(), e);
             throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
         } finally {
             IOUtils.closeQuietly(inputStream);

--- a/script_processor/src/main/java/com/intuit/tank/script/util/ScriptServiceUtil.java
+++ b/script_processor/src/main/java/com/intuit/tank/script/util/ScriptServiceUtil.java
@@ -26,9 +26,9 @@ import com.intuit.tank.project.RequestData;
 import com.intuit.tank.project.Script;
 import com.intuit.tank.project.ScriptStep;
 import com.intuit.tank.script.RequestDataPhase;
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -43,7 +43,6 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -366,7 +365,7 @@ public class ScriptServiceUtil {
             JAXBContext ctx = JAXBContext.newInstance(ScriptTO.class.getPackage().getName());
             return (ScriptTO) ctx.createUnmarshaller().unmarshal(xmlSource);
         } catch (ParserConfigurationException | JAXBException | SAXException e) {
-            LOG.error("Error unmarshalling script: " + e.getMessage() , e);
+            LOG.error("Error unmarshalling script: {}", e.getMessage(), e);
             throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
         } finally {
             IOUtils.closeQuietly(inputStream);

--- a/web/web_support/pom.xml
+++ b/web/web_support/pom.xml
@@ -187,7 +187,26 @@
       <scope>runtime</scope>
     </dependency>
 
-
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-catalina</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-coyote</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jasper</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION
## Restore commons.fileupload

The apache library used to replace fileuploads is not packaged in Tank and only included when deployed with tomcat.
Thus commons.fileupload dependency is being restored and the tomcat dependency tags are moved directly in modules that are deployed in tomcat.

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.