### PR TITLE
primeicons for pagination

### DIFF
--- a/web/web_ui/src/main/webapp/resources/css/primefaces-override.css
+++ b/web/web_ui/src/main/webapp/resources/css/primefaces-override.css
@@ -68,3 +68,39 @@
 .ui-treetable-scrollable-body {
   position: relative;
 }
+
+body .ui-paginator .ui-paginator-first,body .ui-paginator .ui-paginator-prev,body .ui-paginator .ui-paginator-next,body .ui-paginator .ui-paginator-last {
+    border: 1px solid rgba(0,0,0,0);
+}
+
+body .ui-paginator .ui-paginator-first {
+    font-family: "primeicons" !important;
+    background: none;
+}
+body .ui-paginator .ui-paginator-first:before {
+    content: "\e92d";
+}
+
+body .ui-paginator .ui-paginator-prev {
+    font-family: "primeicons" !important;
+    background: none;
+}
+body .ui-paginator .ui-paginator-prev:before {
+    content: "\e931";
+}
+
+body .ui-paginator .ui-paginator-next {
+    font-family: "primeicons" !important;
+    background: none;
+}
+body .ui-paginator .ui-paginator-next:before {
+    content: "\e932";
+}
+
+body .ui-paginator .ui-paginator-last {
+    font-family: "primeicons" !important;
+    background: none;
+}
+body .ui-paginator .ui-paginator-last:before {
+    content: "\e92e";
+}


### PR DESCRIPTION
## primeicons for pagination
Restore pagination icons after move to primefaces 15 broke them
- Redmond theme is no longer supported in primefaces 15
- pagination icons where changed from lines to button in primefaces 15

<img width="423" height="63" alt="image" src="https://github.com/user-attachments/assets/b2cf4f57-c576-4d94-8dbd-3e616ecd417c" />


Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.