### PR TITLE
fix: prevent controller OOM on job creates by removing script deserialization retention

### DIFF
--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
@@ -25,6 +25,9 @@ import com.intuit.tank.project.JobInstance;
 import com.intuit.tank.project.JobQueue;
 import com.intuit.tank.project.JobRegion;
 import com.intuit.tank.project.Project;
+import com.intuit.tank.project.Script;
+import com.intuit.tank.project.ScriptGroup;
+import com.intuit.tank.project.ScriptGroupStep;
 import com.intuit.tank.project.TestPlan;
 import com.intuit.tank.project.Workload;
 import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
@@ -381,6 +384,7 @@ public class JobServiceV2Impl implements JobServiceV2 {
         JobInstanceDao jobInstanceDao = new JobInstanceDao();
 
         Workload workload = project.getWorkloads().get(0);
+        Workload loadedWorkload = workload;
         JobConfiguration jc = workload.getJobConfiguration();
         JobQueue queue = jobQueueDao.findOrCreateForProjectId(project.getId());
         JobInstance jobInstance = new JobInstance(workload, buildJobInstanceName(request, workload, project));
@@ -422,8 +426,40 @@ public class JobServiceV2Impl implements JobServiceV2 {
         jobInstance = jobInstanceDao.saveOrUpdate(jobInstance);
         jobQueueDao.saveOrUpdate(queue);
 
-        ResponseUtil.storeScript(Integer.toString(jobInstance.getId()), workload, jobInstance);
-        return jobInstance;
+        try {
+            ResponseUtil.storeScript(Integer.toString(jobInstance.getId()), workload, jobInstance);
+            return jobInstance;
+        } finally {
+            clearLoadedScriptSteps(loadedWorkload);
+            if (workload != loadedWorkload) {
+                clearLoadedScriptSteps(workload);
+            }
+        }
+    }
+
+    private static void clearLoadedScriptSteps(Workload workload) {
+        if (workload == null || workload.getTestPlans() == null) {
+            return;
+        }
+        for (TestPlan plan : workload.getTestPlans()) {
+            if (plan == null || plan.getScriptGroups() == null) {
+                continue;
+            }
+            for (ScriptGroup group : plan.getScriptGroups()) {
+                if (group == null || group.getScriptGroupSteps() == null) {
+                    continue;
+                }
+                for (ScriptGroupStep groupStep : group.getScriptGroupSteps()) {
+                    if (groupStep == null) {
+                        continue;
+                    }
+                    Script script = groupStep.getScript();
+                    if (script != null && script.getScriptSteps() != null) {
+                        script.getScriptSteps().clear();
+                    }
+                }
+            }
+        }
     }
 
     private static String buildJobInstanceName(CreateJobRequest request, Workload workload, Project project) {

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
@@ -384,7 +384,6 @@ public class JobServiceV2Impl implements JobServiceV2 {
         JobInstanceDao jobInstanceDao = new JobInstanceDao();
 
         Workload workload = project.getWorkloads().get(0);
-        Workload loadedWorkload = workload;
         JobConfiguration jc = workload.getJobConfiguration();
         JobQueue queue = jobQueueDao.findOrCreateForProjectId(project.getId());
         JobInstance jobInstance = new JobInstance(workload, buildJobInstanceName(request, workload, project));
@@ -420,21 +419,13 @@ public class JobServiceV2Impl implements JobServiceV2 {
         }
         jobInstance.setTotalVirtualUsers(totalVirtualUsers);
         queue.addJob(jobInstance);
-        workload = new WorkloadDao().saveOrUpdate(workload);
         String jobDetails = JobDetailFormatter.createJobDetails(validator, workload, jobInstance);
         jobInstance.setJobDetails(jobDetails);
+        clearLoadedScriptSteps(workload);
+        workload = new WorkloadDao().saveOrUpdate(workload);
         jobInstance = jobInstanceDao.saveOrUpdate(jobInstance);
         jobQueueDao.saveOrUpdate(queue);
-
-        try {
-            ResponseUtil.storeScript(Integer.toString(jobInstance.getId()), workload, jobInstance);
-            return jobInstance;
-        } finally {
-            clearLoadedScriptSteps(loadedWorkload);
-            if (workload != loadedWorkload) {
-                clearLoadedScriptSteps(workload);
-            }
-        }
+        return jobInstance;
     }
 
     private static void clearLoadedScriptSteps(Workload workload) {

--- a/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
+++ b/rest-mvc/impl/src/main/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2Impl.java
@@ -429,28 +429,12 @@ public class JobServiceV2Impl implements JobServiceV2 {
     }
 
     private static void clearLoadedScriptSteps(Workload workload) {
-        if (workload == null || workload.getTestPlans() == null) {
-            return;
-        }
-        for (TestPlan plan : workload.getTestPlans()) {
-            if (plan == null || plan.getScriptGroups() == null) {
-                continue;
-            }
-            for (ScriptGroup group : plan.getScriptGroups()) {
-                if (group == null || group.getScriptGroupSteps() == null) {
-                    continue;
-                }
-                for (ScriptGroupStep groupStep : group.getScriptGroupSteps()) {
-                    if (groupStep == null) {
-                        continue;
-                    }
-                    Script script = groupStep.getScript();
-                    if (script != null && script.getScriptSteps() != null) {
-                        script.getScriptSteps().clear();
-                    }
-                }
-            }
-        }
+        workload.getTestPlans().stream()
+                .flatMap(plan -> plan.getScriptGroups().stream())
+                .flatMap(group -> group.getScriptGroupSteps().stream())
+                .map(ScriptGroupStep::getScript)
+                .filter(script -> script != null && script.getScriptSteps() != null)
+                .forEach(script -> script.getScriptSteps().clear());
     }
 
     private static String buildJobInstanceName(CreateJobRequest request, Workload workload, Project project) {

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
@@ -1,0 +1,150 @@
+package com.intuit.tank.rest.mvc.rest.services.jobs;
+
+import com.intuit.tank.dao.DataFileDao;
+import com.intuit.tank.dao.JobInstanceDao;
+import com.intuit.tank.dao.JobNotificationDao;
+import com.intuit.tank.dao.JobQueueDao;
+import com.intuit.tank.dao.WorkloadDao;
+import com.intuit.tank.jobs.models.CreateJobRequest;
+import com.intuit.tank.project.JobConfiguration;
+import com.intuit.tank.project.JobInstance;
+import com.intuit.tank.project.JobQueue;
+import com.intuit.tank.project.Project;
+import com.intuit.tank.project.Script;
+import com.intuit.tank.project.ScriptGroup;
+import com.intuit.tank.project.ScriptGroupStep;
+import com.intuit.tank.project.ScriptStep;
+import com.intuit.tank.project.TestPlan;
+import com.intuit.tank.project.Workload;
+import com.intuit.tank.rest.mvc.rest.util.JobDetailFormatter;
+import com.intuit.tank.rest.mvc.rest.util.JobValidator;
+import com.intuit.tank.rest.mvc.rest.util.ResponseUtil;
+import com.intuit.tank.util.TestParamUtil;
+import com.intuit.tank.util.TestParameterContainer;
+import com.intuit.tank.vm.api.enumerated.IncrementStrategy;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class JobServiceV2ImplTest {
+
+    @Test
+    void addJobToQueue_clearsLoadedScriptSteps_evenWhenStoreScriptThrows() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Script savedScript = createScript("saved-script", 22);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Workload savedWorkload = createWorkload("saved-workload", 222, savedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = createRequest();
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenReturn(savedWorkload));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(123);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+            responseUtil.when(() -> ResponseUtil.storeScript(anyString(), any(Workload.class), any(JobInstance.class)))
+                    .thenThrow(new RuntimeException("boom"));
+
+            RuntimeException thrown = assertThrows(RuntimeException.class,
+                    () -> JobServiceV2Impl.addJobToQueue(project, request));
+
+            assertEquals("boom", thrown.getMessage());
+            assertTrue(loadedScript.getScriptSteps().isEmpty());
+            assertTrue(savedScript.getScriptSteps().isEmpty());
+        }
+    }
+
+    private static Project createProject(Workload workload) {
+        Project project = new Project();
+        project.setId(7);
+        project.setName("project-name");
+        project.addWorkload(workload);
+        return project;
+    }
+
+    private static Workload createWorkload(String name, int id, Script script) {
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setLocation("us-west-2");
+        jobConfiguration.setLoggingProfile("standard");
+        jobConfiguration.setStopBehavior("stop");
+        jobConfiguration.setVmInstanceType("m5.large");
+        jobConfiguration.setNumUsersPerAgent(1);
+        jobConfiguration.setReportingMode("standard");
+        jobConfiguration.setRampTimeExpression("0");
+        jobConfiguration.setSimulationTimeExpression("0");
+
+        ScriptGroupStep groupStep = new ScriptGroupStep();
+        groupStep.setScript(script);
+
+        ScriptGroup group = new ScriptGroup();
+        group.setName(name + "-group");
+        group.addScriptGroupStep(groupStep);
+
+        TestPlan testPlan = new TestPlan();
+        testPlan.setName(name + "-plan");
+        testPlan.addScriptGroup(group);
+
+        Workload workload = new Workload();
+        workload.setId(id);
+        workload.setName(name);
+        workload.setJobConfiguration(jobConfiguration);
+        jobConfiguration.setParent(workload);
+        workload.addTestPlan(testPlan);
+        return workload;
+    }
+
+    private static Script createScript(String name, int id) {
+        Script script = new Script();
+        script.setId(id);
+        script.setName(name);
+        script.setScriptSteps(new ArrayList<>(List.of(new ScriptStep(), new ScriptStep())));
+        return script;
+    }
+
+    private static CreateJobRequest createRequest() throws Exception {
+        CreateJobRequest request = new CreateJobRequest("project-name");
+        setField(request, "workloadType", IncrementStrategy.standard);
+        return request;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -43,11 +43,9 @@ import static org.mockito.Mockito.when;
 class JobServiceV2ImplTest {
 
     @Test
-    void addJobToQueue_clearsLoadedScriptSteps_evenWhenStoreScriptThrows() throws Exception {
+    void addJobToQueue_doesNotCallStoreScript() throws Exception {
         Script loadedScript = createScript("loaded-script", 11);
-        Script savedScript = createScript("saved-script", 22);
         Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
-        Workload savedWorkload = createWorkload("saved-workload", 222, savedScript);
         Project project = createProject(loadedWorkload);
         CreateJobRequest request = createRequest();
         JobQueue queue = new JobQueue(project.getId());
@@ -63,7 +61,7 @@ class JobServiceV2ImplTest {
                          when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
                      });
              MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenReturn(savedWorkload));
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
              MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
                      (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
                          JobInstance savedJob = invocation.getArgument(0);
@@ -77,15 +75,61 @@ class JobServiceV2ImplTest {
                     .thenReturn("job-details");
             testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
                     .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
-            responseUtil.when(() -> ResponseUtil.storeScript(anyString(), any(Workload.class), any(JobInstance.class)))
-                    .thenThrow(new RuntimeException("boom"));
 
-            RuntimeException thrown = assertThrows(RuntimeException.class,
-                    () -> JobServiceV2Impl.addJobToQueue(project, request));
+            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
 
-            assertEquals("boom", thrown.getMessage());
+            assertEquals(123, createdJob.getId());
             assertTrue(loadedScript.getScriptSteps().isEmpty());
-            assertTrue(savedScript.getScriptSteps().isEmpty());
+            responseUtil.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void addJobToQueue_clearsScriptStepsAfterJobDetails() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = createRequest();
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> {
+                         Workload persistedWorkload = invocation.getArgument(0);
+                         assertTrue(getOnlyScript(persistedWorkload).getScriptSteps().isEmpty());
+                         return persistedWorkload;
+                     }));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(123);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenAnswer(invocation -> {
+                        Workload formatterWorkload = invocation.getArgument(1);
+                        assertFalse(getOnlyScript(formatterWorkload).getScriptSteps().isEmpty());
+                        return "job-details";
+                    });
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            JobServiceV2Impl.addJobToQueue(project, request);
+
+            assertTrue(loadedScript.getScriptSteps().isEmpty());
+            responseUtil.verifyNoInteractions();
         }
     }
 
@@ -134,6 +178,10 @@ class JobServiceV2ImplTest {
         script.setName(name);
         script.setScriptSteps(new ArrayList<>(List.of(new ScriptStep(), new ScriptStep())));
         return script;
+    }
+
+    private static Script getOnlyScript(Workload workload) {
+        return workload.getTestPlans().get(0).getScriptGroups().get(0).getScriptGroupSteps().get(0).getScript();
     }
 
     private static CreateJobRequest createRequest() throws Exception {


### PR DESCRIPTION
## Summary
- Remove synchronous `storeScript()` (harness XML generation) from `POST /v2/jobs` create path meaing XML now generated lazily on first start/download via existing fallback
- Clear deserialized `Script.steps` immediately after `JobDetailFormatter` and before DB writes
- Each create was deserializing full script blobs and retaining them through the entire request, causing OOM


Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.