### PR TITLE
Add error message pop-up when attempting to delete user tied to existing resources

### DIFF
--- a/web/web_support/src/main/java/com/intuit/tank/admin/UserAdmin.java
+++ b/web/web_support/src/main/java/com/intuit/tank/admin/UserAdmin.java
@@ -30,11 +30,14 @@ import com.intuit.tank.dao.UserDao;
 import com.intuit.tank.project.Preferences;
 import com.intuit.tank.project.User;
 import com.intuit.tank.qualifier.Modified;
+import com.intuit.tank.util.Messages;
 import com.intuit.tank.util.Multiselectable;
 import com.intuit.tank.view.filter.ViewFilterType;
 import com.intuit.tank.wrapper.SelectableBean;
 import com.intuit.tank.wrapper.SelectableWrapper;
 import com.intuit.tank.wrapper.VersionContainer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * UserAdmin
@@ -47,6 +50,7 @@ import com.intuit.tank.wrapper.VersionContainer;
 public class UserAdmin extends SelectableBean<User> implements Serializable, Multiselectable<User> {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LogManager.getLogger(UserAdmin.class);
 
     private int version;
 
@@ -62,6 +66,9 @@ public class UserAdmin extends SelectableBean<User> implements Serializable, Mul
     @Inject
     @Deleted
     private Event<Preferences> deletedPrefsEvent;
+
+    @Inject
+    private Messages messages;
 
     /**
      * @return the users
@@ -105,12 +112,72 @@ public class UserAdmin extends SelectableBean<User> implements Serializable, Mul
     }
 
     /**
+     * Checks if user owns any resources and returns detailed information
+     * @param userName the user name to check
+     * @return resources owned by the user
+     */
+    private java.util.Map<String, java.util.List<String>> getUserOwnedResources(String userName) {
+        java.util.Map<String, java.util.List<String>> ownedResources = new java.util.HashMap<>();
+
+        // The main check is for projects since they're the top-level resource
+        com.intuit.tank.dao.ProjectDao projectDao = new com.intuit.tank.dao.ProjectDao();
+        java.util.List<com.intuit.tank.project.Project> projects = projectDao.listForOwner(userName);
+        if (!projects.isEmpty()) {
+            java.util.List<String> projectNames = projects.stream()
+                .map(com.intuit.tank.project.Project::getName)
+                .collect(java.util.stream.Collectors.toList());
+            ownedResources.put("projects", projectNames);
+        }
+
+        return ownedResources;
+    }
+
+    /**
+     * Deletes a user by anonymizing their personal data while preserving referential integrity.
+     * The user's name becomes "deleted_user_[id]", email becomes "deleted_users@deleted.com",
+     * and all resources they own have their creator field updated to the anonymized name.
      * 
-     * @param user
+     * @param user the user to delete/anonymize
      */
     public void delete(User user) {
-        new UserDao().delete(user);
-        userEvent.fire(new ModifiedUserMessage(user, this));
+        try {
+            java.util.Map<String, java.util.List<String>> ownedResources = getUserOwnedResources(user.getName());
+            if (!ownedResources.isEmpty()) {
+
+                StringBuilder errorMsg = new StringBuilder();
+                errorMsg.append("Cannot delete user '").append(user.getName()).append("' because they own the following resources:  ");
+
+                for (java.util.Map.Entry<String, java.util.List<String>> entry : ownedResources.entrySet()) {
+                    String resourceType = entry.getKey();
+                    java.util.List<String> resourceNames = entry.getValue();
+                    errorMsg.append("> ").append(resourceType).append(": ");
+                    errorMsg.append(String.join(", ", resourceNames)).append("  ");
+                }
+
+                errorMsg.append("Please reassign or delete those resources first.");
+                messages.error(errorMsg.toString());
+                LOG.warn("User {} owns resources and cannot be deleted: {}", user.getName(), ownedResources);
+                return;
+            }
+
+            // Use UserDao's anonymization method instead of hard delete
+            // This preserves referential integrity while removing user data
+            UserDao userDao = new UserDao();
+            long result = userDao.deleteUserData(user.getName());
+
+            if (result > 0) {
+                userEvent.fire(new ModifiedUserMessage(user, this));
+                messages.info("User " + user.getName() + " has been deleted successfully.");
+            } else {
+                messages.error("Failed to delete/anonymize user '" + user.getName() + "'. User may not exist or an error occurred.");
+                return;
+            }
+        } catch (Exception e) {
+            String errorMsg = "Failed to delete/anonymize user '" + user.getName() +
+                "'. Error: " + e.getMessage();
+            messages.error(errorMsg);
+            LOG.error("Failed to delete/anonymize user " + user.getName(), e);
+        }
     }
 
 }


### PR DESCRIPTION
**Add error message pop-up when attempting to delete user tied to existing resources**

This PR enhances the user deletion functionality in the Admin UI to provide better user experience and data integrity. Instead of hard-deleting users (which could cause database constraint violations), the system now validates resource ownership and uses anonymization to preserve referential integrity before the actual deletion of the user.

<img width="612" height="223" alt="Screenshot 2025-08-20 at 3 11 43 PM" src="https://github.com/user-attachments/assets/614deb25-c055-4a27-a99d-125e0ed5e387" />



Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.