### PR TITLE
Fix script selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <version.enunciate>2.18.1</version.enunciate>
 
     <version.faces>4.1.2</version.faces>
-    <version.primefaces>15.0.6</version.primefaces>
-    <version.primefaces-ext>15.0.6</version.primefaces-ext>
+    <version.primefaces>15.0.7</version.primefaces>
+    <version.primefaces-ext>15.0.7</version.primefaces-ext>
     <version.jsr166>1.7.0</version.jsr166>
     <version.surefire>3.5.3</version.surefire>
     <version.jacoco>0.8.13</version.jacoco>

--- a/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
+++ b/web/web_support/src/main/java/com/intuit/tank/project/WorkloadScripts.java
@@ -67,7 +67,7 @@ public class WorkloadScripts implements Serializable {
     @PostConstruct
     public void postConstruct() {
         List<TestPlan> testPlans = projectBean.getWorkload().getTestPlans();
-        if (testPlans.size() == 0) {
+        if (testPlans.isEmpty()) {
             addTestPlan(TestPlan.builder().name("Test Plan").usersPercentage(100).build());
         } else if (testPlans.size() > tabIndex) {
             this.currentTestPlan = testPlans.get(tabIndex);
@@ -122,12 +122,12 @@ public class WorkloadScripts implements Serializable {
         scriptSelectionModel.getTarget().clear();
     }
 
-    public void onSourceSelect(SelectEvent event) {
-        selectedAvailableScripts = (List<Script>) event.getObject();
+    public void onSourceSelect(SelectEvent<Script> event) {
+        selectedAvailableScripts = List.of(event.getObject());
     }
 
-    public void onTargetSelect(SelectEvent event) {
-        selectedSelectedScripts = (List<Script>) event.getObject();
+    public void onTargetSelect(SelectEvent<Script> event) {
+        selectedSelectedScripts = List.of(event.getObject());
     }
 
     public void onChange(TabChangeEvent event) {


### PR DESCRIPTION
## Fix script selection

### To reproduce
go to any project, click on any script under Available scripts and it will immediately throw the error.

Logging stack was thrown in primefaces 14, but did not affect user interface. In primefaces 15, the exception is making it to the user.

```
17-Sep-2025 18:44:28.013 SEVERE [http-nio-8080-exec-562] com.sun.faces.context.AjaxExceptionHandlerImpl.handlePartialResponseError java.lang.ClassCastException: class com.intuit.tank.project.Script cannot be cast to class java.util.List (com.intuit.tank.project.Script is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @73608eb0; java.util.List is in module java.base of loader 'bootstrap')
	java.lang.ClassCastException: class com.intuit.tank.project.Script cannot be cast to class java.util.List (com.intuit.tank.project.Script is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @73608eb0; java.util.List is in module java.base of loader 'bootstrap')
		at com.intuit.tank.project.WorkloadScripts.onSourceSelect(WorkloadScripts.java:126)
```
Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.