### PR TITLE
Fix content-type on /v2/jobs/script/{jobid}

### DIFF
--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/AgentController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/AgentController.java
@@ -70,11 +70,8 @@ public class AgentController {
         File supportFiles = agentService.getSupportFiles();
         InputStreamResource resource = new InputStreamResource(new FileInputStream(supportFiles));
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + supportFiles.getName() + "\"");
-
         return ResponseEntity.ok()
-                .headers(headers)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + supportFiles.getName() + "\"")
                 .contentLength(supportFiles.length())
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(resource);
@@ -132,10 +129,8 @@ public class AgentController {
     })
     public ResponseEntity<CloudVmStatus> getInstanceStatus(@PathVariable @Parameter(description = "The instance ID associated with the instance", required = true) String instanceId) {
         CloudVmStatus status = agentService.getInstanceStatus(instanceId);
-        if (status != null) {
-            return new ResponseEntity<CloudVmStatus>(status, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (status == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<CloudVmStatus>(status, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/instance/status/{instanceId}", method = RequestMethod.PUT, consumes = { MediaType.APPLICATION_JSON_VALUE })

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/DataFileController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/DataFileController.java
@@ -76,10 +76,8 @@ public class DataFileController {
     })
     public ResponseEntity<DataFileDescriptor> getDatafile(@PathVariable @Parameter(description = "Datafile ID", required = true) Integer datafileId) {
         DataFileDescriptor datafile = dataFileService.getDatafile(datafileId);
-        if (datafile != null){
-            return new ResponseEntity<>(datafile, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (datafile == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(datafile, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/content", method = RequestMethod.GET, produces = { MediaType.TEXT_PLAIN_VALUE } )
@@ -100,7 +98,7 @@ public class DataFileController {
         return ResponseEntity.notFound().build();
     }
 
-    @RequestMapping(value = "/download/{datafileId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/download/{datafileId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     @Operation(description = "Downloads a datafile with the corresponding datafile ID", summary = "Download a datafile")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully downloaded the datafile", content = @Content),
@@ -108,9 +106,8 @@ public class DataFileController {
     })
     public ResponseEntity<StreamingResponseBody> downloadDatafile(@PathVariable @Parameter(description = "Datafile ID", required = true) Integer datafileId) throws IOException {
         Map<String, StreamingResponseBody> response = dataFileService.downloadDatafile(datafileId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/JobController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/JobController.java
@@ -116,10 +116,8 @@ public class JobController {
     })
     public ResponseEntity<List<Map<String, String>>> getAllJobStatus() {
         List<Map<String, String>> status = jobService.getAllJobStatus();
-        if (status != null){
-            return new ResponseEntity<>(status, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (status == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(status, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/status/{jobId}", method = RequestMethod.GET, produces = { MediaType.TEXT_PLAIN_VALUE })
@@ -130,10 +128,8 @@ public class JobController {
     })
     public ResponseEntity<String> getJobStatus(@PathVariable @Parameter(description = "The job ID associated with the job", required = true) Integer jobId) {
         String status = jobService.getJobStatus(jobId);
-        if (status != null){
-            return new ResponseEntity<>(status, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (status == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(status, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/instance-status/{jobId}", method = RequestMethod.GET)
@@ -144,10 +140,8 @@ public class JobController {
     })
     public ResponseEntity<CloudVmStatusContainer> getJobVMStatuses(@PathVariable @Parameter(description = "The job ID associated with the job", required = true) String jobId) {
         CloudVmStatusContainer status = jobService.getJobVMStatus(jobId);
-        if (status != null){
-            return new ResponseEntity<>(status, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (status == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(status, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/script/{jobId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_XML_VALUE })
@@ -158,10 +152,10 @@ public class JobController {
     })
     public ResponseEntity<StreamingResponseBody> getTestScriptForJob(@PathVariable @Parameter(description = "Job ID", required = true) Integer jobId) throws IOException {
         StreamingResponseBody response = jobService.getTestScriptForJob(jobId);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_XML).body(response);
     }
 
-    @RequestMapping(value = "/download/{jobId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/download/{jobId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_XML_VALUE })
     @Operation(description = "Downloads a job's harness XML file", summary = "Download the job's harness file")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully downloaded job's harness file", content = @Content),
@@ -169,18 +163,14 @@ public class JobController {
     })
     public ResponseEntity<StreamingResponseBody> downloadTestScriptForJob(@PathVariable @Parameter(description = "Job ID", required = true) Integer jobId) throws IOException {
         Map<String, StreamingResponseBody> response = jobService.downloadTestScriptForJob(jobId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-
         return ResponseEntity.ok()
-                .headers(headers)
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_XML)
                 .body(responseBody);
     }
 

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/LogController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/LogController.java
@@ -29,7 +29,7 @@ public class LogController {
     @Resource
     private LogServiceV2 logServiceV2;
 
-    @RequestMapping(value = "/{filename}", method = RequestMethod.GET)
+    @RequestMapping(value = "/{filename}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_OCTET_STREAM_VALUE })
     @Operation(description = "Retrieves a specific log file from logs", summary = "Get streaming log file output", hidden = true)
     public ResponseEntity<StreamingResponseBody> getFile(@PathVariable String filename, @RequestParam(required = false) String from) throws IOException {
         StreamingResponseBody response = logServiceV2.getFile(filename, from);

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ProjectController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ProjectController.java
@@ -132,7 +132,7 @@ public class ProjectController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/download/{projectId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/download/{projectId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_XML_VALUE })
     @Operation(description = "Downloads a project's harness XML file", summary = "Download the project's harness file")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully downloaded project's harness file", content = @Content),
@@ -140,18 +140,14 @@ public class ProjectController {
     })
     public ResponseEntity<StreamingResponseBody> downloadTestScriptForProject(@PathVariable @Parameter(description = "Project ID", required = true) Integer projectId) throws IOException {
         Map<String, StreamingResponseBody> response = projectService.downloadTestScriptForProject(projectId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-
         return ResponseEntity.ok()
-                .headers(headers)
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_XML)
                 .body(responseBody);
     }
 

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptController.java
@@ -80,10 +80,8 @@ public class ScriptController {
     })
     public ResponseEntity<ScriptDescription> getScript(@PathVariable @Parameter(description = "Script ID", required = true) Integer scriptId) {
         ScriptDescription script = scriptService.getScript(scriptId);
-        if (script != null){
-            return new ResponseEntity<>(script, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (script == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(script, HttpStatus.OK);
     }
 
     @RequestMapping(method = RequestMethod.POST)
@@ -129,9 +127,8 @@ public class ScriptController {
     })
     public ResponseEntity<StreamingResponseBody> downloadScript(@PathVariable @Parameter(description = "Script ID", required = true) Integer scriptId) throws IOException {
         Map<String, StreamingResponseBody> response = scriptService.downloadScript(scriptId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 
@@ -144,7 +141,7 @@ public class ScriptController {
                 .body(responseBody);
     }
 
-    @RequestMapping(value = "/harness/download/{scriptId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/harness/download/{scriptId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_XML_VALUE })
     @Operation(description = "Downloads the Tank Harness file for a script with the corresponding script ID", summary = "Download the Tank Harness script file")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully downloaded the Tank Harness script file", content = @Content),
@@ -152,18 +149,14 @@ public class ScriptController {
     })
     public ResponseEntity<StreamingResponseBody> downloadHarnessScript(@PathVariable @Parameter(description = "Script ID", required = true) Integer scriptId) throws IOException {
         Map<String, StreamingResponseBody> response = scriptService.downloadHarnessScript(scriptId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-
         return ResponseEntity.ok()
-                .headers(headers)
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_XML)
                 .body(responseBody);
     }
 
@@ -201,10 +194,8 @@ public class ScriptController {
     })
     public ResponseEntity<ExternalScriptTO> getExternalScript(@PathVariable @Parameter(description = "External Script ID", required = true) Integer externalScriptId) {
         ExternalScriptTO script = scriptService.getExternalScript(externalScriptId);
-        if (script != null){
-            return new ResponseEntity<>(script, HttpStatus.OK);
-        }
-        return ResponseEntity.notFound().build();
+        if (script == null) return ResponseEntity.notFound().build();
+        return new ResponseEntity<>(script, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/external", method = RequestMethod.POST, consumes = { MediaType.APPLICATION_JSON_VALUE })
@@ -222,7 +213,7 @@ public class ScriptController {
         return new ResponseEntity<>(savedScript, responseHeaders, HttpStatus.CREATED);
     }
 
-    @RequestMapping(value = "/external/download/{externalScriptId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/external/download/{externalScriptId}", method = RequestMethod.GET, produces = { MediaType.APPLICATION_XML_VALUE })
     @Operation(description = "Downloads the Tank XML file for an external script with the corresponding external script ID", summary = "Download an external script")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully downloaded the Tank XML external script file", content = @Content),
@@ -230,18 +221,14 @@ public class ScriptController {
     })
     public ResponseEntity<StreamingResponseBody> downloadExternalScript(@PathVariable @Parameter(description = "External Script ID", required = true) Integer externalScriptId) throws IOException {
         Map<String, StreamingResponseBody> response = scriptService.downloadExternalScript(externalScriptId);
-        if (response == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (response == null) return ResponseEntity.notFound().build();
+
         String filename = response.keySet().iterator().next();
         StreamingResponseBody responseBody = response.get(filename);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-
         return ResponseEntity.ok()
-                .headers(headers)
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_XML)
                 .body(responseBody);
     }
 

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/JobControllerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/JobControllerTest.java
@@ -196,6 +196,7 @@ public class JobControllerTest {
                     "csv, 3, 4\n" +
                     "file, 5, 6\n", out.toString());
         }
+        assertEquals(MediaType.APPLICATION_XML, result.getHeaders().getContentType());
         assertEquals(200, result.getStatusCode().value());
         verify(jobService).getTestScriptForJob(2);
     }
@@ -211,7 +212,7 @@ public class JobControllerTest {
         payload.put(filename, responseBody);
         when(jobService.downloadTestScriptForJob(2)).thenReturn(payload);
         ResponseEntity<StreamingResponseBody> result = jobController.downloadTestScriptForJob(2);
-        assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
+        assertEquals(MediaType.APPLICATION_XML, result.getHeaders().getContentType());
         assertEquals(filename, result.getHeaders().getContentDisposition().getFilename());
         assertEquals(200, result.getStatusCode().value());
         verify(jobService).downloadTestScriptForJob(2);

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ProjectControllerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ProjectControllerTest.java
@@ -160,7 +160,7 @@ public class ProjectControllerTest {
         payload.put(filename, streamingResponse);
         when(projectService.downloadTestScriptForProject(4)).thenReturn(payload);
         ResponseEntity<StreamingResponseBody> result = projectController.downloadTestScriptForProject(4);
-        assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
+        assertEquals(MediaType.APPLICATION_XML, result.getHeaders().getContentType());
         assertEquals(filename, result.getHeaders().getContentDisposition().getFilename());
         assertEquals(200, result.getStatusCode().value());
         verify(projectService).downloadTestScriptForProject(4);

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/ScriptControllerTest.java
@@ -257,7 +257,7 @@ public class ScriptControllerTest {
         payload.put(filename, streamingResponse);
         when(scriptService.downloadHarnessScript(4)).thenReturn(payload);
         ResponseEntity<StreamingResponseBody> result = scriptController.downloadHarnessScript(4);
-        assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
+        assertEquals(MediaType.APPLICATION_XML, result.getHeaders().getContentType());
         assertEquals(filename, result.getHeaders().getContentDisposition().getFilename());
         assertEquals(200, result.getStatusCode().value());
         verify(scriptService).downloadHarnessScript(4);
@@ -348,7 +348,7 @@ public class ScriptControllerTest {
         payload.put(filename, streamingResponse);
         when(scriptService.downloadExternalScript(5)).thenReturn(payload);
         ResponseEntity<StreamingResponseBody> result = scriptController.downloadExternalScript(5);
-        assertEquals(MediaType.APPLICATION_OCTET_STREAM, result.getHeaders().getContentType());
+        assertEquals(MediaType.APPLICATION_XML, result.getHeaders().getContentType());
         assertEquals(filename, result.getHeaders().getContentDisposition().getFilename());
         assertEquals(200, result.getStatusCode().value());
         verify(scriptService).downloadExternalScript(5);


### PR DESCRIPTION
## Fix content-type on `/v2/jobs/script/{jobid}`
- Ensure XML response are returned with an XML content-encoding header so they can be compressed at the reverse-proxy layer
- Simplify notFound responses

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.