### PR TITLE
API Unit Tests

### DIFF
--- a/jacoco-report-aggregator/pom.xml
+++ b/jacoco-report-aggregator/pom.xml
@@ -72,6 +72,13 @@
 
     <dependency>
       <groupId>com.intuit.tank</groupId>
+      <artifactId>tank-rest-api-impl</artifactId>
+      <scope>compile</scope>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.intuit.tank</groupId>
       <artifactId>tank-script-processor</artifactId>
       <scope>compile</scope>
       <version>${project.version}</version>

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/CustomWebMvcConfigurerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/CustomWebMvcConfigurerTest.java
@@ -1,0 +1,57 @@
+package com.intuit.tank.rest.mvc;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+
+import jakarta.servlet.ServletContext;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class CustomWebMvcConfigurerTest {
+
+    @InjectMocks
+    private CustomWebMvcConfigurer configurer;
+
+    @Mock
+    private ServletContext context;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addViewControllers_registersViewsFromServletContext() {
+        when(context.getResourcePaths("/")).thenReturn(Set.of("/app/", "/docs/"));
+
+        ViewControllerRegistry registry = mock(ViewControllerRegistry.class);
+        ViewControllerRegistration registration = mock(ViewControllerRegistration.class);
+        when(registry.addViewController(anyString())).thenReturn(registration);
+
+        configurer.addViewControllers(registry);
+
+        // Should register root "/" plus entries for each resource path
+        verify(registry).addViewController("/");
+        verify(registry, atLeast(4)).addViewController(anyString()); // root + 2 redirects + 2 forwards
+    }
+
+    @Test
+    void addInterceptors_registersLoggingInterceptor() {
+        InterceptorRegistry registry = mock(InterceptorRegistry.class);
+        InterceptorRegistration registration = mock(InterceptorRegistration.class);
+        when(registry.addInterceptor(any(LoggingInterceptor.class))).thenReturn(registration);
+
+        configurer.addInterceptors(registry);
+
+        verify(registry).addInterceptor(any(LoggingInterceptor.class));
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/LoggingInterceptorTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/LoggingInterceptorTest.java
@@ -1,0 +1,41 @@
+package com.intuit.tank.rest.mvc;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class LoggingInterceptorTest {
+
+    @Test
+    void preHandle_returnsTrue() throws Exception {
+        LoggingInterceptor interceptor = new LoggingInterceptor();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+        assertTrue(result);
+    }
+
+    @Test
+    void afterCompletion_clearsThreadContext() throws Exception {
+        LoggingInterceptor interceptor = new LoggingInterceptor();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Should not throw
+        assertDoesNotThrow(() -> interceptor.afterCompletion(request, response, new Object(), null));
+    }
+
+    @Test
+    void afterCompletion_handlesExceptionParameter() throws Exception {
+        LoggingInterceptor interceptor = new LoggingInterceptor();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertDoesNotThrow(() -> interceptor.afterCompletion(request, response, new Object(), new Exception("test")));
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/JobEventListenerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/JobEventListenerTest.java
@@ -1,0 +1,59 @@
+package com.intuit.tank.rest.mvc.rest.cloud;
+
+import com.intuit.tank.vm.api.enumerated.JobLifecycleEvent;
+import com.intuit.tank.vm.event.JobEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.enterprise.inject.Instance;
+
+import static org.mockito.Mockito.*;
+
+class JobEventListenerTest {
+
+    @InjectMocks
+    private JobEventListener listener;
+
+    @Mock
+    private Instance<JobEventSender> controllerSource;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void observerJobKillRequest_abortedEvent_callsKillJob() {
+        JobEventSender sender = mock(JobEventSender.class);
+        when(controllerSource.get()).thenReturn(sender);
+
+        JobEvent event = new JobEvent("42", "", JobLifecycleEvent.JOB_ABORTED);
+        listener.observerJobKillRequest(event);
+
+        verify(sender).killJob("42", false);
+    }
+
+    @Test
+    void observerJobKillRequest_finishedEvent_clearsContext() {
+        JobEvent event = new JobEvent("42", "", JobLifecycleEvent.JOB_FINISHED);
+        listener.observerJobKillRequest(event);
+        // Should not throw, just clears ThreadContext
+    }
+
+    @Test
+    void observerJobKillRequest_killedEvent_clearsContext() {
+        JobEvent event = new JobEvent("42", "", JobLifecycleEvent.JOB_KILLED);
+        listener.observerJobKillRequest(event);
+    }
+
+    @Test
+    void observerJobKillRequest_otherEvent_doesNothing() {
+        JobEvent event = new JobEvent("42", "", JobLifecycleEvent.AGENT_LAUNCHED);
+        listener.observerJobKillRequest(event);
+        // Should not call killJob or clear context
+        verifyNoInteractions(controllerSource);
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/JobEventSenderTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/JobEventSenderTest.java
@@ -1,26 +1,50 @@
 package com.intuit.tank.rest.mvc.rest.cloud;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Subsegment;
+import com.intuit.tank.dao.JobInstanceDao;
+import com.intuit.tank.dao.WorkloadDao;
+import com.intuit.tank.dao.util.ProjectDaoUtil;
+import com.intuit.tank.harness.data.HDWorkload;
+import com.intuit.tank.perfManager.workLoads.JobManager;
+import com.intuit.tank.project.JobInstance;
+import com.intuit.tank.project.Workload;
+import com.intuit.tank.transform.scriptGenerator.ConverterUtil;
+import com.intuit.tank.vm.api.enumerated.JobLifecycleEvent;
+import com.intuit.tank.vm.api.enumerated.JobQueueStatus;
+import com.intuit.tank.vm.api.enumerated.JobStatus;
+import com.intuit.tank.vm.api.enumerated.VMImageType;
+import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vm.event.JobEvent;
+import com.intuit.tank.vm.perfManager.AgentChannel;
+import com.intuit.tank.vm.settings.TankConfig;
+import com.intuit.tank.vm.settings.VmManagerConfig;
+import com.intuit.tank.vm.vmManager.VMTerminator;
 import com.intuit.tank.vm.vmManager.VMTracker;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatusContainer;
 import com.intuit.tank.vm.vmManager.models.VMStatus;
 import com.intuit.tank.vm.vmManager.models.ValidationStatus;
-import com.intuit.tank.vm.api.enumerated.JobStatus;
-import com.intuit.tank.vm.api.enumerated.VMImageType;
-import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vmManager.environment.amazon.AmazonInstance;
+
+import jakarta.enterprise.event.Event;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.lang.reflect.Method;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -31,6 +55,18 @@ public class JobEventSenderTest {
 
     @Mock
     private VMTracker vmTracker;
+
+    @Mock
+    private VMTerminator terminator;
+
+    @Mock
+    private JobManager jobManager;
+
+    @Mock
+    private AgentChannel agentChannel;
+
+    @Mock
+    private Event<JobEvent> jobEventProducer;
 
     @InjectMocks
     private JobEventSender jobEventSender;
@@ -72,6 +108,10 @@ public class JobEventSenderTest {
         return result;
     }
 
+    // =====================================================================
+    // getInstancesForJob tests (existing)
+    // =====================================================================
+
     @Test
     @DisplayName("getInstancesForJob excludes terminated instances (no longer exist on AWS)")
     void getInstancesForJob_excludesTerminatedInstances() throws Exception {
@@ -79,12 +119,12 @@ public class JobEventSenderTest {
         container.getStatuses().add(createStatus("i-running1", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-terminated", JobStatus.Stopped, VMStatus.terminated));
         container.getStatuses().add(createStatus("i-running2", JobStatus.Running, VMStatus.running));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: Terminated instances excluded (no longer exist on AWS)
         assertEquals(2, instances.size());
         assertTrue(instances.contains("i-running1"));
@@ -98,12 +138,12 @@ public class JobEventSenderTest {
         // Given
         container.getStatuses().add(createStatus("i-running", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-stopped", JobStatus.Stopped, VMStatus.stopped));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: stopped instances are included (EC2 still exists, needs termination)
         assertEquals(2, instances.size());
         assertTrue(instances.contains("i-running"));
@@ -116,12 +156,12 @@ public class JobEventSenderTest {
         // Given
         container.getStatuses().add(createStatus("i-running", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-stopping", JobStatus.Stopped, VMStatus.stopping));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: stopping instances are included (EC2 still exists)
         assertEquals(2, instances.size());
         assertTrue(instances.contains("i-running"));
@@ -134,12 +174,12 @@ public class JobEventSenderTest {
         // Given
         container.getStatuses().add(createStatus("i-running", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-shuttingdown", JobStatus.Stopped, VMStatus.shutting_down));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: shutting_down instances are included (EC2 still exists)
         assertEquals(2, instances.size());
         assertTrue(instances.contains("i-running"));
@@ -151,12 +191,12 @@ public class JobEventSenderTest {
     void getInstancesForJob_includesPendingInstances() throws Exception {
         // Given: Pending instances are still reachable
         container.getStatuses().add(createStatus("i-pending", JobStatus.Starting, VMStatus.pending));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: Pending instances should be included
         assertEquals(1, instances.size());
         assertTrue(instances.contains("i-pending"));
@@ -167,12 +207,12 @@ public class JobEventSenderTest {
     void getInstancesForJob_includesStartingInstances() throws Exception {
         // Given
         container.getStatuses().add(createStatus("i-starting", JobStatus.Starting, VMStatus.starting));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then
         assertEquals(1, instances.size());
         assertTrue(instances.contains("i-starting"));
@@ -183,10 +223,10 @@ public class JobEventSenderTest {
     void getInstancesForJob_returnsEmptyForNonExistent() throws Exception {
         // Given
         when(vmTracker.getVmStatusForJob("999")).thenReturn(null);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("999");
-        
+
         // Then
         assertNotNull(instances);
         assertTrue(instances.isEmpty());
@@ -198,12 +238,12 @@ public class JobEventSenderTest {
         // Given: VMStatus.replaced is set by AgentWatchdog when an agent fails and is replaced
         container.getStatuses().add(createStatus("i-running", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-replaced", JobStatus.Starting, VMStatus.replaced));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: Replaced instances filtered out (they can't receive HTTP commands)
         assertEquals(1, instances.size());
         assertTrue(instances.contains("i-running"));
@@ -214,19 +254,17 @@ public class JobEventSenderTest {
     @DisplayName("getInstancesForJob excludes replaced instances in AgentWatchdog scenario")
     void getInstancesForJob_agentWatchdogScenario() throws Exception {
         // Given: Real-world scenario where AgentWatchdog replaced some agents
-        // - 3 running agents (healthy)
-        // - 2 replaced agents (marked by watchdog with VMStatus.replaced)
         container.getStatuses().add(createStatus("i-healthy1", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-healthy2", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-healthy3", JobStatus.Running, VMStatus.running));
         container.getStatuses().add(createStatus("i-replaced1", JobStatus.Starting, VMStatus.replaced));
         container.getStatuses().add(createStatus("i-replaced2", JobStatus.Starting, VMStatus.replaced));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When: User tries to kill the job
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: Only healthy instances returned (replaced no longer exist on AWS)
         assertEquals(3, instances.size());
         assertTrue(instances.contains("i-healthy1"));
@@ -246,14 +284,13 @@ public class JobEventSenderTest {
         container.getStatuses().add(createStatus("i-stopped", JobStatus.Stopped, VMStatus.stopped));
         container.getStatuses().add(createStatus("i-stopping", JobStatus.Stopped, VMStatus.stopping));
         container.getStatuses().add(createStatus("i-shutting-down", JobStatus.Stopped, VMStatus.shutting_down));
-        
+
         when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
-        
+
         // When
         List<String> instances = invokeGetInstancesForJob("123");
-        
+
         // Then: Excludes replaced and terminated (no longer exist on AWS)
-        // Keeps stopped/stopping/shutting_down (EC2 still exists, needs termination)
         assertEquals(4, instances.size());
         assertTrue(instances.contains("i-running"));
         assertTrue(instances.contains("i-stopped"));
@@ -269,9 +306,9 @@ public class JobEventSenderTest {
         String instanceId = "i-test123";
         CloudVmStatus expectedStatus = createStatus(instanceId, JobStatus.Running, VMStatus.running);
         when(vmTracker.getStatus(instanceId)).thenReturn(expectedStatus);
-        
+
         CloudVmStatus result = jobEventSender.getVmStatus(instanceId);
-        
+
         assertEquals(expectedStatus, result);
         verify(vmTracker).getStatus(instanceId);
     }
@@ -281,11 +318,948 @@ public class JobEventSenderTest {
     void getVmStatusForJob_delegatesToVmTracker() {
         String jobId = "123";
         when(vmTracker.getVmStatusForJob(jobId)).thenReturn(container);
-        
+
         CloudVmStatusContainer result = jobEventSender.getVmStatusForJob(jobId);
-        
+
         assertEquals(container, result);
         verify(vmTracker).getVmStatusForJob(jobId);
     }
-}
 
+    // =====================================================================
+    // startJob tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("startJob with Created status starts the job")
+    void startJob_createdStatus_startsJob() {
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Created);
+
+        File mockFile = mock(File.class);
+        when(mockFile.exists()).thenReturn(true);
+
+        try (MockedStatic<AWSXRay> xray = Mockito.mockStatic(AWSXRay.class);
+             MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> {
+                         when(mock.findById(123)).thenReturn(job);
+                         when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                     });
+             MockedStatic<ProjectDaoUtil> projectDaoUtil = Mockito.mockStatic(ProjectDaoUtil.class)) {
+
+            Subsegment mockSubsegment = mock(Subsegment.class);
+            xray.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            projectDaoUtil.when(() -> ProjectDaoUtil.getScriptFile("123")).thenReturn(mockFile);
+
+            String result = jobEventSender.startJob("123");
+
+            assertEquals("123", result);
+            assertEquals(JobQueueStatus.Starting, job.getStatus());
+            verify(vmTracker).removeStatusForJob("123");
+            verify(jobManager).startJob(123);
+            verify(jobEventProducer).fire(any(JobEvent.class));
+            xray.verify(() -> AWSXRay.beginSubsegment("Start.Job.123"));
+            xray.verify(AWSXRay::endSubsegment);
+        }
+    }
+
+    @Test
+    @DisplayName("startJob with Created status creates script file when it does not exist")
+    void startJob_createdStatus_createsScriptFile() {
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Created);
+
+        File mockFile = mock(File.class);
+        when(mockFile.exists()).thenReturn(false);
+
+        Workload mockWorkload = mock(Workload.class);
+        HDWorkload mockHdWorkload = mock(HDWorkload.class);
+
+        try (MockedStatic<AWSXRay> xray = Mockito.mockStatic(AWSXRay.class);
+             MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> {
+                         when(mock.findById(123)).thenReturn(job);
+                         when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                     });
+             MockedConstruction<WorkloadDao> workloadDaoConstruction = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> {
+                         when(mock.findById(anyInt())).thenReturn(mockWorkload);
+                     });
+             MockedStatic<ProjectDaoUtil> projectDaoUtil = Mockito.mockStatic(ProjectDaoUtil.class);
+             MockedStatic<ConverterUtil> converterUtil = Mockito.mockStatic(ConverterUtil.class)) {
+
+            Subsegment mockSubsegment = mock(Subsegment.class);
+            xray.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            projectDaoUtil.when(() -> ProjectDaoUtil.getScriptFile("123")).thenReturn(mockFile);
+            projectDaoUtil.when(() -> ProjectDaoUtil.storeScriptFile(anyString(), any())).thenAnswer(inv -> null);
+
+            converterUtil.when(() -> ConverterUtil.convertWorkload(any(Workload.class), any(JobInstance.class)))
+                    .thenReturn(mockHdWorkload);
+            converterUtil.when(() -> ConverterUtil.getWorkloadXML(any(HDWorkload.class)))
+                    .thenReturn("<xml>script</xml>");
+
+            String result = jobEventSender.startJob("123");
+
+            assertEquals("123", result);
+            projectDaoUtil.verify(() -> ProjectDaoUtil.storeScriptFile(eq("123"), eq("<xml>script</xml>")));
+        }
+    }
+
+    @Test
+    @DisplayName("startJob with non-Created status does not start")
+    void startJob_nonCreatedStatus_doesNotStart() {
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Running);
+
+        try (MockedStatic<AWSXRay> xray = Mockito.mockStatic(AWSXRay.class);
+             MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.findById(123)).thenReturn(job))) {
+
+            Subsegment mockSubsegment = mock(Subsegment.class);
+            xray.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            String result = jobEventSender.startJob("123");
+
+            assertEquals("123", result);
+            verify(jobManager, never()).startJob(anyInt());
+            verify(jobEventProducer, never()).fire(any(JobEvent.class));
+        }
+    }
+
+    // =====================================================================
+    // startAgents tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("startAgents with Starting status starts agents")
+    void startAgents_startingStatus_startsAgents() {
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Starting);
+
+        try (MockedStatic<AWSXRay> xray = Mockito.mockStatic(AWSXRay.class);
+             MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.findById(123)).thenReturn(job))) {
+
+            Subsegment mockSubsegment = mock(Subsegment.class);
+            xray.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            String result = jobEventSender.startAgents("123");
+
+            assertEquals("123", result);
+            verify(jobManager).startAgents("123");
+            verify(jobEventProducer).fire(any(JobEvent.class));
+            xray.verify(() -> AWSXRay.beginSubsegment("Start.Agents.123"));
+            xray.verify(AWSXRay::endSubsegment);
+        }
+    }
+
+    @Test
+    @DisplayName("startAgents with non-Starting status does not start agents but still fires event")
+    void startAgents_nonStartingStatus_firesEventOnly() {
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Running);
+
+        try (MockedStatic<AWSXRay> xray = Mockito.mockStatic(AWSXRay.class);
+             MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.findById(123)).thenReturn(job))) {
+
+            Subsegment mockSubsegment = mock(Subsegment.class);
+            xray.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            String result = jobEventSender.startAgents("123");
+
+            assertEquals("123", result);
+            verify(jobManager, never()).startAgents(anyString());
+            // Event still fires outside the if block
+            verify(jobEventProducer).fire(any(JobEvent.class));
+        }
+    }
+
+    // =====================================================================
+    // killJob tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("killJob with empty instances sets job to Completed")
+    void killJob_emptyInstances_setsCompleted() {
+        // No instances for job
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        JobInstance job = new JobInstance();
+        job.setId(123);
+        job.setStatus(JobQueueStatus.Running);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(job);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                })) {
+
+            jobEventSender.killJob("123", true);
+
+            verify(vmTracker).stopJob("123");
+            assertEquals(JobQueueStatus.Completed, job.getStatus());
+            assertNotNull(job.getEndTime());
+            verify(jobEventProducer).fire(any(JobEvent.class));
+        }
+    }
+
+    @Test
+    @DisplayName("killJob with null job from DAO does not throw")
+    void killJob_nullJob_doesNotThrow() {
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> when(mock.findById(123)).thenReturn(null))) {
+
+            jobEventSender.killJob("123", true);
+
+            verify(vmTracker).stopJob("123");
+            verify(jobEventProducer).fire(any(JobEvent.class));
+        }
+    }
+
+    @Test
+    @DisplayName("killJob with fireEvent=false does not fire event")
+    void killJob_fireEventFalse_noEvent() {
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        JobInstance job = new JobInstance();
+        job.setId(123);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(job);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                })) {
+
+            jobEventSender.killJob("123", false);
+
+            verify(vmTracker).stopJob("123");
+            verify(jobEventProducer, never()).fire(any(JobEvent.class));
+        }
+    }
+
+    @Test
+    @DisplayName("killJob with instances calls killInstances instead of setting Completed")
+    void killJob_withInstances_callsKillInstances() {
+        container.getStatuses().add(createStatus("i-running", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        // For killInstances: need to mock isDevMode
+        when(vmTracker.isDevMode()).thenReturn(true);
+        CloudVmStatus existingStatus = createStatus("i-running", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-running")).thenReturn(existingStatus);
+
+        jobEventSender.killJob("123", true);
+
+        verify(vmTracker).stopJob("123");
+        verify(agentChannel).killAgents(anyList());
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("killJob(jobId) delegates to killJob(jobId, true)")
+    void killJob_singleArg_delegatesWithFireEvent() {
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        JobInstance job = new JobInstance();
+        job.setId(123);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(job);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                })) {
+
+            jobEventSender.killJob("123");
+
+            verify(vmTracker).stopJob("123");
+            // fire event is called because killJob(jobId) calls killJob(jobId, true)
+            verify(jobEventProducer).fire(any(JobEvent.class));
+        }
+    }
+
+    // =====================================================================
+    // killAllJobs tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("killAllJobs kills all tracked jobs")
+    void killAllJobs_killsAllTrackedJobs() {
+        CloudVmStatusContainer job1 = new CloudVmStatusContainer();
+        job1.setJobId("100");
+        CloudVmStatusContainer job2 = new CloudVmStatusContainer();
+        job2.setJobId("200");
+
+        Set<CloudVmStatusContainer> allJobs = new LinkedHashSet<>(Arrays.asList(job1, job2));
+        when(vmTracker.getAllJobs()).thenReturn(allJobs);
+        // getInstancesForJob returns empty for both
+        when(vmTracker.getVmStatusForJob("100")).thenReturn(null);
+        when(vmTracker.getVmStatusForJob("200")).thenReturn(null);
+
+        JobInstance ji1 = new JobInstance();
+        ji1.setId(100);
+        JobInstance ji2 = new JobInstance();
+        ji2.setId(200);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(100)).thenReturn(ji1);
+                    when(mock.findById(200)).thenReturn(ji2);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                })) {
+
+            Set<CloudVmStatusContainer> result = jobEventSender.killAllJobs();
+
+            assertEquals(2, result.size());
+            verify(vmTracker).stopJob("100");
+            verify(vmTracker).stopJob("200");
+            verify(jobEventProducer, times(2)).fire(any(JobEvent.class));
+        }
+    }
+
+    @Test
+    @DisplayName("killAllJobs with no jobs returns empty set")
+    void killAllJobs_noJobs_returnsEmptySet() {
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        Set<CloudVmStatusContainer> result = jobEventSender.killAllJobs();
+
+        assertTrue(result.isEmpty());
+        verify(vmTracker, never()).stopJob(anyString());
+    }
+
+    // =====================================================================
+    // killInstance / killInstances tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("killInstance delegates to killInstances with singleton list")
+    void killInstance_delegatesToKillInstances() {
+        when(vmTracker.isDevMode()).thenReturn(true);
+        CloudVmStatus existingStatus = createStatus("i-test", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-test")).thenReturn(existingStatus);
+        // checkJobStatus will be called
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.killInstance("i-test");
+
+        verify(agentChannel).killAgents(Collections.singletonList("i-test"));
+    }
+
+    @Test
+    @DisplayName("killInstances in dev mode skips AWS termination")
+    void killInstances_devMode_skipsAwsTermination() {
+        when(vmTracker.isDevMode()).thenReturn(true);
+        CloudVmStatus existingStatus = createStatus("i-dev", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-dev")).thenReturn(existingStatus);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.killInstances(Collections.singletonList("i-dev"));
+
+        verify(agentChannel).killAgents(Collections.singletonList("i-dev"));
+        verify(vmTracker).setStatus(argThat(status ->
+                status.getVmStatus() == VMStatus.terminated &&
+                status.getJobStatus() == JobStatus.Completed &&
+                status.getCurrentUsers() == 0 &&
+                status.getEndTime() != null
+        ));
+    }
+
+    @Test
+    @DisplayName("killInstances in non-dev mode terminates on AWS")
+    void killInstances_nonDevMode_terminatesOnAws() {
+        when(vmTracker.isDevMode()).thenReturn(false);
+        CloudVmStatus existingStatus = createStatus("i-prod", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-prod")).thenReturn(existingStatus);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        when(mockVmConfig.getRegions()).thenReturn(Collections.singleton(VMRegion.US_WEST_2));
+
+        try (MockedConstruction<TankConfig> tankConfigConstruction = Mockito.mockConstruction(TankConfig.class,
+                     (mock, context) -> when(mock.getVmManagerConfig()).thenReturn(mockVmConfig));
+             MockedConstruction<AmazonInstance> amazonConstruction = Mockito.mockConstruction(AmazonInstance.class)) {
+
+            jobEventSender.killInstances(Collections.singletonList("i-prod"));
+
+            verify(agentChannel).killAgents(Collections.singletonList("i-prod"));
+            // Verify AmazonInstance was constructed and killInstances called
+            assertEquals(1, amazonConstruction.constructed().size());
+            verify(amazonConstruction.constructed().get(0)).killInstances(Collections.singletonList("i-prod"));
+        }
+    }
+
+    @Test
+    @DisplayName("killInstances with null existing status skips status update")
+    void killInstances_nullExistingStatus_skipsUpdate() {
+        when(vmTracker.isDevMode()).thenReturn(true);
+        when(vmTracker.getStatus("i-gone")).thenReturn(null);
+
+        jobEventSender.killInstances(Collections.singletonList("i-gone"));
+
+        verify(agentChannel).killAgents(Collections.singletonList("i-gone"));
+        verify(vmTracker, never()).setStatus(any(CloudVmStatus.class));
+    }
+
+    @Test
+    @DisplayName("killInstances with multiple instances updates all statuses")
+    void killInstances_multipleInstances_updatesAll() {
+        when(vmTracker.isDevMode()).thenReturn(true);
+        CloudVmStatus status1 = createStatus("i-1", JobStatus.Running, VMStatus.running);
+        CloudVmStatus status2 = createStatus("i-2", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-1")).thenReturn(status1);
+        when(vmTracker.getStatus("i-2")).thenReturn(status2);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.killInstances(Arrays.asList("i-1", "i-2"));
+
+        verify(agentChannel).killAgents(Arrays.asList("i-1", "i-2"));
+        verify(vmTracker, times(2)).setStatus(any(CloudVmStatus.class));
+    }
+
+    @Test
+    @DisplayName("killInstances with multiple regions terminates in each region")
+    void killInstances_multipleRegions_terminatesInEach() {
+        when(vmTracker.isDevMode()).thenReturn(false);
+        CloudVmStatus existingStatus = createStatus("i-multi", JobStatus.Running, VMStatus.running);
+        when(vmTracker.getStatus("i-multi")).thenReturn(existingStatus);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        Set<VMRegion> regions = new LinkedHashSet<>();
+        regions.add(VMRegion.US_WEST_2);
+        regions.add(VMRegion.US_EAST);
+        when(mockVmConfig.getRegions()).thenReturn(regions);
+
+        try (MockedConstruction<TankConfig> tankConfigConstruction = Mockito.mockConstruction(TankConfig.class,
+                     (mock, context) -> when(mock.getVmManagerConfig()).thenReturn(mockVmConfig));
+             MockedConstruction<AmazonInstance> amazonConstruction = Mockito.mockConstruction(AmazonInstance.class)) {
+
+            jobEventSender.killInstances(Collections.singletonList("i-multi"));
+
+            // AmazonInstance constructed once per region
+            assertEquals(2, amazonConstruction.constructed().size());
+            for (AmazonInstance ai : amazonConstruction.constructed()) {
+                verify(ai).killInstances(Collections.singletonList("i-multi"));
+            }
+        }
+    }
+
+    // =====================================================================
+    // stopAllJobs / stopJob / stopAgent / stopAgents tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("stopAllJobs stops all tracked jobs")
+    void stopAllJobs_stopsAllTrackedJobs() {
+        CloudVmStatusContainer job1 = new CloudVmStatusContainer();
+        job1.setJobId("100");
+        job1.getStatuses().add(createStatus("i-1", JobStatus.Running, VMStatus.running));
+        CloudVmStatusContainer job2 = new CloudVmStatusContainer();
+        job2.setJobId("200");
+        job2.getStatuses().add(createStatus("i-2", JobStatus.Running, VMStatus.running));
+
+        Set<CloudVmStatusContainer> allJobs = new LinkedHashSet<>(Arrays.asList(job1, job2));
+        when(vmTracker.getAllJobs()).thenReturn(allJobs);
+        when(vmTracker.getVmStatusForJob("100")).thenReturn(job1);
+        when(vmTracker.getVmStatusForJob("200")).thenReturn(job2);
+
+        Set<CloudVmStatusContainer> result = jobEventSender.stopAllJobs();
+
+        assertEquals(2, result.size());
+        verify(vmTracker).stopJob("100");
+        verify(vmTracker).stopJob("200");
+        verify(agentChannel).stopAgents(Collections.singletonList("i-1"));
+        verify(agentChannel).stopAgents(Collections.singletonList("i-2"));
+        verify(jobEventProducer, times(2)).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("stopAllJobs with no jobs returns empty set")
+    void stopAllJobs_noJobs_returnsEmptySet() {
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        Set<CloudVmStatusContainer> result = jobEventSender.stopAllJobs();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("stopJob stops agents and fires event")
+    void stopJob_stopsAgentsAndFiresEvent() {
+        container.getStatuses().add(createStatus("i-agent", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.stopJob("123");
+
+        verify(vmTracker).stopJob("123");
+        verify(agentChannel).stopAgents(Collections.singletonList("i-agent"));
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("stopAgent delegates to stopAgents with singleton list")
+    void stopAgent_delegatesToStopAgents() {
+        jobEventSender.stopAgent("i-single");
+
+        verify(agentChannel).stopAgents(Collections.singletonList("i-single"));
+    }
+
+    @Test
+    @DisplayName("stopAgents calls agentChannel.stopAgents")
+    void stopAgents_callsAgentChannel() {
+        List<String> ids = Arrays.asList("i-1", "i-2");
+
+        jobEventSender.stopAgents(ids);
+
+        verify(agentChannel).stopAgents(ids);
+    }
+
+    // =====================================================================
+    // pauseJob / pauseAgent / pauseAgents tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("pauseJob pauses agents and fires event")
+    void pauseJob_pausesAgentsAndFiresEvent() {
+        container.getStatuses().add(createStatus("i-agent", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.pauseJob("123");
+
+        verify(agentChannel).pauseAgents(Collections.singletonList("i-agent"));
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("pauseAgent delegates to pauseAgents with singleton list")
+    void pauseAgent_delegatesToPauseAgents() {
+        jobEventSender.pauseAgent("i-single");
+
+        verify(agentChannel).pauseAgents(Collections.singletonList("i-single"));
+    }
+
+    @Test
+    @DisplayName("pauseAgents calls agentChannel.pauseAgents")
+    void pauseAgents_callsAgentChannel() {
+        List<String> ids = Arrays.asList("i-1", "i-2");
+
+        jobEventSender.pauseAgents(ids);
+
+        verify(agentChannel).pauseAgents(ids);
+    }
+
+    // =====================================================================
+    // restartJob / restartAgent / restartAgents tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("restartJob restarts agents and fires event")
+    void restartJob_restartsAgentsAndFiresEvent() {
+        container.getStatuses().add(createStatus("i-agent", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.restartJob("123");
+
+        verify(agentChannel).restartAgents(Collections.singletonList("i-agent"));
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("restartAgent delegates to restartAgents with singleton list")
+    void restartAgent_delegatesToRestartAgents() {
+        jobEventSender.restartAgent("i-single");
+
+        verify(agentChannel).restartAgents(Collections.singletonList("i-single"));
+    }
+
+    @Test
+    @DisplayName("restartAgents calls agentChannel.restartAgents")
+    void restartAgents_callsAgentChannel() {
+        List<String> ids = Arrays.asList("i-1", "i-2");
+
+        jobEventSender.restartAgents(ids);
+
+        verify(agentChannel).restartAgents(ids);
+    }
+
+    // =====================================================================
+    // pauseRampJob / pauseRampInstance / pauseRampInstances tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("pauseRampJob pauses ramp and fires event")
+    void pauseRampJob_pausesRampAndFiresEvent() {
+        container.getStatuses().add(createStatus("i-agent", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.pauseRampJob("123");
+
+        verify(agentChannel).pauseRamp(Collections.singletonList("i-agent"));
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("pauseRampInstance delegates to pauseRampInstances with singleton list")
+    void pauseRampInstance_delegatesToPauseRampInstances() {
+        jobEventSender.pauseRampInstance("i-single");
+
+        verify(agentChannel).pauseRamp(Collections.singletonList("i-single"));
+    }
+
+    @Test
+    @DisplayName("pauseRampInstances calls agentChannel.pauseRamp")
+    void pauseRampInstances_callsAgentChannel() {
+        List<String> ids = Arrays.asList("i-1", "i-2");
+
+        jobEventSender.pauseRampInstances(ids);
+
+        verify(agentChannel).pauseRamp(ids);
+    }
+
+    // =====================================================================
+    // resumeRampJob / resumeRampInstance / resumeRampInstances tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("resumeRampJob resumes ramp and fires event")
+    void resumeRampJob_resumesRampAndFiresEvent() {
+        container.getStatuses().add(createStatus("i-agent", JobStatus.Running, VMStatus.running));
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.resumeRampJob("123");
+
+        verify(agentChannel).resumeRamp(Collections.singletonList("i-agent"));
+        verify(jobEventProducer).fire(any(JobEvent.class));
+    }
+
+    @Test
+    @DisplayName("resumeRampInstance delegates to resumeRampInstances with singleton list")
+    void resumeRampInstance_delegatesToResumeRampInstances() {
+        jobEventSender.resumeRampInstance("i-single");
+
+        verify(agentChannel).resumeRamp(Collections.singletonList("i-single"));
+    }
+
+    @Test
+    @DisplayName("resumeRampInstances calls agentChannel.resumeRamp")
+    void resumeRampInstances_callsAgentChannel() {
+        List<String> ids = Arrays.asList("i-1", "i-2");
+
+        jobEventSender.resumeRampInstances(ids);
+
+        verify(agentChannel).resumeRamp(ids);
+    }
+
+    // =====================================================================
+    // setVmStatus tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("setVmStatus with running status sets status without termination")
+    void setVmStatus_runningStatus_noTermination() {
+        CloudVmStatus status = createStatus("i-running", JobStatus.Running, VMStatus.running);
+
+        jobEventSender.setVmStatus("i-running", status);
+
+        verify(vmTracker).setStatus(status);
+        verify(terminator, never()).terminate(anyString());
+    }
+
+    @Test
+    @DisplayName("setVmStatus with Completed job status triggers termination and checkJobStatus")
+    void setVmStatus_completedJobStatus_triggersTermination() {
+        CloudVmStatus status = createStatus("i-done", JobStatus.Completed, VMStatus.running);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.setVmStatus("i-done", status);
+
+        verify(vmTracker).setStatus(status);
+        verify(terminator).terminate("i-done");
+        // checkJobStatus is also called
+        verify(vmTracker).getVmStatusForJob("123");
+    }
+
+    @Test
+    @DisplayName("setVmStatus with terminated vm status triggers termination")
+    void setVmStatus_terminatedVmStatus_triggersTermination() {
+        CloudVmStatus status = createStatus("i-term", JobStatus.Running, VMStatus.terminated);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.setVmStatus("i-term", status);
+
+        verify(vmTracker).setStatus(status);
+        verify(terminator).terminate("i-term");
+    }
+
+    @Test
+    @DisplayName("setVmStatus with replaced vm status triggers termination")
+    void setVmStatus_replacedVmStatus_triggersTermination() {
+        CloudVmStatus status = createStatus("i-repl", JobStatus.Running, VMStatus.replaced);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.setVmStatus("i-repl", status);
+
+        verify(vmTracker).setStatus(status);
+        verify(terminator).terminate("i-repl");
+    }
+
+    // =====================================================================
+    // checkJobStatus tests
+    // =====================================================================
+
+    @Test
+    @DisplayName("checkJobStatus with null container does nothing")
+    void checkJobStatus_nullContainer_doesNothing() {
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(null);
+
+        jobEventSender.checkJobStatus("123");
+
+        // Just verifies it does not throw
+        verify(vmTracker).getVmStatusForJob("123");
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with no end time does not complete job")
+    void checkJobStatus_noEndTime_doesNotComplete() {
+        container.setEndTime(null);
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+        jobEventSender.checkJobStatus("123");
+
+        // Container exists but has no end time - the else branch logs and returns
+        verify(vmTracker).getVmStatusForJob("123");
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with end time marks job as Completed")
+    void checkJobStatus_withEndTime_marksJobCompleted() {
+        container.setEndTime(new Date());
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null); // no end time yet
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.emptyList());
+                })) {
+
+            jobEventSender.checkJobStatus("123");
+
+            assertEquals(JobQueueStatus.Completed, finishedJob.getStatus());
+            assertNotNull(finishedJob.getEndTime());
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with end time but job already has end time does not update")
+    void checkJobStatus_jobAlreadyHasEndTime_doesNotUpdate() {
+        container.setEndTime(new Date());
+        Date existingEndTime = new Date(System.currentTimeMillis() - 60000);
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(existingEndTime);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.emptyList());
+                })) {
+
+            jobEventSender.checkJobStatus("123");
+
+            // End time should not change
+            assertEquals(existingEndTime, finishedJob.getEndTime());
+            verify(daoConstruction.constructed().get(0), never()).saveOrUpdate(any(JobInstance.class));
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with running instances checks their status")
+    void checkJobStatus_withRunningInstances_checksStatus() {
+        container.setEndTime(new Date());
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null);
+
+        JobInstance runningJob = new JobInstance();
+        runningJob.setId(456);
+
+        CloudVmStatusContainer runningContainer = new CloudVmStatusContainer();
+        runningContainer.setJobId("456");
+        runningContainer.setEndTime(null); // not finished
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.singletonList(runningJob));
+                })) {
+
+            when(vmTracker.getVmStatusForJob("456")).thenReturn(runningContainer);
+
+            jobEventSender.checkJobStatus("123");
+
+            assertEquals(JobQueueStatus.Completed, finishedJob.getStatus());
+            // Verifies the running job check happened
+            verify(vmTracker).getVmStatusForJob("456");
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with automation job prevents killing")
+    void checkJobStatus_automationJob_preventsKilling() {
+        container.setEndTime(new Date());
+
+        CloudVmStatusContainer automationJob = new CloudVmStatusContainer();
+        automationJob.setJobId("automation-abc"); // non-numeric = automation job
+        automationJob.setEndTime(null); // still running
+
+        Set<CloudVmStatusContainer> allJobs = new HashSet<>();
+        allJobs.add(automationJob);
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(allJobs);
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.emptyList());
+                })) {
+
+            jobEventSender.checkJobStatus("123");
+
+            // The automation job should prevent killing
+            verify(vmTracker).getAllJobs();
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with same job id in running instances skips it")
+    void checkJobStatus_sameJobInRunningInstances_skips() {
+        container.setEndTime(new Date());
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(Collections.emptySet());
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null);
+
+        // The same job appears in the running instances list
+        JobInstance sameJob = new JobInstance();
+        sameJob.setId(123);
+
+        CloudVmStatusContainer sameJobContainer = new CloudVmStatusContainer();
+        sameJobContainer.setJobId("123");
+        sameJobContainer.setEndTime(null);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.singletonList(sameJob));
+                })) {
+
+            // For the same job id, getVmStatusForJob is called once for the main check
+            // and again for the running instances loop - but since it equals jobId, the "found another job" branch is not taken
+            when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+
+            jobEventSender.checkJobStatus("123");
+
+            assertEquals(JobQueueStatus.Completed, finishedJob.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with all completed automation jobs allows killing")
+    void checkJobStatus_completedAutomationJobs_allowsKilling() {
+        container.setEndTime(new Date());
+
+        CloudVmStatusContainer completedAutomation = new CloudVmStatusContainer();
+        completedAutomation.setJobId("automation-xyz");
+        completedAutomation.setEndTime(new Date()); // already finished
+
+        Set<CloudVmStatusContainer> allJobs = new HashSet<>();
+        allJobs.add(completedAutomation);
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(allJobs);
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.emptyList());
+                })) {
+
+            jobEventSender.checkJobStatus("123");
+
+            // Completed automation jobs don't prevent killing
+            assertEquals(JobQueueStatus.Completed, finishedJob.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("checkJobStatus with numeric job in allJobs that has end time does not block")
+    void checkJobStatus_numericJobWithEndTime_doesNotBlock() {
+        container.setEndTime(new Date());
+
+        CloudVmStatusContainer numericJob = new CloudVmStatusContainer();
+        numericJob.setJobId("999"); // numeric, so isCreatable returns true - does not block
+        numericJob.setEndTime(null);
+
+        Set<CloudVmStatusContainer> allJobs = new HashSet<>();
+        allJobs.add(numericJob);
+
+        when(vmTracker.getVmStatusForJob("123")).thenReturn(container);
+        when(vmTracker.getAllJobs()).thenReturn(allJobs);
+
+        JobInstance finishedJob = new JobInstance();
+        finishedJob.setId(123);
+        finishedJob.setEndTime(null);
+
+        try (MockedConstruction<JobInstanceDao> daoConstruction = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, context) -> {
+                    when(mock.findById(123)).thenReturn(finishedJob);
+                    when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> inv.getArgument(0));
+                    when(mock.getForStatus(anyList())).thenReturn(Collections.emptyList());
+                })) {
+
+            jobEventSender.checkJobStatus("123");
+
+            // Numeric job IDs don't block - only non-numeric (automation) job IDs block
+            assertEquals(JobQueueStatus.Completed, finishedJob.getStatus());
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/MessageEventSenderTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/cloud/MessageEventSenderTest.java
@@ -1,0 +1,34 @@
+package com.intuit.tank.rest.mvc.rest.cloud;
+
+import com.intuit.tank.vm.settings.ModifiedEntityMessage;
+import com.intuit.tank.vm.settings.ModificationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.enterprise.event.Event;
+
+import static org.mockito.Mockito.verify;
+
+class MessageEventSenderTest {
+
+    @InjectMocks
+    private MessageEventSender sender;
+
+    @Mock
+    private Event<ModifiedEntityMessage> eventSender;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void sendEvent_firesEvent() {
+        ModifiedEntityMessage msg = new ModifiedEntityMessage(Object.class, 1, ModificationType.ADD);
+        sender.sendEvent(msg);
+        verify(eventSender).fire(msg);
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/errors/ExceptionClassesTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/errors/ExceptionClassesTest.java
@@ -1,0 +1,132 @@
+package com.intuit.tank.rest.mvc.rest.controllers.errors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExceptionClassesTest {
+
+    // =====================================================================
+    // ClientException
+    // =====================================================================
+
+    @Test
+    void clientException_constructorSetsFields() {
+        ClientException e = new ClientException("error msg", 400);
+        assertEquals(400, e.getStatusCode());
+        assertEquals("error msg", e.getMessage());
+    }
+
+    @Test
+    void clientException_getErrorMessage_parsesJsonMessage() {
+        ClientException e = new ClientException("{\"message\":\"parsed error\"}", 500);
+        assertEquals("parsed error", e.getErrorMessage());
+    }
+
+    @Test
+    void clientException_getErrorMessage_returnsRawOnInvalidJson() {
+        ClientException e = new ClientException("not json", 400);
+        assertEquals("not json", e.getErrorMessage());
+    }
+
+    // =====================================================================
+    // GenericServiceException
+    // =====================================================================
+
+    @Test
+    void genericServiceException_defaultConstructor() {
+        GenericServiceException e = new GenericServiceException();
+        assertNull(e.getMessage());
+    }
+
+    @Test
+    void genericServiceException_messageConstructor() {
+        GenericServiceException e = new GenericServiceException("error");
+        assertEquals("error", e.getMessage());
+    }
+
+    @Test
+    void genericServiceException_causeConstructor() {
+        Exception cause = new Exception("root cause");
+        GenericServiceException e = new GenericServiceException(cause);
+        assertEquals(cause, e.getCause());
+    }
+
+    @Test
+    void genericServiceException_messageAndCauseConstructor() {
+        Exception cause = new Exception("root");
+        GenericServiceException e = new GenericServiceException("msg", cause);
+        assertEquals("msg", e.getMessage());
+        assertEquals(cause, e.getCause());
+    }
+
+    // =====================================================================
+    // GenericServiceForbiddenAccessException
+    // =====================================================================
+
+    @Test
+    void forbiddenAccessException_setsFields() {
+        GenericServiceForbiddenAccessException e = new GenericServiceForbiddenAccessException("svc", "res");
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+    }
+
+    // =====================================================================
+    // GenericServiceInternalServerException
+    // =====================================================================
+
+    @Test
+    void internalServerException_setsFields() {
+        Exception cause = new Exception("db");
+        GenericServiceInternalServerException e = new GenericServiceInternalServerException("svc", "res", cause);
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+        assertTrue(e.getMessage().contains("svc"));
+        assertTrue(e.getMessage().contains("res"));
+    }
+
+    // =====================================================================
+    // GenericServiceBadRequestException
+    // =====================================================================
+
+    @Test
+    void badRequestException_setsFieldsWithMessage() {
+        GenericServiceBadRequestException e = new GenericServiceBadRequestException("svc", "res", "bad input");
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+        assertTrue(e.getMessage().contains("bad input"));
+    }
+
+    // =====================================================================
+    // GenericServiceResourceNotFoundException
+    // =====================================================================
+
+    @Test
+    void resourceNotFoundException_setsFields() {
+        GenericServiceResourceNotFoundException e = new GenericServiceResourceNotFoundException("svc", "res", null);
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+    }
+
+    // =====================================================================
+    // GenericServiceDeleteException
+    // =====================================================================
+
+    @Test
+    void deleteException_setsFields() {
+        GenericServiceDeleteException e = new GenericServiceDeleteException("svc", "res", new Exception("err"));
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+    }
+
+    // =====================================================================
+    // GenericServiceCreateOrUpdateException
+    // =====================================================================
+
+    @Test
+    void createOrUpdateException_setsFields() {
+        GenericServiceCreateOrUpdateException e = new GenericServiceCreateOrUpdateException("svc", "res", new Exception());
+        assertEquals("svc", e.getService());
+        assertEquals("res", e.getResource());
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/errors/GenericExceptionHandlerTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/controllers/errors/GenericExceptionHandlerTest.java
@@ -7,11 +7,13 @@
  */
 package com.intuit.tank.rest.mvc.rest.controllers.errors;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GenericExceptionHandlerTest {
     @Test
@@ -44,5 +46,57 @@ public class GenericExceptionHandlerTest {
         Throwable e = mock(Throwable.class);
         SimpleErrorResponse response = genericExceptionHandler.handleOtherErrors(e);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleBadRequestException() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        GenericServiceBadRequestException e = mock(GenericServiceBadRequestException.class);
+        SimpleErrorResponse response = genericExceptionHandler.handleBadRequestException(e);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleForbiddenAccessException() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        GenericServiceForbiddenAccessException e = mock(GenericServiceForbiddenAccessException.class);
+        SimpleErrorResponse response = genericExceptionHandler.handleForbiddenAccessException(e);
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleInternalServerException() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        GenericServiceInternalServerException e = mock(GenericServiceInternalServerException.class);
+        SimpleErrorResponse response = genericExceptionHandler.handleInternalServerException(e);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleClientException() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        ClientException e = mock(ClientException.class);
+        when(e.getStatusCode()).thenReturn(422);
+        when(e.getErrorMessage()).thenReturn("Unprocessable");
+        SimpleErrorResponse response = genericExceptionHandler.handleClientException(e);
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleFileException() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        org.springframework.web.multipart.MultipartException ex = mock(org.springframework.web.multipart.MultipartException.class);
+        org.springframework.http.ResponseEntity<Object> response = genericExceptionHandler.handleFileException(request, ex);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandleNoResourceFound() {
+        GenericExceptionHandler genericExceptionHandler = new GenericExceptionHandler();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        org.springframework.web.servlet.resource.NoResourceFoundException ex = mock(org.springframework.web.servlet.resource.NoResourceFoundException.class);
+        org.springframework.http.ResponseEntity<Object> response = genericExceptionHandler.handleNoResourceFound(request, ex);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 }

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/AdminTokenServiceTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/AdminTokenServiceTest.java
@@ -5,18 +5,25 @@ import com.intuit.tank.project.User;
 import com.intuit.tank.vm.settings.TankConfig;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.Parameter;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class AdminTokenServiceTest {
 
     @Test
     void isValidAdminToken_returnsFalseForNullToken() {
-        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                 (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
-             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class)) {
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class)) {
 
             AdminTokenService service = new AdminTokenService();
             service.init();
@@ -27,9 +34,9 @@ class AdminTokenServiceTest {
 
     @Test
     void isValidAdminToken_returnsFalseForEmptyToken() {
-        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                 (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
-             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class)) {
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class)) {
 
             AdminTokenService service = new AdminTokenService();
             service.init();
@@ -41,9 +48,9 @@ class AdminTokenServiceTest {
 
     @Test
     void isValidAdminToken_returnsFalseWhenNoUserFoundForToken() {
-        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                 (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
-             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class,
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class,
                 (mock, ctx) -> when(mock.findByApiToken("invalid-token")).thenReturn(null))) {
 
             AdminTokenService service = new AdminTokenService();
@@ -54,21 +61,90 @@ class AdminTokenServiceTest {
     }
 
     @Test
-    void isValidAdminToken_returnsFalseWhenUserFoundButSSMFails() {
+    void isValidAdminToken_returnsFalseWhenSSMFails() {
         User user = new User();
         user.setName("admin");
 
-        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+        SsmClient mockSsmClient = mock(SsmClient.class);
+        when(mockSsmClient.getParameter(any(GetParameterRequest.class)))
+                .thenThrow(new RuntimeException("SSM connection refused"));
+
+        SsmClientBuilder mockBuilder = mock(SsmClientBuilder.class);
+        when(mockBuilder.build()).thenReturn(mockSsmClient);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                 (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
-             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class,
-                (mock, ctx) -> when(mock.findByApiToken("some-token")).thenReturn(user))) {
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class,
+                (mock, ctx) -> when(mock.findByApiToken("some-token")).thenReturn(user));
+             MockedStatic<SsmClient> ssmStatic = Mockito.mockStatic(SsmClient.class)) {
+
+            ssmStatic.when(SsmClient::builder).thenReturn(mockBuilder);
 
             AdminTokenService service = new AdminTokenService();
             service.init();
 
-            // SSM client will fail in test environment (no AWS credentials)
-            // This exercises the user-found but SSM-fails path
             assertFalse(service.isValidAdminToken("some-token"));
+        }
+    }
+
+    @Test
+    void isValidAdminToken_returnsFalseWhenTokensDoNotMatch() {
+        User user = new User();
+        user.setName("admin");
+
+        Parameter param = Parameter.builder().value("different-token").build();
+        GetParameterResponse response = GetParameterResponse.builder().parameter(param).build();
+
+        SsmClient mockSsmClient = mock(SsmClient.class);
+        when(mockSsmClient.getParameter(any(GetParameterRequest.class))).thenReturn(response);
+
+        SsmClientBuilder mockBuilder = mock(SsmClientBuilder.class);
+        when(mockBuilder.build()).thenReturn(mockSsmClient);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class,
+                (mock, ctx) -> when(mock.findByApiToken("my-token")).thenReturn(user));
+             MockedStatic<SsmClient> ssmStatic = Mockito.mockStatic(SsmClient.class)) {
+
+            ssmStatic.when(SsmClient::builder).thenReturn(mockBuilder);
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            assertFalse(service.isValidAdminToken("my-token"));
+        }
+    }
+
+    @Test
+    void isValidAdminToken_returnsTrueWhenTokensMatch() {
+        User user = new User();
+        user.setName("admin");
+
+        Parameter param = Parameter.builder().value("matching-token").build();
+        GetParameterResponse response = GetParameterResponse.builder().parameter(param).build();
+
+        SsmClient mockSsmClient = mock(SsmClient.class);
+        when(mockSsmClient.getParameter(any(GetParameterRequest.class))).thenReturn(response);
+
+        SsmClientBuilder mockBuilder = mock(SsmClientBuilder.class);
+        when(mockBuilder.build()).thenReturn(mockSsmClient);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> ignoredDao = Mockito.mockConstruction(UserDao.class,
+                (mock, ctx) -> {
+                    when(mock.findByApiToken("matching-token")).thenReturn(user);
+                    when(mock.saveOrUpdate(any(User.class))).thenReturn(user);
+                });
+             MockedStatic<SsmClient> ssmStatic = Mockito.mockStatic(SsmClient.class)) {
+
+            ssmStatic.when(SsmClient::builder).thenReturn(mockBuilder);
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            assertTrue(service.isValidAdminToken("matching-token"));
         }
     }
 }

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/AdminTokenServiceTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/AdminTokenServiceTest.java
@@ -1,0 +1,74 @@
+package com.intuit.tank.rest.mvc.rest.services;
+
+import com.intuit.tank.dao.UserDao;
+import com.intuit.tank.project.User;
+import com.intuit.tank.vm.settings.TankConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AdminTokenServiceTest {
+
+    @Test
+    void isValidAdminToken_returnsFalseForNullToken() {
+        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class)) {
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            assertFalse(service.isValidAdminToken(null));
+        }
+    }
+
+    @Test
+    void isValidAdminToken_returnsFalseForEmptyToken() {
+        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class)) {
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            assertFalse(service.isValidAdminToken(""));
+            assertFalse(service.isValidAdminToken("   "));
+        }
+    }
+
+    @Test
+    void isValidAdminToken_returnsFalseWhenNoUserFoundForToken() {
+        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class,
+                (mock, ctx) -> when(mock.findByApiToken("invalid-token")).thenReturn(null))) {
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            assertFalse(service.isValidAdminToken("invalid-token"));
+        }
+    }
+
+    @Test
+    void isValidAdminToken_returnsFalseWhenUserFoundButSSMFails() {
+        User user = new User();
+        user.setName("admin");
+
+        try (MockedConstruction<TankConfig> tcMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getInstanceName()).thenReturn("test"));
+             MockedConstruction<UserDao> daoMock = Mockito.mockConstruction(UserDao.class,
+                (mock, ctx) -> when(mock.findByApiToken("some-token")).thenReturn(user))) {
+
+            AdminTokenService service = new AdminTokenService();
+            service.init();
+
+            // SSM client will fail in test environment (no AWS credentials)
+            // This exercises the user-found but SSM-fails path
+            assertFalse(service.isValidAdminToken("some-token"));
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/agent/AgentServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/agent/AgentServiceV2ImplTest.java
@@ -1,0 +1,446 @@
+package com.intuit.tank.rest.mvc.rest.services.agent;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+import com.intuit.tank.agent.models.TankHttpClientDefinitionContainer;
+import com.intuit.tank.perfManager.workLoads.JobManager;
+import com.intuit.tank.rest.mvc.rest.cloud.JobEventSender;
+import com.intuit.tank.rest.mvc.rest.cloud.ServletInjector;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceBadRequestException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import com.intuit.tank.vm.agent.messages.AgentAvailability;
+import com.intuit.tank.vm.agent.messages.AgentData;
+import com.intuit.tank.vm.agent.messages.AgentTestStartData;
+import com.intuit.tank.vm.agent.messages.Headers;
+import com.intuit.tank.vm.api.enumerated.JobStatus;
+import com.intuit.tank.vm.api.enumerated.VMImageType;
+import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vm.perfManager.StandaloneAgentTracker;
+import com.intuit.tank.vm.settings.AgentConfig;
+import com.intuit.tank.vm.settings.TankConfig;
+import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
+import com.intuit.tank.vm.vmManager.models.VMStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.servlet.ServletContext;
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class AgentServiceV2ImplTest {
+
+    @InjectMocks
+    private AgentServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    private AutoCloseable mocks;
+    private MockedStatic<AWSXRay> xrayMock;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        xrayMock = Mockito.mockStatic(AWSXRay.class);
+        Segment mockSegment = mock(Segment.class);
+        Subsegment mockSubsegment = mock(Subsegment.class);
+        xrayMock.when(AWSXRay::getCurrentSegment).thenReturn(mockSegment);
+        xrayMock.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        xrayMock.close();
+        mocks.close();
+    }
+
+    // =====================================================================
+    // ping
+    // =====================================================================
+
+    @Test
+    void ping_returnsPong() {
+        String result = service.ping();
+        assertTrue(result.startsWith("PONG"));
+        assertTrue(result.contains("AgentServiceV2"));
+    }
+
+    // =====================================================================
+    // getSettings
+    // =====================================================================
+
+    @Test
+    void getSettings_readsAgentSettingsFile() {
+        File mockConfigFile = mock(File.class);
+        File mockParentDir = mock(File.class);
+
+        when(mockConfigFile.getParentFile()).thenReturn(mockParentDir);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getSourceConfigFile()).thenReturn(mockConfigFile))) {
+            // When agent-settings.xml doesn't exist, it falls back to config file
+            // This will throw because we can't read a mock file — testing exception path
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getSettings());
+        }
+    }
+
+    // =====================================================================
+    // getHeaders
+    // =====================================================================
+
+    @Test
+    void getHeaders_returnsConfiguredHeaders() {
+        Map<String, String> headerMap = new LinkedHashMap<>();
+        headerMap.put("Accept", "application/json");
+        headerMap.put("Content-Type", "text/xml");
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getRequestHeaderMap()).thenReturn(headerMap);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenReturn(mockAgentConfig))) {
+
+            Headers result = service.getHeaders();
+
+            assertNotNull(result);
+            assertEquals(2, result.getHeaders().size());
+            assertEquals("Accept", result.getHeaders().get(0).getKey());
+            assertEquals("application/json", result.getHeaders().get(0).getValue());
+        }
+    }
+
+    @Test
+    void getHeaders_returnsEmptyWhenNoHeaders() {
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getRequestHeaderMap()).thenReturn(null);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenReturn(mockAgentConfig))) {
+
+            Headers result = service.getHeaders();
+            assertNotNull(result);
+            assertTrue(result.getHeaders().isEmpty());
+        }
+    }
+
+    @Test
+    void getHeaders_throwsOnError() {
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenThrow(new RuntimeException("config error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getHeaders());
+        }
+    }
+
+    // =====================================================================
+    // getClients
+    // =====================================================================
+
+    @Test
+    void getClients_returnsClientDefinitions() {
+        Map<String, String> clientMap = new LinkedHashMap<>();
+        clientMap.put("Apache", "com.intuit.tank.http.ApacheClient");
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientMap()).thenReturn(clientMap);
+        when(mockAgentConfig.getTankClientDefault()).thenReturn("Apache");
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenReturn(mockAgentConfig))) {
+
+            TankHttpClientDefinitionContainer result = service.getClients();
+
+            assertNotNull(result);
+            assertEquals(1, result.getDefinitions().size());
+            assertEquals("Apache", result.getDefinitions().get(0).getName());
+            assertEquals("Apache", result.getDefaultDefinition());
+        }
+    }
+
+    @Test
+    void getClients_usesFirstDefinitionWhenNoDefault() {
+        Map<String, String> clientMap = new LinkedHashMap<>();
+        clientMap.put("Custom", "com.example.CustomClient");
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientMap()).thenReturn(clientMap);
+        when(mockAgentConfig.getTankClientDefault()).thenReturn(null);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenReturn(mockAgentConfig))) {
+
+            TankHttpClientDefinitionContainer result = service.getClients();
+
+            assertEquals("Custom", result.getDefaultDefinition());
+        }
+    }
+
+    @Test
+    void getClients_throwsOnError() {
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> when(mock.getAgentConfig()).thenThrow(new RuntimeException("config error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getClients());
+        }
+    }
+
+    // =====================================================================
+    // agentReady
+    // =====================================================================
+
+    @Test
+    void agentReady_registersAgent() {
+        AgentData agentData = new AgentData();
+        AgentTestStartData startData = new AgentTestStartData();
+        startData.setJobId("42");
+
+        JobManager mockJobManager = mock(JobManager.class);
+        when(mockJobManager.registerAgentForJob(agentData)).thenReturn(startData);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobManager.class))).thenReturn(mockJobManager))) {
+
+            AgentTestStartData result = service.agentReady(agentData);
+
+            assertEquals("42", result.getJobId());
+        }
+    }
+
+    @Test
+    void agentReady_throwsOnRegistrationError() {
+        AgentData agentData = new AgentData();
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobManager.class)))
+                        .thenThrow(new RuntimeException("CDI error")))) {
+
+            assertThrows(GenericServiceBadRequestException.class, () -> service.agentReady(agentData));
+        }
+    }
+
+    // =====================================================================
+    // setStandaloneAgentAvailability
+    // =====================================================================
+
+    @Test
+    void setStandaloneAgentAvailability_addsAvailability() {
+        AgentAvailability availability = mock(AgentAvailability.class);
+        StandaloneAgentTracker tracker = mock(StandaloneAgentTracker.class);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(StandaloneAgentTracker.class)))
+                        .thenReturn(tracker))) {
+
+            service.setStandaloneAgentAvailability(availability);
+
+            verify(tracker).addAvailability(availability);
+        }
+    }
+
+    @Test
+    void setStandaloneAgentAvailability_throwsOnError() {
+        AgentAvailability availability = mock(AgentAvailability.class);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(StandaloneAgentTracker.class)))
+                        .thenThrow(new RuntimeException("CDI error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class,
+                    () -> service.setStandaloneAgentAvailability(availability));
+        }
+    }
+
+    // =====================================================================
+    // getInstanceStatus
+    // =====================================================================
+
+    @Test
+    void getInstanceStatus_returnsStatus() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Running,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
+
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatus("i-123")).thenReturn(status);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            CloudVmStatus result = service.getInstanceStatus("i-123");
+
+            assertNotNull(result);
+            assertEquals("i-123", result.getInstanceId());
+            assertEquals(JobStatus.Running, result.getJobStatus());
+        }
+    }
+
+    @Test
+    void getInstanceStatus_throwsOnError() {
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("not found")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class,
+                    () -> service.getInstanceStatus("i-999"));
+        }
+    }
+
+    // =====================================================================
+    // setInstanceStatus
+    // =====================================================================
+
+    @Test
+    void setInstanceStatus_delegatesToJobEventSender() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Running,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
+        JobEventSender mockSender = mock(JobEventSender.class);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            service.setInstanceStatus("i-123", status);
+
+            verify(mockSender).setVmStatus("i-123", status);
+        }
+    }
+
+    @Test
+    void setInstanceStatus_throwsOnError() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Running,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class,
+                    () -> service.setInstanceStatus("i-123", status));
+        }
+    }
+
+    // =====================================================================
+    // stopInstance
+    // =====================================================================
+
+    @Test
+    void stopInstance_stopsAndReturnsStatus() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Stopped,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.stopping, null, 0, 100, null, null);
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatus("i-123")).thenReturn(status);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.stopInstance("i-123");
+
+            assertEquals("stopping", result);
+            verify(mockSender).stopAgent("i-123");
+        }
+    }
+
+    @Test
+    void stopInstance_throwsOnError() {
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class,
+                    () -> service.stopInstance("i-123"));
+        }
+    }
+
+    // =====================================================================
+    // pauseInstance
+    // =====================================================================
+
+    @Test
+    void pauseInstance_pausesAndReturnsStatus() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Paused,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.rampPaused, null, 5, 100, null, null);
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatus("i-123")).thenReturn(status);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.pauseInstance("i-123");
+
+            assertEquals("rampPaused", result);
+            verify(mockSender).pauseRampInstance("i-123");
+        }
+    }
+
+    // =====================================================================
+    // resumeInstance
+    // =====================================================================
+
+    @Test
+    void resumeInstance_resumesAndReturnsStatus() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Running,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatus("i-123")).thenReturn(status);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.resumeInstance("i-123");
+
+            assertEquals("running", result);
+            verify(mockSender).resumeRampInstance("i-123");
+        }
+    }
+
+    // =====================================================================
+    // killInstance
+    // =====================================================================
+
+    @Test
+    void killInstance_killsAndReturnsStatus() {
+        CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Completed,
+                VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.terminated, null, 0, 100, null, null);
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatus("i-123")).thenReturn(status);
+
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.killInstance("i-123");
+
+            assertEquals("terminated", result);
+            verify(mockSender).killInstance("i-123");
+        }
+    }
+
+    @Test
+    void killInstance_throwsOnError() {
+        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class,
+                    () -> service.killInstance("i-123"));
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/agent/AgentServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/agent/AgentServiceV2ImplTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@SuppressWarnings("unchecked")
 class AgentServiceV2ImplTest {
 
     @InjectMocks
@@ -212,7 +211,7 @@ class AgentServiceV2ImplTest {
         JobManager mockJobManager = mock(JobManager.class);
         when(mockJobManager.registerAgentForJob(agentData)).thenReturn(startData);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobManager.class))).thenReturn(mockJobManager))) {
 
             AgentTestStartData result = service.agentReady(agentData);
@@ -225,7 +224,7 @@ class AgentServiceV2ImplTest {
     void agentReady_throwsOnRegistrationError() {
         AgentData agentData = new AgentData();
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobManager.class)))
                         .thenThrow(new RuntimeException("CDI error")))) {
 
@@ -242,7 +241,7 @@ class AgentServiceV2ImplTest {
         AgentAvailability availability = mock(AgentAvailability.class);
         StandaloneAgentTracker tracker = mock(StandaloneAgentTracker.class);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(StandaloneAgentTracker.class)))
                         .thenReturn(tracker))) {
 
@@ -256,7 +255,7 @@ class AgentServiceV2ImplTest {
     void setStandaloneAgentAvailability_throwsOnError() {
         AgentAvailability availability = mock(AgentAvailability.class);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(StandaloneAgentTracker.class)))
                         .thenThrow(new RuntimeException("CDI error")))) {
 
@@ -277,7 +276,7 @@ class AgentServiceV2ImplTest {
         JobEventSender mockSender = mock(JobEventSender.class);
         when(mockSender.getVmStatus("i-123")).thenReturn(status);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -291,7 +290,7 @@ class AgentServiceV2ImplTest {
 
     @Test
     void getInstanceStatus_throwsOnError() {
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenThrow(new RuntimeException("not found")))) {
 
@@ -310,7 +309,7 @@ class AgentServiceV2ImplTest {
                 VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
         JobEventSender mockSender = mock(JobEventSender.class);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -325,7 +324,7 @@ class AgentServiceV2ImplTest {
         CloudVmStatus status = new CloudVmStatus("i-123", "42", "sg", JobStatus.Running,
                 VMImageType.AGENT, VMRegion.US_WEST_2, VMStatus.running, null, 10, 100, null, null);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenThrow(new RuntimeException("error")))) {
 
@@ -345,7 +344,7 @@ class AgentServiceV2ImplTest {
         JobEventSender mockSender = mock(JobEventSender.class);
         when(mockSender.getVmStatus("i-123")).thenReturn(status);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -358,7 +357,7 @@ class AgentServiceV2ImplTest {
 
     @Test
     void stopInstance_throwsOnError() {
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenThrow(new RuntimeException("error")))) {
 
@@ -378,7 +377,7 @@ class AgentServiceV2ImplTest {
         JobEventSender mockSender = mock(JobEventSender.class);
         when(mockSender.getVmStatus("i-123")).thenReturn(status);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -400,7 +399,7 @@ class AgentServiceV2ImplTest {
         JobEventSender mockSender = mock(JobEventSender.class);
         when(mockSender.getVmStatus("i-123")).thenReturn(status);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -422,7 +421,7 @@ class AgentServiceV2ImplTest {
         JobEventSender mockSender = mock(JobEventSender.class);
         when(mockSender.getVmStatus("i-123")).thenReturn(status);
 
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenReturn(mockSender))) {
 
@@ -435,7 +434,7 @@ class AgentServiceV2ImplTest {
 
     @Test
     void killInstance_throwsOnError() {
-        try (@SuppressWarnings("rawtypes") MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
+        try (@SuppressWarnings({"rawtypes", "unchecked"}) MockedConstruction<ServletInjector> ignored = Mockito.mockConstruction(ServletInjector.class,
                 (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
                         .thenThrow(new RuntimeException("error")))) {
 

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/datafiles/DataFileServiceV2ImplTest.java
@@ -1,0 +1,236 @@
+package com.intuit.tank.rest.mvc.rest.services.datafiles;
+
+import com.intuit.tank.dao.DataFileDao;
+import com.intuit.tank.project.DataFile;
+import com.intuit.tank.datafiles.models.DataFileDescriptor;
+import com.intuit.tank.datafiles.models.DataFileDescriptorContainer;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceDeleteException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import com.intuit.tank.rest.mvc.rest.util.DataFileServiceUtil;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class DataFileServiceV2ImplTest {
+
+    private final DataFileServiceV2Impl service = new DataFileServiceV2Impl();
+
+    @Test
+    void ping_returnsPong() {
+        assertTrue(service.ping().contains("PONG"));
+    }
+
+    // =====================================================================
+    // getDatafile
+    // =====================================================================
+
+    @Test
+    void getDatafile_returnsDescriptor() {
+        DataFile df = createDataFile(1, "test.csv");
+        DataFileDescriptor desc = new DataFileDescriptor();
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(df));
+             MockedStatic<DataFileServiceUtil> utilMock = Mockito.mockStatic(DataFileServiceUtil.class)) {
+            utilMock.when(() -> DataFileServiceUtil.dataFileToDescriptor(df)).thenReturn(desc);
+
+            DataFileDescriptor result = service.getDatafile(1);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void getDatafile_returnsNullWhenNotFound() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertNull(service.getDatafile(999));
+        }
+    }
+
+    @Test
+    void getDatafile_throwsOnError() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getDatafile(1));
+        }
+    }
+
+    // =====================================================================
+    // getDatafiles
+    // =====================================================================
+
+    @Test
+    void getDatafiles_returnsAll() {
+        DataFile df1 = createDataFile(1, "file1.csv");
+        DataFile df2 = createDataFile(2, "file2.csv");
+        DataFileDescriptor d1 = new DataFileDescriptor();
+        DataFileDescriptor d2 = new DataFileDescriptor();
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(df1, df2)));
+             MockedStatic<DataFileServiceUtil> utilMock = Mockito.mockStatic(DataFileServiceUtil.class)) {
+            utilMock.when(() -> DataFileServiceUtil.dataFileToDescriptor(df1)).thenReturn(d1);
+            utilMock.when(() -> DataFileServiceUtil.dataFileToDescriptor(df2)).thenReturn(d2);
+
+            DataFileDescriptorContainer result = service.getDatafiles();
+            assertNotNull(result);
+            assertEquals(2, result.getDataFiles().size());
+        }
+    }
+
+    // =====================================================================
+    // getAllDatafileNames
+    // =====================================================================
+
+    @Test
+    void getAllDatafileNames_returnsNameMap() {
+        DataFile df = createDataFile(1, "myfile.csv");
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(df)))) {
+
+            Map<Integer, String> result = service.getAllDatafileNames();
+            assertEquals(1, result.size());
+            assertEquals("myfile.csv", result.get(1));
+        }
+    }
+
+    // =====================================================================
+    // getDatafileContent
+    // =====================================================================
+
+    @Test
+    void getDatafileContent_returnsNullWhenNotFound() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertNull(service.getDatafileContent(999, null, null));
+        }
+    }
+
+    // =====================================================================
+    // downloadDatafile
+    // =====================================================================
+
+    @Test
+    void downloadDatafile_returnsNullWhenNotFound() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertNull(service.downloadDatafile(999));
+        }
+    }
+
+    // =====================================================================
+    // uploadDatafile
+    // =====================================================================
+
+    @Test
+    void uploadDatafile_createsNewDatafile() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream("line1\nline2".getBytes(StandardCharsets.UTF_8)));
+        when(file.getOriginalFilename()).thenReturn("data.csv");
+
+        DataFile savedDf = createDataFile(5, "data.csv");
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(0)).thenReturn(null);
+                    doAnswer(invocation -> {
+                        DataFile df = invocation.getArgument(0);
+                        df.setId(5);
+                        return null;
+                    }).when(mock).storeDataFile(any(DataFile.class), any());
+                })) {
+
+            Map<String, String> result = service.uploadDatafile(null, null, file);
+            assertNotNull(result);
+            assertTrue(result.get("message").contains("uploaded"));
+            assertEquals("5", result.get("datafileId"));
+        }
+    }
+
+    @Test
+    void uploadDatafile_overwritesExisting() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+        when(file.getOriginalFilename()).thenReturn("existing.csv");
+
+        DataFile existing = createDataFile(3, "existing.csv");
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(3)).thenReturn(existing);
+                })) {
+
+            Map<String, String> result = service.uploadDatafile(3, null, file);
+            assertTrue(result.get("message").contains("overwritten"));
+        }
+    }
+
+    // =====================================================================
+    // deleteDatafile
+    // =====================================================================
+
+    @Test
+    void deleteDatafile_deletesExisting() {
+        DataFile df = createDataFile(1, "todelete.csv");
+
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(df))) {
+
+            String result = service.deleteDatafile(1);
+            assertEquals("", result);
+
+            verify(daoMock.constructed().get(0)).delete(df);
+        }
+    }
+
+    @Test
+    void deleteDatafile_returnsMessageWhenNotFound() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.deleteDatafile(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteDatafile_throwsOnError() {
+        try (MockedConstruction<DataFileDao> daoMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteDatafile(1));
+        }
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private static DataFile createDataFile(int id, String path) {
+        DataFile df = new DataFile();
+        df.setId(id);
+        df.setPath(path);
+        df.setCreated(new Date());
+        df.setModified(new Date());
+        return df;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/filters/FilterServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/filters/FilterServiceV2ImplTest.java
@@ -1,0 +1,308 @@
+package com.intuit.tank.rest.mvc.rest.services.filters;
+
+import com.intuit.tank.common.ScriptUtil;
+import com.intuit.tank.dao.FilterGroupDao;
+import com.intuit.tank.dao.ScriptDao;
+import com.intuit.tank.dao.ScriptFilterDao;
+import com.intuit.tank.dao.ScriptFilterGroupDao;
+import com.intuit.tank.filters.models.*;
+import com.intuit.tank.project.Script;
+import com.intuit.tank.project.ScriptFilter;
+import com.intuit.tank.project.ScriptFilterGroup;
+import com.intuit.tank.rest.mvc.rest.cloud.MessageEventSender;
+import com.intuit.tank.rest.mvc.rest.cloud.ServletInjector;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceDeleteException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import com.intuit.tank.rest.mvc.rest.util.FilterServiceUtil;
+import com.intuit.tank.rest.mvc.rest.util.ScriptFilterUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.servlet.ServletContext;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class FilterServiceV2ImplTest {
+
+    @InjectMocks
+    private FilterServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void ping_returnsPong() {
+        assertTrue(service.ping().contains("PONG"));
+    }
+
+    // =====================================================================
+    // getFilter
+    // =====================================================================
+
+    @Test
+    void getFilter_returnsFilter() {
+        ScriptFilter filter = new ScriptFilter();
+        FilterTO to = FilterTO.builder().withId(1).withName("test").withProductName("prod").build();
+
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(filter));
+             MockedStatic<FilterServiceUtil> utilMock = Mockito.mockStatic(FilterServiceUtil.class)) {
+            utilMock.when(() -> FilterServiceUtil.filterToTO(filter)).thenReturn(to);
+
+            FilterTO result = service.getFilter(1);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void getFilter_throwsOnError() {
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getFilter(1));
+        }
+    }
+
+    // =====================================================================
+    // getFilterGroup
+    // =====================================================================
+
+    @Test
+    void getFilterGroup_returnsFilterGroup() {
+        ScriptFilterGroup group = new ScriptFilterGroup();
+        FilterGroupTO to = FilterGroupTO.builder().withId(1).withName("grp").withProductName("prod").build();
+
+        try (MockedConstruction<ScriptFilterGroupDao> daoMock = Mockito.mockConstruction(ScriptFilterGroupDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(group));
+             MockedStatic<FilterServiceUtil> utilMock = Mockito.mockStatic(FilterServiceUtil.class)) {
+            utilMock.when(() -> FilterServiceUtil.filterGroupToTO(group)).thenReturn(to);
+
+            FilterGroupTO result = service.getFilterGroup(1);
+            assertNotNull(result);
+        }
+    }
+
+    // =====================================================================
+    // getFilters
+    // =====================================================================
+
+    @Test
+    void getFilters_returnsAll() {
+        ScriptFilter f1 = new ScriptFilter();
+        FilterTO to1 = FilterTO.builder().withId(1).withName("f1").withProductName("p").build();
+
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(f1)));
+             MockedStatic<FilterServiceUtil> utilMock = Mockito.mockStatic(FilterServiceUtil.class)) {
+            utilMock.when(() -> FilterServiceUtil.filterToTO(f1)).thenReturn(to1);
+
+            FilterContainer result = service.getFilters();
+            assertNotNull(result);
+            assertEquals(1, result.getFilters().size());
+        }
+    }
+
+    // =====================================================================
+    // getFilterGroups
+    // =====================================================================
+
+    @Test
+    void getFilterGroups_returnsAll() {
+        ScriptFilterGroup g1 = new ScriptFilterGroup();
+        FilterGroupTO to1 = FilterGroupTO.builder().withId(1).withName("g1").withProductName("p").build();
+
+        try (MockedConstruction<ScriptFilterGroupDao> daoMock = Mockito.mockConstruction(ScriptFilterGroupDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(g1)));
+             MockedStatic<FilterServiceUtil> utilMock = Mockito.mockStatic(FilterServiceUtil.class)) {
+            utilMock.when(() -> FilterServiceUtil.filterGroupToTO(g1)).thenReturn(to1);
+
+            FilterGroupContainer result = service.getFilterGroups();
+            assertNotNull(result);
+            assertEquals(1, result.getFilterGroups().size());
+        }
+    }
+
+    // =====================================================================
+    // applyFilters
+    // =====================================================================
+
+    @Test
+    void applyFilters_appliesFiltersToScript() {
+        Script script = new Script();
+        script.setId(1);
+        script.setName("TestScript");
+        script.setCreated(new Date());
+        script.setModified(new Date());
+
+        ApplyFiltersRequest request = new ApplyFiltersRequest(null, List.of(10, 20), List.of());
+
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(1)).thenReturn(script);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(script);
+                });
+             MockedConstruction<FilterGroupDao> fgDaoMock = Mockito.mockConstruction(FilterGroupDao.class);
+             MockedStatic<ScriptFilterUtil> filterUtilMock = Mockito.mockStatic(ScriptFilterUtil.class);
+             MockedStatic<ScriptUtil> scriptUtilMock = Mockito.mockStatic(ScriptUtil.class);
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.applyFilters(1, request);
+            assertEquals("Filters applied", result);
+        }
+    }
+
+    @Test
+    void applyFilters_returnsMessageWhenScriptNotFound() {
+        ApplyFiltersRequest request = new ApplyFiltersRequest(null, List.of(10), List.of());
+
+        try (MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.applyFilters(999, request);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void applyFilters_withFilterGroups_flattensAndApplies() {
+        Script script = new Script();
+        script.setId(1);
+        script.setName("Test");
+        script.setCreated(new Date());
+        script.setModified(new Date());
+
+        ScriptFilter groupFilter = new ScriptFilter();
+        groupFilter.setId(30);
+        Set<ScriptFilter> filters = new HashSet<>();
+        filters.add(groupFilter);
+
+        com.intuit.tank.project.ScriptFilterGroup filterGroup = new com.intuit.tank.project.ScriptFilterGroup();
+        filterGroup.setFilters(filters);
+
+        ApplyFiltersRequest request = new ApplyFiltersRequest(null, List.of(), List.of(5));
+
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(1)).thenReturn(script);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(script);
+                });
+             MockedConstruction<FilterGroupDao> fgDaoMock = Mockito.mockConstruction(FilterGroupDao.class,
+                (mock, ctx) -> when(mock.findById(5)).thenReturn(filterGroup));
+             MockedStatic<ScriptFilterUtil> filterUtilMock = Mockito.mockStatic(ScriptFilterUtil.class);
+             MockedStatic<ScriptUtil> scriptUtilMock = Mockito.mockStatic(ScriptUtil.class);
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            String result = service.applyFilters(1, request);
+            assertEquals("Filters applied", result);
+            filterUtilMock.verify(() -> ScriptFilterUtil.applyFilters(anyList(), eq(script)));
+        }
+    }
+
+    @Test
+    void applyFilters_returnsNullWhenScriptIdNull() {
+        ApplyFiltersRequest request = new ApplyFiltersRequest(null, List.of(1), List.of());
+
+        String result = service.applyFilters(null, request);
+        assertNull(result);
+    }
+
+    // =====================================================================
+    // deleteFilter
+    // =====================================================================
+
+    @Test
+    void deleteFilter_deletesExisting() {
+        ScriptFilter filter = new ScriptFilter();
+
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(filter))) {
+
+            String result = service.deleteFilter(1);
+            assertEquals("", result);
+
+            verify(daoMock.constructed().get(0)).delete(filter);
+        }
+    }
+
+    @Test
+    void deleteFilter_returnsMessageWhenNotFound() {
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.deleteFilter(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteFilter_throwsOnError() {
+        try (MockedConstruction<ScriptFilterDao> daoMock = Mockito.mockConstruction(ScriptFilterDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteFilter(1));
+        }
+    }
+
+    // =====================================================================
+    // deleteFilterGroup
+    // =====================================================================
+
+    @Test
+    void deleteFilterGroup_deletesExisting() {
+        ScriptFilterGroup group = new ScriptFilterGroup();
+
+        try (MockedConstruction<ScriptFilterGroupDao> daoMock = Mockito.mockConstruction(ScriptFilterGroupDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(group))) {
+
+            String result = service.deleteFilterGroup(1);
+            assertEquals("", result);
+
+            verify(daoMock.constructed().get(0)).delete(group);
+        }
+    }
+
+    @Test
+    void deleteFilterGroup_returnsMessageWhenNotFound() {
+        try (MockedConstruction<ScriptFilterGroupDao> daoMock = Mockito.mockConstruction(ScriptFilterGroupDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.deleteFilterGroup(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteFilterGroup_throwsOnError() {
+        try (MockedConstruction<ScriptFilterGroupDao> daoMock = Mockito.mockConstruction(ScriptFilterGroupDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteFilterGroup(1));
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
@@ -1,14 +1,23 @@
 package com.intuit.tank.rest.mvc.rest.services.jobs;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Segment;
 import com.intuit.tank.dao.DataFileDao;
 import com.intuit.tank.dao.JobInstanceDao;
 import com.intuit.tank.dao.JobNotificationDao;
 import com.intuit.tank.dao.JobQueueDao;
+import com.intuit.tank.dao.JobRegionDao;
+import com.intuit.tank.dao.ProjectDao;
 import com.intuit.tank.dao.WorkloadDao;
+import com.intuit.tank.harness.StopBehavior;
+import com.intuit.tank.jobs.models.CreateJobRegion;
 import com.intuit.tank.jobs.models.CreateJobRequest;
+import com.intuit.tank.jobs.models.JobContainer;
+import com.intuit.tank.jobs.models.JobTO;
 import com.intuit.tank.project.JobConfiguration;
 import com.intuit.tank.project.JobInstance;
 import com.intuit.tank.project.JobQueue;
+import com.intuit.tank.project.JobRegion;
 import com.intuit.tank.project.Project;
 import com.intuit.tank.project.Script;
 import com.intuit.tank.project.ScriptGroup;
@@ -16,31 +25,1034 @@ import com.intuit.tank.project.ScriptGroupStep;
 import com.intuit.tank.project.ScriptStep;
 import com.intuit.tank.project.TestPlan;
 import com.intuit.tank.project.Workload;
+import com.intuit.tank.rest.mvc.rest.cloud.JobEventSender;
+import com.intuit.tank.rest.mvc.rest.cloud.ServletInjector;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
 import com.intuit.tank.rest.mvc.rest.util.JobDetailFormatter;
+import com.intuit.tank.rest.mvc.rest.util.JobServiceUtil;
 import com.intuit.tank.rest.mvc.rest.util.JobValidator;
 import com.intuit.tank.rest.mvc.rest.util.ResponseUtil;
 import com.intuit.tank.util.TestParamUtil;
 import com.intuit.tank.util.TestParameterContainer;
 import com.intuit.tank.vm.api.enumerated.IncrementStrategy;
+import com.intuit.tank.vm.api.enumerated.JobQueueStatus;
+import com.intuit.tank.vm.api.enumerated.TerminationPolicy;
+import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vm.vmManager.models.CloudVmStatusContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
+import jakarta.servlet.ServletContext;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class JobServiceV2ImplTest {
+
+    @InjectMocks
+    private JobServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    private AutoCloseable mocks;
+    private MockedStatic<AWSXRay> xrayMock;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        xrayMock = Mockito.mockStatic(AWSXRay.class);
+        Segment mockSegment = mock(Segment.class);
+        xrayMock.when(AWSXRay::getCurrentSegment).thenReturn(mockSegment);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        xrayMock.close();
+        mocks.close();
+    }
+
+    // =====================================================================
+    // ping
+    // =====================================================================
+
+    @Test
+    void ping_returnsPong() {
+        String result = service.ping();
+        assertTrue(result.startsWith("PONG"));
+        assertTrue(result.contains("JobServiceV2"));
+    }
+
+    // =====================================================================
+    // getJob
+    // =====================================================================
+
+    @Test
+    void getJob_found_returnsJobTO() {
+        JobInstance job = createJobInstance(42, "test-job", JobQueueStatus.Running);
+
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            JobTO result = service.getJob(42);
+
+            assertNotNull(result);
+            assertEquals(42, result.getId());
+            assertEquals("test-job", result.getName());
+        }
+    }
+
+    @Test
+    void getJob_notFound_returnsNull() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(99)).thenReturn(null))) {
+
+            JobTO result = service.getJob(99);
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void getJob_error_throwsException() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("db error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getJob(1));
+        }
+    }
+
+    // =====================================================================
+    // getJobsByProject
+    // =====================================================================
+
+    @Test
+    void getJobsByProject_projectFound_returnsJobs() {
+        Project project = new Project();
+        project.setId(10);
+        project.setName("proj");
+
+        JobInstance job1 = createJobInstance(1, "job1", JobQueueStatus.Created);
+        JobInstance job2 = createJobInstance(2, "job2", JobQueueStatus.Running);
+        JobQueue queue = new JobQueue(10);
+        queue.addJob(job1);
+        queue.addJob(job2);
+
+        try (MockedConstruction<ProjectDao> projDaoMock = Mockito.mockConstruction(ProjectDao.class,
+                     (mock, ctx) -> when(mock.findByIdEager(10)).thenReturn(project));
+             MockedConstruction<JobQueueDao> queueDaoMock = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, ctx) -> when(mock.findOrCreateForProjectId(10)).thenReturn(queue))) {
+
+            JobContainer result = service.getJobsByProject(10);
+
+            assertNotNull(result);
+            assertEquals(2, result.getJobs().size());
+        }
+    }
+
+    @Test
+    void getJobsByProject_projectNotFound_returnsNull() {
+        try (MockedConstruction<ProjectDao> projDaoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(99)).thenReturn(null))) {
+
+            JobContainer result = service.getJobsByProject(99);
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void getJobsByProject_error_throwsException() {
+        try (MockedConstruction<ProjectDao> projDaoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getJobsByProject(1));
+        }
+    }
+
+    // =====================================================================
+    // getAllJobs
+    // =====================================================================
+
+    @Test
+    void getAllJobs_nonEmpty_returnsContainer() {
+        JobInstance job = createJobInstance(1, "job1", JobQueueStatus.Running);
+        List<JobInstance> jobs = new ArrayList<>(List.of(job));
+
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(jobs))) {
+
+            JobContainer result = service.getAllJobs();
+
+            assertNotNull(result);
+            assertEquals(1, result.getJobs().size());
+        }
+    }
+
+    @Test
+    void getAllJobs_empty_returnsNull() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(new ArrayList<>()))) {
+
+            JobContainer result = service.getAllJobs();
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void getAllJobs_error_throwsException() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenThrow(new RuntimeException("db error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getAllJobs());
+        }
+    }
+
+    // =====================================================================
+    // createJob
+    // =====================================================================
+
+    @Test
+    void createJob_success_returnsJobIdAndStatus() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "projectId", 7);
+
+        Script script = createScript("s", 1);
+        Workload workload = createWorkload("wl", 10, script);
+        Project project = createProject(workload);
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<JobDetailFormatter> jdf = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> tpu = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<ProjectDao> projDaoMock = Mockito.mockConstruction(ProjectDao.class,
+                     (mock, ctx) -> {
+                         when(mock.findByIdEager(7)).thenReturn(project);
+                         when(mock.saveOrUpdateProject(any(Project.class))).thenAnswer(inv -> inv.getArgument(0));
+                     });
+             MockedConstruction<JobValidator> valMock = Mockito.mockConstruction(JobValidator.class,
+                     (mock, ctx) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> queueDaoMock = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, ctx) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> wlDaoMock = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, ctx) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(inv -> inv.getArgument(0)));
+             MockedConstruction<JobInstanceDao> jiDaoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(inv -> {
+                         JobInstance ji = inv.getArgument(0);
+                         ji.setId(555);
+                         return ji;
+                     }));
+             MockedConstruction<DataFileDao> dfDaoMock = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> jnDaoMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jdf.when(() -> JobDetailFormatter.createJobDetails(any(), any(), any())).thenReturn("details");
+            tpu.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            Map<String, String> result = service.createJob(request);
+
+            assertEquals("555", result.get("JobId"));
+            assertEquals("created", result.get("status"));
+        }
+    }
+
+    @Test
+    void createJob_error_throwsException() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "projectId", 7);
+
+        try (MockedConstruction<ProjectDao> projDaoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.createJob(request));
+        }
+    }
+
+    @Test
+    void createJob_nullProjectId_returnsEmptyMap() throws Exception {
+        CreateJobRequest request = createRequest();
+        // projectId is null by default
+
+        Map<String, String> result = service.createJob(request);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // =====================================================================
+    // getJobStatus
+    // =====================================================================
+
+    @Test
+    void getJobStatus_found_returnsStatusName() {
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.Running);
+
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.getJobStatus(42);
+
+            assertEquals("Running", result);
+        }
+    }
+
+    @Test
+    void getJobStatus_notFound_returnsNull() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(99)).thenReturn(null))) {
+
+            String result = service.getJobStatus(99);
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void getJobStatus_error_throwsException() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getJobStatus(1));
+        }
+    }
+
+    // =====================================================================
+    // getJobVMStatus
+    // =====================================================================
+
+    @Test
+    void getJobVMStatus_success_returnsContainer() {
+        CloudVmStatusContainer container = mock(CloudVmStatusContainer.class);
+        JobEventSender mockSender = mock(JobEventSender.class);
+        when(mockSender.getVmStatusForJob("42")).thenReturn(container);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            CloudVmStatusContainer result = service.getJobVMStatus("42");
+
+            assertNotNull(result);
+            assertSame(container, result);
+        }
+    }
+
+    @Test
+    void getJobVMStatus_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getJobVMStatus("42"));
+        }
+    }
+
+    // =====================================================================
+    // getAllJobStatus
+    // =====================================================================
+
+    @Test
+    void getAllJobStatus_withJobs_returnsStatusList() {
+        JobInstance job1 = createJobInstance(1, "j1", JobQueueStatus.Running);
+        JobInstance job2 = createJobInstance(2, "j2", JobQueueStatus.Completed);
+        List<JobInstance> jobs = List.of(job1, job2);
+
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(jobs))) {
+
+            List<Map<String, String>> result = service.getAllJobStatus();
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals("1", result.get(0).get("jobId"));
+            assertEquals("Running", result.get(0).get("status"));
+            assertEquals("2", result.get(1).get("jobId"));
+            assertEquals("Completed", result.get(1).get("status"));
+        }
+    }
+
+    @Test
+    void getAllJobStatus_empty_returnsEmptyList() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(new ArrayList<>()))) {
+
+            List<Map<String, String>> result = service.getAllJobStatus();
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    void getAllJobStatus_error_throwsException() {
+        try (MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getAllJobStatus());
+        }
+    }
+
+    // =====================================================================
+    // startJob
+    // =====================================================================
+
+    @Test
+    void startJob_success_returnsStatus() {
+        JobEventSender mockSender = mock(JobEventSender.class);
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.Starting);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                     (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                             .thenReturn(mockSender));
+             MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.startJob(42);
+
+            assertEquals("Starting", result);
+            verify(mockSender).startJob("42");
+        }
+    }
+
+    @Test
+    void startJob_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.startJob(1));
+        }
+    }
+
+    // =====================================================================
+    // stopJob
+    // =====================================================================
+
+    @Test
+    void stopJob_success_returnsStatus() {
+        JobEventSender mockSender = mock(JobEventSender.class);
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.Stopped);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                     (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                             .thenReturn(mockSender));
+             MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.stopJob(42);
+
+            assertEquals("Stopped", result);
+            verify(mockSender).stopJob("42");
+        }
+    }
+
+    @Test
+    void stopJob_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.stopJob(1));
+        }
+    }
+
+    // =====================================================================
+    // pauseJob
+    // =====================================================================
+
+    @Test
+    void pauseJob_success_returnsStatus() {
+        JobEventSender mockSender = mock(JobEventSender.class);
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.RampPaused);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                     (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                             .thenReturn(mockSender));
+             MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.pauseJob(42);
+
+            assertEquals("RampPaused", result);
+            verify(mockSender).pauseRampJob("42");
+        }
+    }
+
+    @Test
+    void pauseJob_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.pauseJob(1));
+        }
+    }
+
+    // =====================================================================
+    // resumeJob
+    // =====================================================================
+
+    @Test
+    void resumeJob_success_returnsStatus() {
+        JobEventSender mockSender = mock(JobEventSender.class);
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.Running);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                     (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                             .thenReturn(mockSender));
+             MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.resumeJob(42);
+
+            assertEquals("Running", result);
+            verify(mockSender).resumeRampJob("42");
+        }
+    }
+
+    @Test
+    void resumeJob_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.resumeJob(1));
+        }
+    }
+
+    // =====================================================================
+    // killJob
+    // =====================================================================
+
+    @Test
+    void killJob_success_returnsStatus() {
+        JobEventSender mockSender = mock(JobEventSender.class);
+        JobInstance job = createJobInstance(42, "j", JobQueueStatus.Completed);
+
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                     (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                             .thenReturn(mockSender));
+             MockedConstruction<JobInstanceDao> daoMock = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, ctx) -> when(mock.findById(42)).thenReturn(job))) {
+
+            String result = service.killJob(42);
+
+            assertEquals("Completed", result);
+            verify(mockSender).killJob("42");
+        }
+    }
+
+    @Test
+    void killJob_error_throwsException() {
+        try (MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(JobEventSender.class)))
+                        .thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.killJob(1));
+        }
+    }
+
+    // =====================================================================
+    // buildJobConfiguration (static method)
+    // =====================================================================
+
+    @Test
+    void buildJobConfiguration_nullJobConfig_throwsException() throws Exception {
+        CreateJobRequest request = createRequest();
+        Project project = new Project();
+        project.setName("proj");
+        // project has no workloads, so jobConfiguration will be null
+
+        assertThrows(GenericServiceCreateOrUpdateException.class,
+                () -> JobServiceV2Impl.buildJobConfiguration(request, project));
+    }
+
+    @Test
+    void buildJobConfiguration_nullProject_throwsException() throws Exception {
+        CreateJobRequest request = createRequest();
+
+        assertThrows(GenericServiceCreateOrUpdateException.class,
+                () -> JobServiceV2Impl.buildJobConfiguration(request, null));
+    }
+
+    @Test
+    void buildJobConfiguration_setsRampTime() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "rampTime", "300");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("300", jc.getRampTimeExpression());
+    }
+
+    @Test
+    void buildJobConfiguration_setsSimulationTime() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "simulationTime", "600");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("600", jc.getSimulationTimeExpression());
+    }
+
+    @Test
+    void buildJobConfiguration_setsWorkloadType() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "workloadType", IncrementStrategy.increasing);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(IncrementStrategy.increasing, jc.getIncrementStrategy());
+    }
+
+    @Test
+    void buildJobConfiguration_setsStopBehavior_whenProvided() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "stopBehavior", StopBehavior.END_OF_TEST.name());
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(StopBehavior.END_OF_TEST.name(), jc.getStopBehavior());
+    }
+
+    @Test
+    void buildJobConfiguration_setsStopBehavior_defaultWhenEmpty() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "stopBehavior", "");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(StopBehavior.END_OF_SCRIPT_GROUP.name(), jc.getStopBehavior());
+    }
+
+    @Test
+    void buildJobConfiguration_setsStopBehavior_defaultWhenNull() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "stopBehavior", null);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(StopBehavior.END_OF_SCRIPT_GROUP.name(), jc.getStopBehavior());
+    }
+
+    @Test
+    void buildJobConfiguration_setsVmInstance() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "vmInstance", "c5.xlarge");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("c5.xlarge", jc.getVmInstanceType());
+    }
+
+    @Test
+    void buildJobConfiguration_setsNumUsersPerAgent() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "numUsersPerAgent", 50);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(50, jc.getNumUsersPerAgent());
+    }
+
+    @Test
+    void buildJobConfiguration_terminationPolicy_timeWhenSimTime() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "simulationTime", "600");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(TerminationPolicy.time, jc.getTerminationPolicy());
+    }
+
+    @Test
+    void buildJobConfiguration_terminationPolicy_scriptWhenNoSimTime() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "simulationTime", "0");
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.setSimulationTimeExpression("0");
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(TerminationPolicy.script, jc.getTerminationPolicy());
+    }
+
+    @Test
+    void buildJobConfiguration_setsJobRegions() throws Exception {
+        CreateJobRequest request = createRequest();
+        Set<CreateJobRegion> regions = new HashSet<>();
+        regions.add(new CreateJobRegion("us-west-2a", "100", "50"));
+        setField(request, "jobRegions", regions);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        // Ensure jobRegions is initialized
+        jc.getJobRegions().add(new JobRegion(VMRegion.US_EAST, "10", "100"));
+
+        try (MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class,
+                (mock, ctx) -> when(mock.saveOrUpdate(any(JobRegion.class))).thenAnswer(inv -> inv.getArgument(0)))) {
+
+            JobServiceV2Impl.buildJobConfiguration(request, project);
+
+            assertEquals(1, jc.getJobRegions().size());
+        }
+    }
+
+    @Test
+    void buildJobConfiguration_jobRegions_nullUsers_defaultsToZero() throws Exception {
+        CreateJobRequest request = createRequest();
+        Set<CreateJobRegion> regions = new HashSet<>();
+        regions.add(new CreateJobRegion("us-east-1b", null, null));
+        setField(request, "jobRegions", regions);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.getJobRegions().add(new JobRegion(VMRegion.US_EAST, "10", "100"));
+
+        try (MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class,
+                (mock, ctx) -> when(mock.saveOrUpdate(any(JobRegion.class))).thenAnswer(inv -> {
+                    JobRegion jr = inv.getArgument(0);
+                    assertEquals("0", jr.getUsers());
+                    assertEquals("0", jr.getPercentage());
+                    return jr;
+                }))) {
+
+            JobServiceV2Impl.buildJobConfiguration(request, project);
+        }
+    }
+
+    @Test
+    void buildJobConfiguration_jobRegions_emptyRegionName_skipped() throws Exception {
+        CreateJobRequest request = createRequest();
+        Set<CreateJobRegion> regions = new HashSet<>();
+        regions.add(new CreateJobRegion("", "100", "50"));
+        setField(request, "jobRegions", regions);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.getJobRegions().add(new JobRegion(VMRegion.US_EAST, "10", "100"));
+
+        try (MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class)) {
+
+            JobServiceV2Impl.buildJobConfiguration(request, project);
+
+            // empty region should be skipped - the old ones were cleared but nothing new added
+            assertTrue(jc.getJobRegions().isEmpty());
+        }
+    }
+
+    @Test
+    void buildJobConfiguration_nullJobRegions_skipsRegionSetting() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "jobRegions", null);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.getJobRegions().add(new JobRegion(VMRegion.US_EAST, "10", "100"));
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        // Original region should remain since jobRegions is null
+        assertEquals(1, jc.getJobRegions().size());
+    }
+
+    @Test
+    void buildJobConfiguration_setsUserIntervalAndRates() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "userIntervalIncrement", 5);
+        setField(request, "targetRampRate", 2.5);
+        setField(request, "targetRatePerAgent", 1.5);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(5, jc.getUserIntervalIncrement());
+        assertEquals(2.5, jc.getTargetRampRate(), 0.01);
+        assertEquals(1.5, jc.getTargetRatePerAgent(), 0.01);
+    }
+
+    @Test
+    void buildJobConfiguration_noRampTime_doesNotOverride() throws Exception {
+        CreateJobRequest request = createRequest();
+        // rampTime is null by default
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.setRampTimeExpression("existing");
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("existing", jc.getRampTimeExpression());
+    }
+
+    @Test
+    void buildJobConfiguration_noSimulationTime_doesNotOverride() throws Exception {
+        CreateJobRequest request = createRequest();
+        // simulationTime is null by default
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.setSimulationTimeExpression("existing");
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("existing", jc.getSimulationTimeExpression());
+    }
+
+    @Test
+    void buildJobConfiguration_noVmInstance_doesNotOverride() throws Exception {
+        CreateJobRequest request = createRequest();
+        // vmInstance is null by default
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.setVmInstanceType("original");
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals("original", jc.getVmInstanceType());
+    }
+
+    @Test
+    void buildJobConfiguration_nullWorkloadType_doesNotOverride() throws Exception {
+        CreateJobRequest request = createRequest();
+        setField(request, "workloadType", null);
+
+        Project project = createProjectWithJobConfig();
+        JobConfiguration jc = project.getWorkloads().get(0).getJobConfiguration();
+        jc.setIncrementStrategy(IncrementStrategy.increasing);
+
+        JobServiceV2Impl.buildJobConfiguration(request, project);
+
+        assertEquals(IncrementStrategy.increasing, jc.getIncrementStrategy());
+    }
+
+    // =====================================================================
+    // buildJobInstanceName (tested via addJobToQueue)
+    // =====================================================================
+
+    @Test
+    void addJobToQueue_customJobInstanceName_usesCustomName() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = createRequest();
+        setField(request, "jobInstanceName", "my-custom-job-name");
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(123);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
+
+            assertEquals("my-custom-job-name", createdJob.getName());
+        }
+    }
+
+    @Test
+    void addJobToQueue_increasingWorkloadType_usesUsersInName() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = createRequest();
+        setField(request, "workloadType", IncrementStrategy.increasing);
+        // no custom jobInstanceName - use generated
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(124);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
+
+            // Name should contain "_users_" for increasing workload type
+            assertTrue(createdJob.getName().contains("_users_"));
+            assertTrue(createdJob.getName().startsWith("project-name"));
+        }
+    }
+
+    @Test
+    void addJobToQueue_standardWorkloadType_usesNonlinearInName() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = createRequest();
+        setField(request, "workloadType", IncrementStrategy.standard);
+        setField(request, "projectName", null); // use project's own name
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(125);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
+
+            assertTrue(createdJob.getName().contains("_nonlinear_"));
+            assertTrue(createdJob.getName().startsWith("project-name"));
+        }
+    }
+
+    @Test
+    void addJobToQueue_requestProjectName_overridesProjectName() throws Exception {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        CreateJobRequest request = new CreateJobRequest("custom-project-name");
+        setField(request, "workloadType", IncrementStrategy.standard);
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(126);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
+
+            assertTrue(createdJob.getName().startsWith("custom-project-name"));
+        }
+    }
+
+    // =====================================================================
+    // ORIGINAL TESTS (preserved)
+    // =====================================================================
 
     @Test
     void addJobToQueue_doesNotCallStoreScript() throws Exception {
@@ -133,7 +1145,44 @@ class JobServiceV2ImplTest {
         }
     }
 
+    // =====================================================================
+    // Helper methods
+    // =====================================================================
+
+    private static JobInstance createJobInstance(int id, String name, JobQueueStatus status) {
+        JobInstance job = new JobInstance();
+        job.setId(id);
+        job.setName(name);
+        job.setStatus(status);
+        job.setCreated(new Date());
+        return job;
+    }
+
     private static Project createProject(Workload workload) {
+        Project project = new Project();
+        project.setId(7);
+        project.setName("project-name");
+        project.addWorkload(workload);
+        return project;
+    }
+
+    private static Project createProjectWithJobConfig() {
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        jobConfiguration.setLocation("us-west-2");
+        jobConfiguration.setLoggingProfile("standard");
+        jobConfiguration.setStopBehavior("stop");
+        jobConfiguration.setVmInstanceType("m5.large");
+        jobConfiguration.setNumUsersPerAgent(1);
+        jobConfiguration.setReportingMode("standard");
+        jobConfiguration.setRampTimeExpression("0");
+        jobConfiguration.setSimulationTimeExpression("0");
+
+        Workload workload = new Workload();
+        workload.setId(10);
+        workload.setName("wl");
+        workload.setJobConfiguration(jobConfiguration);
+        jobConfiguration.setParent(workload);
+
         Project project = new Project();
         project.setId(7);
         project.setName("project-name");

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/jobs/JobServiceV2ImplTest.java
@@ -883,171 +883,45 @@ class JobServiceV2ImplTest {
 
     @Test
     void addJobToQueue_customJobInstanceName_usesCustomName() throws Exception {
-        Script loadedScript = createScript("loaded-script", 11);
-        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
-        Project project = createProject(loadedWorkload);
         CreateJobRequest request = createRequest();
         setField(request, "jobInstanceName", "my-custom-job-name");
-        JobQueue queue = new JobQueue(project.getId());
 
-        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
-             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
-             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
-             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
-                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
-             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
-                     (mock, context) -> {
-                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
-                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
-                     });
-             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
-             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
-                         JobInstance savedJob = invocation.getArgument(0);
-                         savedJob.setId(123);
-                         return savedJob;
-                     }));
-             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
-             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+        JobInstance createdJob = runAddJobToQueue(request);
 
-            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
-                    .thenReturn("job-details");
-            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
-                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
-
-            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
-
-            assertEquals("my-custom-job-name", createdJob.getName());
-        }
+        assertEquals("my-custom-job-name", createdJob.getName());
     }
 
     @Test
     void addJobToQueue_increasingWorkloadType_usesUsersInName() throws Exception {
-        Script loadedScript = createScript("loaded-script", 11);
-        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
-        Project project = createProject(loadedWorkload);
         CreateJobRequest request = createRequest();
         setField(request, "workloadType", IncrementStrategy.increasing);
-        // no custom jobInstanceName - use generated
-        JobQueue queue = new JobQueue(project.getId());
 
-        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
-             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
-             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
-             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
-                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
-             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
-                     (mock, context) -> {
-                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
-                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
-                     });
-             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
-             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
-                         JobInstance savedJob = invocation.getArgument(0);
-                         savedJob.setId(124);
-                         return savedJob;
-                     }));
-             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
-             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+        JobInstance createdJob = runAddJobToQueue(request);
 
-            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
-                    .thenReturn("job-details");
-            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
-                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
-
-            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
-
-            // Name should contain "_users_" for increasing workload type
-            assertTrue(createdJob.getName().contains("_users_"));
-            assertTrue(createdJob.getName().startsWith("project-name"));
-        }
+        assertTrue(createdJob.getName().contains("_users_"));
+        assertTrue(createdJob.getName().startsWith("project-name"));
     }
 
     @Test
     void addJobToQueue_standardWorkloadType_usesNonlinearInName() throws Exception {
-        Script loadedScript = createScript("loaded-script", 11);
-        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
-        Project project = createProject(loadedWorkload);
         CreateJobRequest request = createRequest();
         setField(request, "workloadType", IncrementStrategy.standard);
-        setField(request, "projectName", null); // use project's own name
-        JobQueue queue = new JobQueue(project.getId());
+        setField(request, "projectName", null);
 
-        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
-             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
-             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
-             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
-                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
-             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
-                     (mock, context) -> {
-                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
-                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
-                     });
-             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
-             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
-                         JobInstance savedJob = invocation.getArgument(0);
-                         savedJob.setId(125);
-                         return savedJob;
-                     }));
-             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
-             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+        JobInstance createdJob = runAddJobToQueue(request);
 
-            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
-                    .thenReturn("job-details");
-            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
-                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
-
-            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
-
-            assertTrue(createdJob.getName().contains("_nonlinear_"));
-            assertTrue(createdJob.getName().startsWith("project-name"));
-        }
+        assertTrue(createdJob.getName().contains("_nonlinear_"));
+        assertTrue(createdJob.getName().startsWith("project-name"));
     }
 
     @Test
     void addJobToQueue_requestProjectName_overridesProjectName() throws Exception {
-        Script loadedScript = createScript("loaded-script", 11);
-        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
-        Project project = createProject(loadedWorkload);
         CreateJobRequest request = new CreateJobRequest("custom-project-name");
         setField(request, "workloadType", IncrementStrategy.standard);
-        JobQueue queue = new JobQueue(project.getId());
 
-        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
-             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
-             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
-             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
-                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
-             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
-                     (mock, context) -> {
-                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
-                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
-                     });
-             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
-             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
-                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
-                         JobInstance savedJob = invocation.getArgument(0);
-                         savedJob.setId(126);
-                         return savedJob;
-                     }));
-             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
-             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+        JobInstance createdJob = runAddJobToQueue(request);
 
-            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
-                    .thenReturn("job-details");
-            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
-                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
-
-            JobInstance createdJob = JobServiceV2Impl.addJobToQueue(project, request);
-
-            assertTrue(createdJob.getName().startsWith("custom-project-name"));
-        }
+        assertTrue(createdJob.getName().startsWith("custom-project-name"));
     }
 
     // =====================================================================
@@ -1231,6 +1105,42 @@ class JobServiceV2ImplTest {
 
     private static Script getOnlyScript(Workload workload) {
         return workload.getTestPlans().get(0).getScriptGroups().get(0).getScriptGroupSteps().get(0).getScript();
+    }
+
+    private static JobInstance runAddJobToQueue(CreateJobRequest request) {
+        Script loadedScript = createScript("loaded-script", 11);
+        Workload loadedWorkload = createWorkload("loaded-workload", 111, loadedScript);
+        Project project = createProject(loadedWorkload);
+        JobQueue queue = new JobQueue(project.getId());
+
+        try (MockedStatic<ResponseUtil> responseUtil = Mockito.mockStatic(ResponseUtil.class);
+             MockedStatic<JobDetailFormatter> jobDetailFormatter = Mockito.mockStatic(JobDetailFormatter.class);
+             MockedStatic<TestParamUtil> testParamUtil = Mockito.mockStatic(TestParamUtil.class);
+             MockedConstruction<JobValidator> ignoredValidator = Mockito.mockConstruction(JobValidator.class,
+                     (mock, context) -> when(mock.getDurationMs(anyString())).thenReturn(0L));
+             MockedConstruction<JobQueueDao> ignoredJobQueueDao = Mockito.mockConstruction(JobQueueDao.class,
+                     (mock, context) -> {
+                         when(mock.findOrCreateForProjectId(anyInt())).thenReturn(queue);
+                         when(mock.saveOrUpdate(any(JobQueue.class))).thenReturn(queue);
+                     });
+             MockedConstruction<WorkloadDao> ignoredWorkloadDao = Mockito.mockConstruction(WorkloadDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(Workload.class))).thenAnswer(invocation -> invocation.getArgument(0)));
+             MockedConstruction<JobInstanceDao> ignoredJobInstanceDao = Mockito.mockConstruction(JobInstanceDao.class,
+                     (mock, context) -> when(mock.saveOrUpdate(any(JobInstance.class))).thenAnswer(invocation -> {
+                         JobInstance savedJob = invocation.getArgument(0);
+                         savedJob.setId(123);
+                         return savedJob;
+                     }));
+             MockedConstruction<DataFileDao> ignoredDataFileDao = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> ignoredJobNotificationDao = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            jobDetailFormatter.when(() -> JobDetailFormatter.createJobDetails(any(JobValidator.class), any(Workload.class), any(JobInstance.class)))
+                    .thenReturn("job-details");
+            testParamUtil.when(() -> TestParamUtil.evaluateTestTimes(anyLong(), anyString(), anyString()))
+                    .thenReturn(TestParameterContainer.builder().withRampTime(0L).withSimulationTime(0L).build());
+
+            return JobServiceV2Impl.addJobToQueue(project, request);
+        }
     }
 
     private static CreateJobRequest createRequest() throws Exception {

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/logs/LogServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/logs/LogServiceV2ImplTest.java
@@ -1,0 +1,77 @@
+package com.intuit.tank.rest.mvc.rest.services.logs;
+
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import jakarta.servlet.ServletContext;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogServiceV2ImplTest {
+
+    @InjectMocks
+    private LogServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getFile_rejectsPathTraversal() {
+        assertThrows(GenericServiceResourceNotFoundException.class,
+                () -> service.getFile("../etc/passwd", "0"));
+    }
+
+    @Test
+    void getFile_rejectsAbsolutePath() {
+        assertThrows(GenericServiceResourceNotFoundException.class,
+                () -> service.getFile("/var/log/syslog", "0"));
+    }
+
+    @Test
+    void getFile_throwsWhenFileNotFound() {
+        assertThrows(GenericServiceResourceNotFoundException.class,
+                () -> service.getFile("nonexistent-file.log", "0"));
+    }
+
+    @Test
+    void getFile_handlesNullStart() {
+        // Should default start to "0" and throw because file doesn't exist
+        assertThrows(GenericServiceResourceNotFoundException.class,
+                () -> service.getFile("nonexistent.log", null));
+    }
+
+    @Test
+    void getFile_readsExistingFile() throws IOException {
+        // Create a real "logs" directory with a test file
+        File logsDir = new File("logs");
+        logsDir.mkdirs();
+        File testFile = new File(logsDir, "test-log-for-coverage.log");
+        try {
+            Files.writeString(testFile.toPath(), "log line 1\nlog line 2\n");
+
+            StreamingResponseBody body = service.getFile("test-log-for-coverage.log", "0");
+            assertNotNull(body);
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            body.writeTo(out);
+            String content = out.toString();
+            assertTrue(content.contains("log line"));
+        } finally {
+            testFile.delete();
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/logs/LogServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/logs/LogServiceV2ImplTest.java
@@ -1,6 +1,7 @@
 package com.intuit.tank.rest.mvc.rest.services.logs;
 
 import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -18,15 +19,26 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class LogServiceV2ImplTest {
 
+    private static final String TEST_LOG_FILENAME = "test-log-for-coverage.log";
+
     @InjectMocks
     private LogServiceV2Impl service;
 
     @Mock
     private ServletContext servletContext;
 
+    private File testFile;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (testFile != null && testFile.exists()) {
+            testFile.delete();
+        }
     }
 
     @Test
@@ -49,29 +61,24 @@ class LogServiceV2ImplTest {
 
     @Test
     void getFile_handlesNullStart() {
-        // Should default start to "0" and throw because file doesn't exist
         assertThrows(GenericServiceResourceNotFoundException.class,
                 () -> service.getFile("nonexistent.log", null));
     }
 
     @Test
     void getFile_readsExistingFile() throws IOException {
-        // Create a real "logs" directory with a test file
         File logsDir = new File("logs");
         logsDir.mkdirs();
-        File testFile = new File(logsDir, "test-log-for-coverage.log");
-        try {
-            Files.writeString(testFile.toPath(), "log line 1\nlog line 2\n");
+        testFile = new File(logsDir, TEST_LOG_FILENAME);
+        Files.writeString(testFile.toPath(), "log line 1\nlog line 2\n");
 
-            StreamingResponseBody body = service.getFile("test-log-for-coverage.log", "0");
-            assertNotNull(body);
+        StreamingResponseBody body = service.getFile(TEST_LOG_FILENAME, "0");
+        assertNotNull(body);
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            body.writeTo(out);
-            String content = out.toString();
-            assertTrue(content.contains("log line"));
-        } finally {
-            testFile.delete();
-        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String content = out.toString();
+        assertTrue(content.contains("log line 1"));
+        assertTrue(content.contains("log line 2"));
     }
 }

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/projects/ProjectServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/projects/ProjectServiceV2ImplTest.java
@@ -1,0 +1,301 @@
+package com.intuit.tank.rest.mvc.rest.services.projects;
+
+import com.intuit.tank.dao.ProjectDao;
+import com.intuit.tank.dao.ScriptDao;
+import com.intuit.tank.project.*;
+import com.intuit.tank.projects.models.*;
+import com.intuit.tank.rest.mvc.rest.cloud.MessageEventSender;
+import com.intuit.tank.rest.mvc.rest.cloud.ServletInjector;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceDeleteException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import com.intuit.tank.rest.mvc.rest.util.ProjectServiceUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.servlet.ServletContext;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ProjectServiceV2ImplTest {
+
+    @InjectMocks
+    private ProjectServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void ping_returnsPong() {
+        assertTrue(service.ping().contains("PONG"));
+    }
+
+    // =====================================================================
+    // getAllProjects
+    // =====================================================================
+
+    @Test
+    void getAllProjects_returnsProjects() {
+        Project p = createProject(1, "TestProject");
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findAllFast()).thenReturn(List.of(p)))) {
+
+            ProjectContainer result = service.getAllProjects();
+            assertNotNull(result);
+            assertEquals(1, result.getProjects().size());
+            assertEquals("TestProject", result.getProjects().get(0).getName());
+        }
+    }
+
+    @Test
+    void getAllProjects_throwsOnError() {
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findAllFast()).thenThrow(new RuntimeException("DB error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getAllProjects());
+        }
+    }
+
+    // =====================================================================
+    // getAllProjectNames
+    // =====================================================================
+
+    @Test
+    void getAllProjectNames_returnsNameMap() {
+        Project p1 = createProject(1, "ProjectA");
+        Project p2 = createProject(2, "ProjectB");
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findAllFast()).thenReturn(List.of(p1, p2)))) {
+
+            Map<Integer, String> result = service.getAllProjectNames();
+            assertEquals(2, result.size());
+            assertEquals("ProjectA", result.get(1));
+        }
+    }
+
+    // =====================================================================
+    // getProject
+    // =====================================================================
+
+    @Test
+    void getProject_returnsProject() {
+        Project p = createProject(1, "Found");
+        ProjectTO to = ProjectTO.builder().withId(1).withName("Found").build();
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(1)).thenReturn(p));
+             MockedStatic<ProjectServiceUtil> utilMock = Mockito.mockStatic(ProjectServiceUtil.class)) {
+            utilMock.when(() -> ProjectServiceUtil.projectToTransferObject(p)).thenReturn(to);
+
+            ProjectTO result = service.getProject(1);
+            assertNotNull(result);
+            assertEquals("Found", result.getName());
+        }
+    }
+
+    // =====================================================================
+    // createProject
+    // =====================================================================
+
+    @Test
+    void createProject_createsNewProject() {
+        Project savedProject = createProject(42, "NewProject");
+        AutomationRequest request = AutomationRequest.builder()
+                .withName("NewProject")
+                .withProductName("MyProduct")
+                .withComments("test")
+                .build();
+
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> {
+                    when(mock.findByName("NewProject")).thenReturn(null);
+                    when(mock.saveOrUpdateProject(any(Project.class))).thenReturn(savedProject);
+                });
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            Map<String, String> result = service.createProject(request);
+            assertEquals("42", result.get("ProjectId"));
+            assertEquals("Created", result.get("status"));
+        }
+    }
+
+    // =====================================================================
+    // updateProject
+    // =====================================================================
+
+    @Test
+    void updateProject_updatesExistingProject() {
+        Project existingProject = createProject(1, "Existing");
+        AutomationRequest request = AutomationRequest.builder()
+                .withName("Updated")
+                .build();
+
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> {
+                    when(mock.findByIdEager(1)).thenReturn(existingProject);
+                    when(mock.saveOrUpdateProject(any(Project.class))).thenReturn(existingProject);
+                });
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            Map<String, String> result = service.updateProject(1, request);
+            assertEquals("Updated", result.get("status"));
+        }
+    }
+
+    @Test
+    void updateProject_returnsErrorWhenNotFound() {
+        AutomationRequest request = AutomationRequest.builder().withName("X").build();
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(999)).thenReturn(null))) {
+
+            Map<String, String> result = service.updateProject(999, request);
+            assertTrue(result.containsKey("error"));
+        }
+    }
+
+    // =====================================================================
+    // deleteProject
+    // =====================================================================
+
+    @Test
+    void deleteProject_deletesExisting() {
+        Project p = createProject(1, "ToDelete");
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(1)).thenReturn(p))) {
+
+            String result = service.deleteProject(1);
+            assertEquals("", result);
+
+            ProjectDao dao = daoMock.constructed().get(0);
+            verify(dao).delete(p);
+        }
+    }
+
+    @Test
+    void deleteProject_returnsMessageWhenNotFound() {
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(999)).thenReturn(null))) {
+
+            String result = service.deleteProject(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteProject_throwsOnError() {
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.findByIdEager(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteProject(1));
+        }
+    }
+
+    // =====================================================================
+    // createOrUpdateProject with test plans
+    // =====================================================================
+
+    @Test
+    void createProject_withTestPlans_assemblesCorrectly() {
+        Script script = new Script();
+        script.setId(10);
+        script.setName("TestScript");
+
+        Project savedProject = createProject(42, "WithPlans");
+
+        AutomationScriptGroupStep step = AutomationScriptGroupStep.builder()
+                .withScriptId(10).withLoop(2).build();
+        AutomationScriptGroup sg = AutomationScriptGroup.builder()
+                .withName("SG1").withLoop(1).withScripts(List.of(step)).build();
+        AutomationTestPlan tp = AutomationTestPlan.builder()
+                .withName("Plan1").withUserPercentage(100).withScriptGroups(List.of(sg)).build();
+
+        AutomationRequest request = AutomationRequest.builder()
+                .withName("WithPlans")
+                .withTestPlans(List.of(tp))
+                .build();
+
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> {
+                    when(mock.findByName("WithPlans")).thenReturn(null);
+                    when(mock.saveOrUpdateProject(any(Project.class))).thenReturn(savedProject);
+                });
+             MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(10)).thenReturn(script));
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class)))
+                        .thenReturn(mockSender))) {
+
+            Map<String, String> result = service.createProject(request);
+            assertEquals("42", result.get("ProjectId"));
+        }
+    }
+
+    // =====================================================================
+    // downloadTestScriptForProject
+    // =====================================================================
+
+    @Test
+    void downloadTestScriptForProject_returnsNullWhenNotFound() {
+        try (MockedConstruction<ProjectDao> daoMock = Mockito.mockConstruction(ProjectDao.class,
+                (mock, ctx) -> when(mock.loadScripts(999)).thenReturn(null))) {
+
+            assertNull(service.downloadTestScriptForProject(999));
+        }
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private static Project createProject(int id, String name) {
+        Project p = new Project();
+        p.setId(id);
+        p.setName(name);
+        p.setCreated(new Date());
+        p.setModified(new Date());
+        p.setCreator("System");
+
+        Workload workload = new Workload();
+        workload.setName(name);
+        JobConfiguration jc = new JobConfiguration();
+        workload.setJobConfiguration(jc);
+        jc.setParent(workload);
+        TestPlan testPlan = TestPlan.builder().name("Main").usersPercentage(100).build();
+        workload.addTestPlan(testPlan);
+
+        List<Workload> workloads = new ArrayList<>();
+        workloads.add(workload);
+        p.setWorkloads(workloads);
+        workload.setParent(p);
+
+        return p;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2ImplTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/services/scripts/ScriptServiceV2ImplTest.java
@@ -1,0 +1,592 @@
+package com.intuit.tank.rest.mvc.rest.services.scripts;
+
+import com.intuit.tank.dao.ExternalScriptDao;
+import com.intuit.tank.dao.ScriptDao;
+import com.intuit.tank.common.ScriptUtil;
+import com.intuit.tank.project.ExternalScript;
+import com.intuit.tank.project.Script;
+import com.intuit.tank.rest.mvc.rest.cloud.MessageEventSender;
+import com.intuit.tank.rest.mvc.rest.cloud.ServletInjector;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceCreateOrUpdateException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceDeleteException;
+import com.intuit.tank.rest.mvc.rest.controllers.errors.GenericServiceResourceNotFoundException;
+import com.intuit.tank.rest.mvc.rest.util.ResponseUtil;
+import com.intuit.tank.rest.mvc.rest.util.ScriptServiceUtil;
+import com.intuit.tank.script.models.*;
+import com.intuit.tank.script.processor.ScriptProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import jakarta.servlet.ServletContext;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ScriptServiceV2ImplTest {
+
+    @InjectMocks
+    private ScriptServiceV2Impl service;
+
+    @Mock
+    private ServletContext servletContext;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    // =====================================================================
+    // ping
+    // =====================================================================
+
+    @Test
+    void ping_returnsPong() {
+        String result = service.ping();
+        assertTrue(result.startsWith("PONG"));
+        assertTrue(result.contains("ScriptServiceV2"));
+    }
+
+    // =====================================================================
+    // getScript
+    // =====================================================================
+
+    @Test
+    void getScript_returnsScriptDescription() {
+        Script script = createScript(1, "TestScript");
+        ScriptDescription desc = new ScriptDescription();
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(script));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.scriptToScriptDescription(script)).thenReturn(desc);
+
+            ScriptDescription result = service.getScript(1);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void getScript_returnsNullWhenNotFound() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            ScriptDescription result = service.getScript(999);
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void getScript_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("DB error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getScript(1));
+        }
+    }
+
+    // =====================================================================
+    // getScripts
+    // =====================================================================
+
+    @Test
+    void getScripts_returnsAllScripts() {
+        Script s1 = createScript(1, "Script1");
+        Script s2 = createScript(2, "Script2");
+        ScriptDescription d1 = new ScriptDescription();
+        ScriptDescription d2 = new ScriptDescription();
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(s1, s2)));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.scriptToScriptDescription(s1)).thenReturn(d1);
+            utilMock.when(() -> ScriptServiceUtil.scriptToScriptDescription(s2)).thenReturn(d2);
+
+            ScriptDescriptionContainer result = service.getScripts();
+            assertNotNull(result);
+            assertEquals(2, result.getScripts().size());
+        }
+    }
+
+    // =====================================================================
+    // getAllScriptNames
+    // =====================================================================
+
+    @Test
+    void getAllScriptNames_returnsNameMap() {
+        Script s1 = createScript(1, "Alpha");
+        Script s2 = createScript(2, "Beta");
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(s1, s2)))) {
+
+            Map<Integer, String> result = service.getAllScriptNames();
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals("Alpha", result.get(1));
+            assertEquals("Beta", result.get(2));
+        }
+    }
+
+    // =====================================================================
+    // deleteScript
+    // =====================================================================
+
+    @Test
+    void deleteScript_deletesExistingScript() {
+        Script script = createScript(1, "ToDelete");
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(1)).thenReturn(script);
+                })) {
+
+            String result = service.deleteScript(1);
+            assertEquals("", result);
+
+            ScriptDao dao = daoMock.constructed().get(0);
+            verify(dao).delete(script);
+        }
+    }
+
+    @Test
+    void deleteScript_returnsMessageWhenNotFound() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.deleteScript(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteScript_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteScript(1));
+        }
+    }
+
+    // =====================================================================
+    // downloadScript
+    // =====================================================================
+
+    @Test
+    void downloadScript_returnsStreamingBody() {
+        Script script = createScript(1, "DownloadMe");
+        ScriptTO scriptTO = new ScriptTO();
+        StreamingResponseBody body = mock(StreamingResponseBody.class);
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(script));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class);
+             MockedStatic<ResponseUtil> responseMock = Mockito.mockStatic(ResponseUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.scriptToTransferObject(script)).thenReturn(scriptTO);
+            responseMock.when(() -> ResponseUtil.getXMLStream(scriptTO)).thenReturn(body);
+
+            Map<String, StreamingResponseBody> result = service.downloadScript(1);
+            assertNotNull(result);
+            assertTrue(result.containsKey("DownloadMe_TS.xml"));
+        }
+    }
+
+    @Test
+    void downloadScript_returnsNullWhenNotFound() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            Map<String, StreamingResponseBody> result = service.downloadScript(999);
+            assertNull(result);
+        }
+    }
+
+    // =====================================================================
+    // createScript - copy path
+    // =====================================================================
+
+    @Test
+    void createScript_copyPath_copiesExistingScript() throws IOException {
+        Script sourceScript = createScript(10, "SourceScript");
+        Script copiedScript = createScript(11, "CopiedScript");
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(10)).thenReturn(sourceScript);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(copiedScript);
+                });
+             MockedStatic<ScriptUtil> scriptUtilMock = Mockito.mockStatic(ScriptUtil.class)) {
+            scriptUtilMock.when(() -> ScriptUtil.copyScript("System", "CopiedScript", sourceScript))
+                    .thenReturn(copiedScript);
+
+            Map<String, String> result = service.createScript("CopiedScript", null, null, "true", 10, null, null);
+            assertNotNull(result);
+            assertTrue(result.get("message").contains("created successfully"));
+        }
+    }
+
+    @Test
+    void createScript_copyPath_throwsWhenNoSourceId() {
+        assertThrows(GenericServiceCreateOrUpdateException.class,
+                () -> service.createScript("NewCopy", null, null, "true", null, null, null));
+    }
+
+    @Test
+    void createScript_copyPath_throwsWhenNoName() {
+        assertThrows(GenericServiceCreateOrUpdateException.class,
+                () -> service.createScript("", null, null, "true", 10, null, null));
+    }
+
+    @Test
+    void createScript_copyPath_throwsWhenSourceNotFound() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertThrows(GenericServiceCreateOrUpdateException.class,
+                    () -> service.createScript("CopyName", null, null, "true", 999, null, null));
+        }
+    }
+
+    // =====================================================================
+    // createScript - recording/proxy upload path
+    // =====================================================================
+
+    @Test
+    void createScript_recordingPath_createsNewScript() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream("test content".getBytes(StandardCharsets.UTF_8)));
+
+        Script newScript = createScript(0, "New");
+        Script savedScript = createScript(5, "RecordedScript");
+
+        ScriptProcessor mockProcessor = mock(ScriptProcessor.class);
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(0)).thenReturn(null);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(savedScript);
+                });
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> {
+                    when(mock.getManagedBean(eq(servletContext), eq(ScriptProcessor.class))).thenReturn(mockProcessor);
+                    when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class))).thenReturn(mockSender);
+                })) {
+
+            Map<String, String> result = service.createScript("RecordedScript", null, "recording", null, null, null, file);
+            assertNotNull(result);
+            assertTrue(result.containsKey("scriptId"));
+        }
+    }
+
+    @Test
+    void createScript_recordingPath_overwritesExistingScript() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+        Script existingScript = createScript(5, "Existing");
+        ScriptProcessor mockProcessor = mock(ScriptProcessor.class);
+        MessageEventSender mockSender = mock(MessageEventSender.class);
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(5)).thenReturn(existingScript);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(existingScript);
+                });
+             MockedConstruction<ServletInjector> injectorMock = Mockito.mockConstruction(ServletInjector.class,
+                (mock, ctx) -> {
+                    when(mock.getManagedBean(eq(servletContext), eq(ScriptProcessor.class))).thenReturn(mockProcessor);
+                    when(mock.getManagedBean(eq(servletContext), eq(MessageEventSender.class))).thenReturn(mockSender);
+                })) {
+
+            Map<String, String> result = service.createScript("Updated", 5, "recording", null, null, null, file);
+            assertNotNull(result);
+            assertTrue(result.get("message").contains("overwritten"));
+        }
+    }
+
+    // =====================================================================
+    // createScript - XML update path
+    // =====================================================================
+
+    @Test
+    void createScript_updatePath_updatesExistingScript() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream("<xml/>".getBytes(StandardCharsets.UTF_8)));
+
+        ScriptTO scriptTO = new ScriptTO();
+        Script parsedScript = createScript(5, "ExistingName");
+        Script existingScript = createScript(5, "ExistingName");
+        existingScript.setSerializedScriptStepId(99);
+
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> {
+                    when(mock.findById(5)).thenReturn(existingScript);
+                    when(mock.saveOrUpdate(any(Script.class))).thenReturn(parsedScript);
+                });
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.parseXMLtoScriptTO(any(InputStream.class))).thenReturn(scriptTO);
+            utilMock.when(() -> ScriptServiceUtil.transferObjectToScript(scriptTO)).thenReturn(parsedScript);
+
+            Map<String, String> result = service.createScript(null, null, null, null, null, null, file);
+            assertNotNull(result);
+            assertTrue(result.get("message").contains("updated successfully"));
+        }
+    }
+
+    // =====================================================================
+    // External Scripts
+    // =====================================================================
+
+    @Test
+    void getExternalScripts_returnsAll() {
+        ExternalScript es = new ExternalScript();
+        es.setName("ExtScript");
+        ExternalScriptTO to = new ExternalScriptTO();
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenReturn(List.of(es)));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.externalScriptToTO(es)).thenReturn(to);
+
+            ExternalScriptContainer result = service.getExternalScripts();
+            assertNotNull(result);
+            assertEquals(1, result.getScripts().size());
+        }
+    }
+
+    @Test
+    void getExternalScript_returnsScript() {
+        ExternalScript es = new ExternalScript();
+        ExternalScriptTO to = new ExternalScriptTO();
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(es));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.externalScriptToTO(es)).thenReturn(to);
+
+            ExternalScriptTO result = service.getExternalScript(1);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void getExternalScript_returnsNullWhenNotFound() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            ExternalScriptTO result = service.getExternalScript(999);
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void createExternalScript_savesAndReturns() {
+        ExternalScriptTO requestTO = new ExternalScriptTO();
+        ExternalScript entity = new ExternalScript();
+        ExternalScript saved = new ExternalScript();
+        saved.setName("Saved");
+        ExternalScriptTO resultTO = new ExternalScriptTO();
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.saveOrUpdate(any(ExternalScript.class))).thenReturn(saved));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.TOToExternalScript(requestTO)).thenReturn(entity);
+            utilMock.when(() -> ScriptServiceUtil.externalScriptToTO(saved)).thenReturn(resultTO);
+
+            ExternalScriptTO result = service.createExternalScript(requestTO);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void deleteExternalScript_deletesExisting() {
+        ExternalScript es = new ExternalScript();
+        es.setName("ToDelete");
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(es))) {
+
+            String result = service.deleteExternalScript(1);
+            assertEquals("", result);
+
+            ExternalScriptDao dao = daoMock.constructed().get(0);
+            verify(dao).delete(es);
+        }
+    }
+
+    @Test
+    void deleteExternalScript_returnsMessageWhenNotFound() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            String result = service.deleteExternalScript(999);
+            assertTrue(result.contains("does not exist"));
+        }
+    }
+
+    @Test
+    void deleteExternalScript_throwsOnError() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceDeleteException.class, () -> service.deleteExternalScript(1));
+        }
+    }
+
+    // =====================================================================
+    // downloadHarnessScript
+    // =====================================================================
+
+    @Test
+    void downloadHarnessScript_returnsNullWhenNotFound() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertNull(service.downloadHarnessScript(999));
+        }
+    }
+
+    // =====================================================================
+    // downloadExternalScript
+    // =====================================================================
+
+    @Test
+    void downloadExternalScript_returnsNullWhenNotFound() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(999)).thenReturn(null))) {
+
+            assertNull(service.downloadExternalScript(999));
+        }
+    }
+
+    @Test
+    void downloadExternalScript_returnsStreamWhenFound() {
+        ExternalScript es = new ExternalScript();
+        es.setName("MyExt");
+        es.setCreated(new java.util.Date());
+        es.setModified(new java.util.Date());
+        ExternalScriptTO to = ExternalScriptTO.builder().withId(1).withName("MyExt").build();
+        StreamingResponseBody body = mock(StreamingResponseBody.class);
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(es));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class);
+             MockedStatic<ResponseUtil> responseMock = Mockito.mockStatic(ResponseUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.externalScriptToTO(es)).thenReturn(to);
+            responseMock.when(() -> ResponseUtil.getXMLStream(to)).thenReturn(body);
+
+            Map<String, StreamingResponseBody> result = service.downloadExternalScript(1);
+            assertNotNull(result);
+            assertTrue(result.containsKey("MyExt_ETS.xml"));
+        }
+    }
+
+    // =====================================================================
+    // Error paths
+    // =====================================================================
+
+    @Test
+    void getScripts_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getScripts());
+        }
+    }
+
+    @Test
+    void getAllScriptNames_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getAllScriptNames());
+        }
+    }
+
+    @Test
+    void downloadScript_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.downloadScript(1));
+        }
+    }
+
+    @Test
+    void downloadHarnessScript_throwsOnError() {
+        try (MockedConstruction<ScriptDao> daoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.downloadHarnessScript(1));
+        }
+    }
+
+    @Test
+    void getExternalScripts_throwsOnError() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findAll()).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getExternalScripts());
+        }
+    }
+
+    @Test
+    void getExternalScript_throwsOnError() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.getExternalScript(1));
+        }
+    }
+
+    @Test
+    void createExternalScript_throwsOnError() {
+        ExternalScriptTO requestTO = new ExternalScriptTO();
+
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.saveOrUpdate(any(ExternalScript.class))).thenThrow(new RuntimeException("error")));
+             MockedStatic<ScriptServiceUtil> utilMock = Mockito.mockStatic(ScriptServiceUtil.class)) {
+            utilMock.when(() -> ScriptServiceUtil.TOToExternalScript(requestTO)).thenReturn(new ExternalScript());
+
+            assertThrows(GenericServiceCreateOrUpdateException.class, () -> service.createExternalScript(requestTO));
+        }
+    }
+
+    @Test
+    void downloadExternalScript_throwsOnError() {
+        try (MockedConstruction<ExternalScriptDao> daoMock = Mockito.mockConstruction(ExternalScriptDao.class,
+                (mock, ctx) -> when(mock.findById(anyInt())).thenThrow(new RuntimeException("error")))) {
+
+            assertThrows(GenericServiceResourceNotFoundException.class, () -> service.downloadExternalScript(1));
+        }
+    }
+
+    // =====================================================================
+    // Helper
+    // =====================================================================
+
+    private static Script createScript(int id, String name) {
+        Script script = new Script();
+        script.setId(id);
+        script.setName(name);
+        script.setCreated(new Date());
+        script.setModified(new Date());
+        return script;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/DataFileServiceUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/DataFileServiceUtilTest.java
@@ -1,0 +1,65 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.dao.DataFileDao;
+import com.intuit.tank.datafiles.models.DataFileDescriptor;
+import com.intuit.tank.project.DataFile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class DataFileServiceUtilTest {
+
+    @Test
+    void dataFileToDescriptor_convertsAllFields() {
+        DataFile df = new DataFile();
+        df.setId(5);
+        df.setPath("test-data.csv");
+        df.setCreator("admin");
+        df.setComments("test data");
+        df.setCreated(new Date());
+        df.setModified(new Date());
+
+        DataFileDescriptor desc = DataFileServiceUtil.dataFileToDescriptor(df);
+
+        assertEquals(5, desc.getId());
+        assertEquals("test-data.csv", desc.getName());
+        assertEquals("admin", desc.getCreator());
+        assertEquals("test data", desc.getComments());
+        assertNotNull(desc.getDataUrl());
+        assertTrue(desc.getDataUrl().contains("5"));
+    }
+
+    @Test
+    void descriptorToDataFile_convertsAllFields() {
+        DataFileDescriptor desc = DataFileDescriptor.builder()
+                .withId(3)
+                .withName("myfile.csv")
+                .withCreator("user")
+                .withComments("desc")
+                .withCreated(new Date())
+                .withModified(new Date())
+                .build();
+
+        DataFileDao dao = mock(DataFileDao.class);
+        DataFile df = DataFileServiceUtil.descriptorToDataFile(dao, desc);
+
+        assertEquals(3, df.getId());
+        assertEquals("myfile.csv", df.getPath());
+        assertEquals("user", df.getCreator());
+    }
+
+    @Test
+    void descriptorToDataFile_handlesNullId() {
+        DataFileDescriptor desc = DataFileDescriptor.builder()
+                .withName("noId.csv")
+                .build();
+
+        DataFileDao dao = mock(DataFileDao.class);
+        DataFile df = DataFileServiceUtil.descriptorToDataFile(dao, desc);
+
+        assertEquals(0, df.getId());
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/FileReaderTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/FileReaderTest.java
@@ -1,0 +1,95 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void getFileStreamingResponseBody_readsEntireFile() throws IOException {
+        File testFile = createTestFile("line1\nline2\nline3\n");
+        long total = testFile.length();
+
+        StreamingResponseBody body = FileReader.getFileStreamingResponseBody(testFile, total, "0");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        String content = out.toString(StandardCharsets.UTF_8);
+        assertTrue(content.contains("line1"));
+        assertTrue(content.contains("line3"));
+    }
+
+    @Test
+    void getFileStreamingResponseBody_readsFromOffset() throws IOException {
+        File testFile = createTestFile("AAAA\nBBBB\nCCCC\n");
+        long total = testFile.length();
+
+        // Start at offset 5 (after "AAAA\n")
+        StreamingResponseBody body = FileReader.getFileStreamingResponseBody(testFile, total, "5");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        String content = out.toString(StandardCharsets.UTF_8);
+        assertFalse(content.startsWith("AAAA"));
+        assertTrue(content.contains("BBBB"));
+    }
+
+    @Test
+    void getFileStreamingResponseBody_handlesNullStart() throws IOException {
+        File testFile = createTestFile("content\n");
+        long total = testFile.length();
+
+        StreamingResponseBody body = FileReader.getFileStreamingResponseBody(testFile, total, null);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("content"));
+    }
+
+    @Test
+    void getFileStreamingResponseBody_handlesInvalidStart() throws IOException {
+        File testFile = createTestFile("data\n");
+        long total = testFile.length();
+
+        // Invalid start string should default to 0
+        StreamingResponseBody body = FileReader.getFileStreamingResponseBody(testFile, total, "not-a-number");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("data"));
+    }
+
+    @Test
+    void getFileStreamingResponseBody_negativeStart_readsLastNLines() throws IOException {
+        File testFile = createTestFile("line1\nline2\nline3\nline4\nline5\n");
+        long total = testFile.length();
+
+        // -2 means get last 2 lines
+        StreamingResponseBody body = FileReader.getFileStreamingResponseBody(testFile, total, "-2");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+
+        String content = out.toString(StandardCharsets.UTF_8);
+        // Should contain at least the last lines
+        assertTrue(content.contains("line5") || content.contains("line4"));
+    }
+
+    private File createTestFile(String content) throws IOException {
+        Path file = tempDir.resolve("test.log");
+        Files.writeString(file, content);
+        return file.toFile();
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/FilterServiceUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/FilterServiceUtilTest.java
@@ -1,0 +1,40 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.filters.models.FilterGroupTO;
+import com.intuit.tank.filters.models.FilterTO;
+import com.intuit.tank.project.ScriptFilter;
+import com.intuit.tank.project.ScriptFilterGroup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilterServiceUtilTest {
+
+    @Test
+    void filterToTO_convertsAllFields() {
+        ScriptFilter filter = new ScriptFilter();
+        filter.setId(1);
+        filter.setName("MyFilter");
+        filter.setProductName("Product1");
+
+        FilterTO to = FilterServiceUtil.filterToTO(filter);
+
+        assertEquals(1, to.getId());
+        assertEquals("MyFilter", to.getName());
+        assertEquals("Product1", to.getProductName());
+    }
+
+    @Test
+    void filterGroupToTO_convertsAllFields() {
+        ScriptFilterGroup group = new ScriptFilterGroup();
+        group.setId(2);
+        group.setName("MyGroup");
+        group.setProductName("Product2");
+
+        FilterGroupTO to = FilterServiceUtil.filterGroupToTO(group);
+
+        assertEquals(2, to.getId());
+        assertEquals("MyGroup", to.getName());
+        assertEquals("Product2", to.getProductName());
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatterTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobDetailFormatterTest.java
@@ -1,0 +1,475 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.dao.DataFileDao;
+import com.intuit.tank.dao.JobNotificationDao;
+import com.intuit.tank.dao.JobRegionDao;
+import com.intuit.tank.project.*;
+import com.intuit.tank.vm.api.enumerated.IncrementStrategy;
+import com.intuit.tank.vm.api.enumerated.TerminationPolicy;
+import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vm.settings.AgentConfig;
+import com.intuit.tank.vm.settings.TankConfig;
+import com.intuit.tank.vm.settings.VmInstanceType;
+import com.intuit.tank.vm.settings.VmManagerConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JobDetailFormatterTest {
+
+    // =====================================================================
+    // estimateCost
+    // =====================================================================
+
+    @Test
+    void estimateCost_calculatesCorrectly() {
+        // 2 instances, $1.00/hr, 2 hours (7200000ms)
+        BigDecimal result = JobDetailFormatter.estimateCost(2, new BigDecimal("1.00"), 7200000L);
+        // 2 * 1.00 * 2 = 4.00, plus 1.5x = 4.00 + 6.00 = 10.00
+        assertEquals(new BigDecimal("10.000"), result.setScale(3));
+    }
+
+    @Test
+    void estimateCost_minimumOneHour() {
+        // Even with 0 time, minimum is 1 hour
+        BigDecimal result = JobDetailFormatter.estimateCost(1, new BigDecimal("0.50"), 0L);
+        // 1 * 0.50 * 1 = 0.50, plus 1.5x = 0.50 + 0.75 = 1.25
+        assertEquals(0, result.compareTo(new BigDecimal("1.25")));
+    }
+
+    @Test
+    void estimateCost_zeroInstances() {
+        BigDecimal result = JobDetailFormatter.estimateCost(0, new BigDecimal("1.00"), 3600000L);
+        assertEquals(0, BigDecimal.ZERO.compareTo(result));
+    }
+
+    // =====================================================================
+    // addProperty
+    // =====================================================================
+
+    @Test
+    void addProperty_addsKeyAndValue() {
+        StringBuilder sb = new StringBuilder();
+        JobDetailFormatter.addProperty(sb, "Name", "TestJob");
+        String result = sb.toString();
+        assertTrue(result.contains("Name"));
+        assertTrue(result.contains("TestJob"));
+        assertTrue(result.contains("<br/>"));
+    }
+
+    @Test
+    void addProperty_handlesNullValue() {
+        StringBuilder sb = new StringBuilder();
+        JobDetailFormatter.addProperty(sb, "Label", null);
+        String result = sb.toString();
+        assertTrue(result.contains("Label"));
+        assertTrue(result.contains("<br/>"));
+    }
+
+    @Test
+    void addProperty_replacesSpacesWithNbsp() {
+        StringBuilder sb = new StringBuilder();
+        JobDetailFormatter.addProperty(sb, "My Key", "val");
+        assertTrue(sb.toString().contains("My&nbsp;Key"));
+    }
+
+    // =====================================================================
+    // addError
+    // =====================================================================
+
+    @Test
+    void addError_formatsWithErrorSpan() {
+        StringBuilder sb = new StringBuilder();
+        JobDetailFormatter.addError(sb, "Something went wrong");
+        String result = sb.toString();
+        assertTrue(result.contains("class=\"error\""));
+        assertTrue(result.contains("Something went wrong"));
+        assertTrue(result.contains("</span>"));
+    }
+
+    // =====================================================================
+    // getSimulationTime
+    // =====================================================================
+
+    @Test
+    void getSimulationTime_returnsJobSimulationTime_whenNotScriptPolicy() {
+        JobInstance job = new JobInstance();
+        job.setSimulationTime(60000L);
+        job.setTerminationPolicy(TerminationPolicy.time);
+
+        Workload workload = new Workload();
+        JobValidator validator = mock(JobValidator.class);
+
+        long result = JobDetailFormatter.getSimulationTime(job, workload, validator);
+        assertEquals(60000L, result);
+    }
+
+    @Test
+    void getSimulationTime_calculatesFromTestPlans_whenScriptPolicy() {
+        JobInstance job = new JobInstance();
+        job.setSimulationTime(0L);
+        job.setTerminationPolicy(TerminationPolicy.script);
+
+        TestPlan tp1 = TestPlan.builder().name("Plan1").usersPercentage(50).build();
+        TestPlan tp2 = TestPlan.builder().name("Plan2").usersPercentage(50).build();
+        Workload workload = new Workload();
+        workload.addTestPlan(tp1);
+        workload.addTestPlan(tp2);
+
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getExpectedTime("Plan1")).thenReturn(30000L);
+        when(validator.getExpectedTime("Plan2")).thenReturn(50000L);
+
+        long result = JobDetailFormatter.getSimulationTime(job, workload, validator);
+        assertEquals(50000L, result); // max of the two
+    }
+
+    // =====================================================================
+    // createJobDetails with scriptName (simpler path)
+    // =====================================================================
+
+    // =====================================================================
+    // createJobDetails with proposedJobInstance - increasing workload
+    // =====================================================================
+
+    @Test
+    void createJobDetails_withJobInstance_increasingWorkload_returnsFullDetails() {
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getDeclaredVariables()).thenReturn(Collections.emptyMap());
+        when(validator.getUsedVariables()).thenReturn(Collections.emptySet());
+        when(validator.getBestPracticeViolations()).thenReturn(Collections.emptySet());
+        when(validator.getAssignments()).thenReturn(Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(false);
+        when(validator.getExpectedTime("MainPlan")).thenReturn(60000L);
+
+        Script script = new Script();
+        script.setId(1);
+        script.setName("TestScript");
+
+        ScriptGroupStep sgs = new ScriptGroupStep();
+        sgs.setScript(script);
+        sgs.setLoop(1);
+
+        ScriptGroup sg = new ScriptGroup();
+        sg.setName("Group1");
+        sg.setLoop(1);
+        sg.addScriptGroupStep(sgs);
+
+        TestPlan tp = TestPlan.builder().name("MainPlan").usersPercentage(100).build();
+        tp.addScriptGroup(sg);
+
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new JobConfiguration());
+        workload.addTestPlan(tp);
+
+        JobInstance job = new JobInstance();
+        job.setName("TestJob");
+        job.setCreator("admin");
+        job.setIncrementStrategy(IncrementStrategy.increasing);
+        job.setTerminationPolicy(TerminationPolicy.script);
+        job.setTotalVirtualUsers(100);
+        job.setNumUsersPerAgent(50);
+        job.setRampTime(10000L);
+        job.setSimulationTime(60000L);
+        job.setLocation("us-west-2");
+        job.setLoggingProfile("STANDARD");
+        job.setStopBehavior("END_OF_SCRIPT_GROUP");
+        job.setVmInstanceType("m5.large");
+        job.setUserIntervalIncrement(10);
+        job.setExecutionTime(60000L);
+
+        // Add a job region version
+        JobRegion region = new JobRegion(VMRegion.US_WEST_2, "100", "100");
+        region.setId(1);
+        job.getJobRegionVersions().add(new EntityVersion(1, 0, JobRegion.class));
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientName(anyString())).thenReturn("ApacheHttpClient");
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        VmInstanceType vmType = mock(VmInstanceType.class);
+        when(vmType.getName()).thenReturn("m5.large");
+        when(vmType.getCost()).thenReturn(0.096);
+        when(vmType.getCpus()).thenReturn(4);
+        when(vmType.getEcus()).thenReturn(8);
+        when(vmType.getMemory()).thenReturn(8.0);
+        when(mockVmConfig.getInstanceTypes()).thenReturn(List.of(vmType));
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> {
+                    when(mock.getAgentConfig()).thenReturn(mockAgentConfig);
+                    when(mock.getVmManagerConfig()).thenReturn(mockVmConfig);
+                    when(mock.getStandalone()).thenReturn(false);
+                });
+             MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(region));
+             MockedConstruction<DataFileDao> dfdMock = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> jndMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            String result = JobDetailFormatter.createJobDetails(validator, workload, job);
+
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertTrue(result.contains("TestJob"), "Expected 'TestJob' in: " + result.substring(0, Math.min(500, result.length())));
+            assertTrue(result.contains("admin"));
+            assertTrue(result.contains("Linear"));
+            assertTrue(result.contains("Variable&nbsp;Validation"));
+        }
+    }
+
+    @Test
+    void createJobDetails_withJobInstance_blankName_showsError() {
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getDeclaredVariables()).thenReturn(Collections.emptyMap());
+        when(validator.getUsedVariables()).thenReturn(Collections.emptySet());
+        when(validator.getBestPracticeViolations()).thenReturn(Collections.emptySet());
+        when(validator.getAssignments()).thenReturn(Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(false);
+        when(validator.getExpectedTime(anyString())).thenReturn(0L);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new JobConfiguration());
+        workload.addTestPlan(tp);
+
+        JobInstance job = new JobInstance();
+        job.setName(""); // blank name triggers error
+        job.setIncrementStrategy(IncrementStrategy.increasing);
+        job.setTerminationPolicy(TerminationPolicy.time);
+        job.setSimulationTime(0L); // 0 + time termination triggers error
+        job.setExecutionTime(0L);
+        job.setVmInstanceType("m5.large");
+        job.setStopBehavior("END_OF_SCRIPT_GROUP");
+        job.setLoggingProfile("STANDARD");
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientName(anyString())).thenReturn("Client");
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        when(mockVmConfig.getInstanceTypes()).thenReturn(Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> {
+                    when(mock.getAgentConfig()).thenReturn(mockAgentConfig);
+                    when(mock.getVmManagerConfig()).thenReturn(mockVmConfig);
+                    when(mock.getStandalone()).thenReturn(false);
+                });
+             MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class);
+             MockedConstruction<DataFileDao> dfdMock = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> jndMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            String result = JobDetailFormatter.createJobDetails(validator, workload, job);
+
+            assertNotNull(result);
+            assertTrue(result.contains("ERRORS"));
+            assertTrue(result.contains("Name cannot be null"));
+            assertTrue(result.contains("Simulation time not set"));
+            assertTrue(result.contains("No users defined"));
+            assertTrue(result.contains("No scripts defined"));
+        }
+    }
+
+    @Test
+    void createJobDetails_withJobInstance_standardWorkload_showsRegions() {
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getDeclaredVariables()).thenReturn(Collections.emptyMap());
+        when(validator.getUsedVariables()).thenReturn(Collections.emptySet());
+        when(validator.getBestPracticeViolations()).thenReturn(Collections.emptySet());
+        when(validator.getAssignments()).thenReturn(Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(false);
+        when(validator.getExpectedTime(anyString())).thenReturn(0L);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new JobConfiguration());
+        workload.addTestPlan(tp);
+
+        JobInstance job = new JobInstance();
+        job.setName("NonlinearJob");
+        job.setCreator("admin");
+        job.setIncrementStrategy(IncrementStrategy.standard);
+        job.setTerminationPolicy(TerminationPolicy.script);
+        job.setTargetRampRate(10.0);
+        job.setTargetRatePerAgent(5.0);
+        job.setNumAgents(2);
+        job.setRampTime(5000L);
+        job.setSimulationTime(30000L);
+        job.setExecutionTime(30000L);
+        job.setVmInstanceType("m5.large");
+        job.setStopBehavior("END_OF_SCRIPT_GROUP");
+        job.setLoggingProfile("STANDARD");
+        job.setLocation("us-west-2");
+
+        JobRegion region = new JobRegion(VMRegion.US_WEST_2, "0", "100");
+        region.setId(1);
+        job.getJobRegionVersions().add(new EntityVersion(1, 0, JobRegion.class));
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientName(anyString())).thenReturn("Client");
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        when(mockVmConfig.getInstanceTypes()).thenReturn(Collections.emptyList());
+        when(mockVmConfig.getRegions()).thenReturn(Collections.emptySet());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> {
+                    when(mock.getAgentConfig()).thenReturn(mockAgentConfig);
+                    when(mock.getVmManagerConfig()).thenReturn(mockVmConfig);
+                    when(mock.getStandalone()).thenReturn(false);
+                });
+             MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(region));
+             MockedConstruction<DataFileDao> dfdMock = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> jndMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            String result = JobDetailFormatter.createJobDetails(validator, workload, job);
+
+            assertNotNull(result);
+            assertTrue(result.contains("NonlinearJob"));
+            assertTrue(result.contains("Nonlinear"));
+            assertTrue(result.contains("Regions"));
+        }
+    }
+
+    @Test
+    void createJobDetails_withVariablesAndDataFiles() {
+        JobValidator validator = mock(JobValidator.class);
+        Map<String, Set<String>> declaredVars = new HashMap<>();
+        declaredVars.put("server", Set.of("project:: example.com"));
+        when(validator.getDeclaredVariables()).thenReturn(declaredVars);
+        when(validator.getUsedVariables()).thenReturn(Set.of("server", "orphanedVar"));
+        when(validator.isOrphaned("orphanedVar")).thenReturn(true);
+        when(validator.isSuperfluous("server")).thenReturn(false);
+        when(validator.getBestPracticeViolations()).thenReturn(Set.of("No Logging Keys"));
+        when(validator.getAssignments()).thenReturn(Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(true);
+        when(validator.getExpectedTime(anyString())).thenReturn(0L);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new JobConfiguration());
+        workload.addTestPlan(tp);
+
+        JobInstance job = new JobInstance();
+        job.setName("VarJob");
+        job.setIncrementStrategy(IncrementStrategy.increasing);
+        job.setTerminationPolicy(TerminationPolicy.script);
+        job.setTotalVirtualUsers(10);
+        job.setNumUsersPerAgent(10);
+        job.setExecutionTime(0L);
+        job.setVmInstanceType("m5.large");
+        job.setStopBehavior("END_OF_SCRIPT_GROUP");
+        job.setLoggingProfile("STANDARD");
+        job.getVariables().put("server", "example.com");
+        job.getVariables().put("dataFile", "users.csv");
+
+        // Add data file version
+        DataFile df = new DataFile();
+        df.setId(5);
+        df.setPath("users.csv");
+        job.getDataFileVersions().add(new EntityVersion(5, 0, DataFile.class));
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientName(anyString())).thenReturn("Client");
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        when(mockVmConfig.getInstanceTypes()).thenReturn(Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> {
+                    when(mock.getAgentConfig()).thenReturn(mockAgentConfig);
+                    when(mock.getVmManagerConfig()).thenReturn(mockVmConfig);
+                    when(mock.getStandalone()).thenReturn(false);
+                });
+             MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class);
+             MockedConstruction<DataFileDao> dfdMock = Mockito.mockConstruction(DataFileDao.class,
+                (mock, ctx) -> when(mock.findById(5)).thenReturn(df));
+             MockedConstruction<JobNotificationDao> jndMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            String result = JobDetailFormatter.createJobDetails(validator, workload, job);
+
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertTrue(result.contains("Data&nbsp;Files"));
+            assertTrue(result.contains("users.csv"));
+            assertTrue(result.contains("Global&nbsp;Variables"));
+            assertTrue(result.contains("Variable&nbsp;Validation"));
+            assertTrue(result.contains("Best&nbsp;Practice&nbsp;Violations"));
+        }
+    }
+
+    @Test
+    void createJobDetails_withStandaloneConfig_showsUsersInsteadOfRegion() {
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getDeclaredVariables()).thenReturn(Collections.emptyMap());
+        when(validator.getUsedVariables()).thenReturn(Collections.emptySet());
+        when(validator.getBestPracticeViolations()).thenReturn(Collections.emptySet());
+        when(validator.getAssignments()).thenReturn(Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(false);
+        when(validator.getExpectedTime(anyString())).thenReturn(0L);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new JobConfiguration());
+        workload.addTestPlan(tp);
+
+        JobInstance job = new JobInstance();
+        job.setName("StandaloneJob");
+        job.setIncrementStrategy(IncrementStrategy.increasing);
+        job.setTerminationPolicy(TerminationPolicy.script);
+        job.setTotalVirtualUsers(50);
+        job.setNumUsersPerAgent(50);
+        job.setExecutionTime(0L);
+        job.setVmInstanceType("m5.large");
+        job.setStopBehavior("END_OF_SCRIPT_GROUP");
+        job.setLoggingProfile("STANDARD");
+
+        JobRegion region = new JobRegion(VMRegion.US_WEST_2, "50", "100");
+        region.setId(1);
+        job.getJobRegionVersions().add(new EntityVersion(1, 0, JobRegion.class));
+
+        AgentConfig mockAgentConfig = mock(AgentConfig.class);
+        when(mockAgentConfig.getTankClientName(anyString())).thenReturn("Client");
+        VmManagerConfig mockVmConfig = mock(VmManagerConfig.class);
+        when(mockVmConfig.getInstanceTypes()).thenReturn(Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                (mock, ctx) -> {
+                    when(mock.getAgentConfig()).thenReturn(mockAgentConfig);
+                    when(mock.getVmManagerConfig()).thenReturn(mockVmConfig);
+                    when(mock.getStandalone()).thenReturn(true); // standalone mode
+                });
+             MockedConstruction<JobRegionDao> jrdMock = Mockito.mockConstruction(JobRegionDao.class,
+                (mock, ctx) -> when(mock.findById(1)).thenReturn(region));
+             MockedConstruction<DataFileDao> dfdMock = Mockito.mockConstruction(DataFileDao.class);
+             MockedConstruction<JobNotificationDao> jndMock = Mockito.mockConstruction(JobNotificationDao.class)) {
+
+            String result = JobDetailFormatter.createJobDetails(validator, workload, job);
+
+            assertNotNull(result);
+            assertTrue(result.contains("Users")); // Standalone shows "Users" instead of region name
+        }
+    }
+
+    @Test
+    void createJobDetails_withScriptName_returnsDetails() {
+        JobValidator validator = mock(JobValidator.class);
+        when(validator.getDuration("MyScript")).thenReturn("00:01:30");
+        when(validator.getDeclaredVariables()).thenReturn(java.util.Collections.emptyMap());
+        when(validator.getUsedVariables()).thenReturn(java.util.Collections.emptySet());
+        when(validator.getBestPracticeViolations()).thenReturn(java.util.Collections.emptySet());
+        when(validator.getAssignments()).thenReturn(java.util.Collections.emptyMap());
+        when(validator.isProcessAssignements()).thenReturn(false);
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            String result = JobDetailFormatter.createJobDetails(validator, "MyScript");
+            assertNotNull(result);
+            assertTrue(result.contains("MyScript"));
+            assertTrue(result.contains("Estimated Time"));
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobServiceUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobServiceUtilTest.java
@@ -1,0 +1,37 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.jobs.models.JobTO;
+import com.intuit.tank.project.JobInstance;
+import com.intuit.tank.vm.api.enumerated.JobQueueStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobServiceUtilTest {
+
+    @Test
+    void jobToTO_convertsAllFields() {
+        JobInstance job = new JobInstance();
+        job.setId(42);
+        job.setName("LoadTest1");
+        job.setLocation("us-west-2");
+        job.setStatus(JobQueueStatus.Running);
+        job.setTotalVirtualUsers(1000);
+        job.setRampTime(60000L);
+        job.setSimulationTime(300000L);
+        job.setStartTime(new Date());
+        job.setEndTime(new Date());
+
+        JobTO to = JobServiceUtil.jobToTO(job);
+
+        assertEquals(42, to.getId());
+        assertEquals("LoadTest1", to.getName());
+        assertEquals("us-west-2", to.getLocation());
+        assertEquals("Running", to.getStatus());
+        assertEquals(1000, to.getNumUsers());
+        assertEquals(60000L, to.getRampTimeMilis());
+        assertEquals(300000L, to.getSimulationTimeMilis());
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobValidatorTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/JobValidatorTest.java
@@ -1,0 +1,200 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.dao.ScriptDao;
+import com.intuit.tank.project.*;
+import com.intuit.tank.vm.settings.TankConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class JobValidatorTest {
+
+    // =====================================================================
+    // Constructor with Script
+    // =====================================================================
+
+    @Test
+    void constructorWithScript_processesEmptyScript() {
+        Script script = createScript(1, "EmptyScript", Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            JobValidator validator = new JobValidator(script);
+
+            assertTrue(validator.getDeclaredVariables().isEmpty());
+            assertTrue(validator.getUsedVariables().isEmpty());
+            assertTrue(validator.getOrphanedVariables().isEmpty());
+            assertTrue(validator.getSuperfluousVariables().isEmpty());
+            assertTrue(validator.isProcessAssignements());
+            // No logging keys → violation
+            assertTrue(validator.getBestPracticeViolations().stream()
+                    .anyMatch(v -> v.contains("No Logging Keys")));
+        }
+    }
+
+    @Test
+    void constructorWithScript_processesStepsWithLoggingKey() {
+        ScriptStep step = new ScriptStep();
+        step.setType("request");
+        step.setLoggingKey("login_page");
+
+        Script script = createScript(1, "WithLogging", List.of(step));
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            JobValidator validator = new JobValidator(script);
+
+            // Has logging keys, so no "No Logging Keys" violation
+            assertTrue(validator.getBestPracticeViolations().stream()
+                    .noneMatch(v -> v.contains("No Logging Keys")));
+        }
+    }
+
+    // =====================================================================
+    // Constructor with TestPlans
+    // =====================================================================
+
+    @Test
+    void constructorWithTestPlans_extractsAndProcessesScripts() {
+        Script script = createScript(10, "TestScript", Collections.emptyList());
+        ScriptGroupStep sgs = new ScriptGroupStep();
+        sgs.setScript(script);
+        sgs.setLoop(1);
+
+        ScriptGroup sg = new ScriptGroup();
+        sg.setName("Group1");
+        sg.setLoop(1);
+        sg.addScriptGroupStep(sgs);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        tp.addScriptGroup(sg);
+
+        try (MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.loadScriptSteps(any(Script.class))).thenReturn(script));
+             MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+
+            Map<String, String> globals = new HashMap<>();
+            globals.put("server", "example.com");
+
+            JobValidator validator = new JobValidator(List.of(tp), globals);
+
+            // Global variable should be in declared variables
+            assertTrue(validator.getDeclaredVariables().containsKey("server"));
+            // Global variables used nowhere → superfluous
+            assertTrue(validator.getSuperfluousVariables().contains("server"));
+        }
+    }
+
+    @Test
+    void constructorWithTestPlans_multipliesLoopCounts() {
+        ScriptStep step = new ScriptStep();
+        step.setType("thinkTime");
+        step.setLoggingKey("key");
+
+        Script script = createScript(10, "LoopScript", List.of(step));
+        ScriptGroupStep sgs = new ScriptGroupStep();
+        sgs.setScript(script);
+        sgs.setLoop(3);
+
+        ScriptGroup sg = new ScriptGroup();
+        sg.setName("Group1");
+        sg.setLoop(2);
+        sg.addScriptGroupStep(sgs);
+
+        TestPlan tp = TestPlan.builder().name("Plan1").usersPercentage(100).build();
+        tp.addScriptGroup(sg);
+
+        try (MockedConstruction<ScriptDao> scriptDaoMock = Mockito.mockConstruction(ScriptDao.class,
+                (mock, ctx) -> when(mock.loadScriptSteps(any(Script.class))).thenReturn(script));
+             MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+
+            JobValidator validator = new JobValidator(List.of(tp), new HashMap<>());
+
+            // Duration should exist for the plan - loop is 2*3=6
+            long duration = validator.getDurationMs("Plan1");
+            // Should be non-negative (exact value depends on step duration)
+            assertTrue(duration >= 0);
+        }
+    }
+
+    // =====================================================================
+    // getDurationMs / getDuration
+    // =====================================================================
+
+    @Test
+    void getDurationMs_returnsZeroForUnknownGroup() {
+        Script script = createScript(1, "S", Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            JobValidator validator = new JobValidator(script);
+
+            assertEquals(0L, validator.getDurationMs("nonexistent"));
+            assertNotNull(validator.getDuration("nonexistent"));
+        }
+    }
+
+    // =====================================================================
+    // Best practice violations
+    // =====================================================================
+
+    @Test
+    void bestPracticeViolation_variableDeclaredAfterRequest() {
+        ScriptStep requestStep = new ScriptStep();
+        requestStep.setType("request");
+        requestStep.setLoggingKey("page");
+
+        ScriptStep varStep = new ScriptStep();
+        varStep.setType("variable");
+        varStep.setStepIndex(2);
+        Set<RequestData> data = new HashSet<>();
+        RequestData rd = new RequestData();
+        rd.setKey("myVar");
+        rd.setValue("val");
+        data.add(rd);
+        varStep.setData(data);
+
+        Script script = createScript(1, "VarAfterRequest", List.of(requestStep, varStep));
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            JobValidator validator = new JobValidator(script);
+
+            assertTrue(validator.getBestPracticeViolations().stream()
+                    .anyMatch(v -> v.contains("Declare variables before request")));
+        }
+    }
+
+    // =====================================================================
+    // isOrphaned / isSuperfluous
+    // =====================================================================
+
+    @Test
+    void isOrphaned_returnsTrueForUndeclaredUsedVariable() {
+        // A step that uses a variable but doesn't declare it
+        Script script = createScript(1, "S", Collections.emptyList());
+
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class)) {
+            JobValidator validator = new JobValidator(script);
+
+            // With an empty script, there are no orphaned vars
+            assertFalse(validator.isOrphaned("someVar"));
+        }
+    }
+
+    // =====================================================================
+    // Helper
+    // =====================================================================
+
+    private static Script createScript(int id, String name, List<ScriptStep> steps) {
+        Script script = new Script();
+        script.setId(id);
+        script.setName(name);
+        script.setCreated(new Date());
+        script.setModified(new Date());
+        script.setScriptSteps(new ArrayList<>(steps));
+        return script;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ProjectServiceUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ProjectServiceUtilTest.java
@@ -1,0 +1,135 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.project.*;
+import com.intuit.tank.projects.models.ProjectTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectServiceUtilTest {
+
+    @Test
+    void projectToTransferObject_convertsBasicFields() {
+        Project project = createProject(1, "TestProject", "System");
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+
+        assertEquals(1, to.getId());
+        assertEquals("TestProject", to.getName());
+        assertEquals("System", to.getCreator());
+    }
+
+    @Test
+    void projectToTransferObject_convertsJobConfiguration() {
+        Project project = createProject(2, "Configured", "admin");
+        JobConfiguration config = project.getWorkloads().get(0).getJobConfiguration();
+        config.setRampTimeExpression("60s");
+        config.setSimulationTimeExpression("300s");
+        config.setStopBehavior("END_OF_SCRIPT_GROUP");
+        config.setLocation("us-west-2");
+        config.setUserIntervalIncrement(5);
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+
+        assertEquals("60s", to.getRampTime());
+        assertEquals("END_OF_SCRIPT_GROUP", to.getStopBehavior());
+        assertEquals("us-west-2", to.getLocation());
+        assertEquals(5, to.getUserIntervalIncrement());
+    }
+
+    @Test
+    void projectToTransferObject_convertsTestPlans() {
+        Project project = createProject(3, "WithPlans", "user");
+        Workload workload = project.getWorkloads().get(0);
+
+        // Add a script group to the test plan
+        Script script = new Script();
+        script.setId(10);
+        script.setName("LoginScript");
+
+        ScriptGroupStep sgs = new ScriptGroupStep();
+        sgs.setScript(script);
+        sgs.setLoop(2);
+
+        ScriptGroup sg = new ScriptGroup();
+        sg.setName("LoginGroup");
+        sg.setLoop(1);
+        sg.addScriptGroupStep(sgs);
+
+        workload.getTestPlans().get(0).addScriptGroup(sg);
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+
+        assertNotNull(to.getTestPlans());
+        assertFalse(to.getTestPlans().isEmpty());
+        assertEquals("Main", to.getTestPlans().get(0).getName());
+        assertEquals(1, to.getTestPlans().get(0).getScriptGroups().size());
+        assertEquals("LoginGroup", to.getTestPlans().get(0).getScriptGroups().get(0).getName());
+        assertEquals(10, to.getTestPlans().get(0).getScriptGroups().get(0).getScripts().get(0).getScriptId());
+    }
+
+    @Test
+    void projectToTransferObject_convertsVariables() {
+        Project project = createProject(4, "WithVars", "admin");
+        JobConfiguration config = project.getWorkloads().get(0).getJobConfiguration();
+        config.getVariables().put("env", "staging");
+        config.getVariables().put("timeout", "30");
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+
+        assertNotNull(to.getVariables());
+        assertEquals(2, to.getVariables().size());
+    }
+
+    @Test
+    void projectToTransferObject_convertsDataFileIds() {
+        Project project = createProject(5, "WithDataFiles", "admin");
+        JobConfiguration config = project.getWorkloads().get(0).getJobConfiguration();
+        config.setDataFileIds(Set.of(1, 2, 3));
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+
+        assertNotNull(to.getDataFileIds());
+        assertEquals(3, to.getDataFileIds().size());
+    }
+
+    @Test
+    void projectToTransferObject_handlesEmptyTestPlans() {
+        Project project = createProject(6, "NoPlans", "admin");
+        project.getWorkloads().get(0).getTestPlans().clear();
+
+        ProjectTO to = ProjectServiceUtil.projectToTransferObject(project);
+        assertTrue(to.getTestPlans() == null || to.getTestPlans().isEmpty());
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private static Project createProject(int id, String name, String creator) {
+        Project p = new Project();
+        p.setId(id);
+        p.setName(name);
+        p.setCreator(creator);
+        p.setCreated(new Date());
+        p.setModified(new Date());
+
+        Workload workload = new Workload();
+        workload.setName(name);
+        JobConfiguration jc = new JobConfiguration();
+        workload.setJobConfiguration(jc);
+        jc.setParent(workload);
+
+        TestPlan tp = TestPlan.builder().name("Main").usersPercentage(100).build();
+        workload.addTestPlan(tp);
+
+        List<Workload> workloads = new ArrayList<>();
+        workloads.add(workload);
+        p.setWorkloads(workloads);
+        workload.setParent(p);
+
+        return p;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ResponseUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ResponseUtilTest.java
@@ -1,0 +1,41 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Subsegment;
+import com.intuit.tank.script.models.ScriptTO;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+
+class ResponseUtilTest {
+
+    @Test
+    void getXMLStream_returnsNonNullStreamingBody() {
+        StreamingResponseBody body = ResponseUtil.getXMLStream(new ScriptTO());
+        assertNotNull(body);
+    }
+
+    @Test
+    void getXMLStream_marshalsScriptTOToXml() throws Exception {
+        Subsegment mockSubsegment = mock(Subsegment.class);
+
+        try (MockedStatic<AWSXRay> xrayMock = Mockito.mockStatic(AWSXRay.class)) {
+            xrayMock.when(() -> AWSXRay.beginSubsegment(anyString())).thenReturn(mockSubsegment);
+
+            StreamingResponseBody body = ResponseUtil.getXMLStream(new ScriptTO());
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            body.writeTo(out);
+
+            String xml = out.toString("UTF-8");
+            assertNotNull(xml);
+            assertTrue(xml.contains("<?xml"));
+        }
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ScriptFilterUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ScriptFilterUtilTest.java
@@ -1,0 +1,726 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.project.*;
+import com.intuit.tank.util.ScriptFilterType;
+import com.intuit.tank.vm.api.enumerated.ScriptFilterActionType;
+import com.intuit.tank.vm.script.util.AddActionScope;
+import com.intuit.tank.vm.script.util.RemoveActionScope;
+import com.intuit.tank.vm.script.util.ReplaceActionScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScriptFilterUtilTest {
+
+    // =====================================================================
+    // applyFilter - Remove request action
+    // =====================================================================
+
+    @Test
+    void applyFilter_removeRequest_removesMatchingStep() {
+        ScriptStep step = createRequestStep("example.com", "/api/test");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.request.getValue(), null, null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(steps.isEmpty());
+    }
+
+    @Test
+    void applyFilter_removeRequest_keepsNonMatchingStep() {
+        ScriptStep step = createRequestStep("other.com", "/api/test");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.request.getValue(), null, null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals(1, steps.size());
+    }
+
+    // =====================================================================
+    // applyFilter - Replace actions
+    // =====================================================================
+
+    @Test
+    void applyFilter_replacePath_updatesPath() {
+        ScriptStep step = createRequestStep("example.com", "/old/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.path.getValue(), null, "/new/path"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("/new/path", step.getSimplePath());
+    }
+
+    @Test
+    void applyFilter_replaceHost_updatesHostname() {
+        ScriptStep step = createRequestStep("old.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "old.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.host.getValue(), null, "new.com"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("new.com", step.getHostname());
+    }
+
+    @Test
+    void applyFilter_replaceOnFail_updatesOnFail() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.onfail.getValue(), null, "abort"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("abort", step.getOnFail());
+    }
+
+    // =====================================================================
+    // applyFilter - Add actions
+    // =====================================================================
+
+    @Test
+    void applyFilter_addRequestHeader_addsHeader() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.requestHeader.getValue(), "Authorization", "Bearer token123"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getRequestheaders().stream()
+                .anyMatch(rd -> rd.getKey().equals("Authorization") && rd.getValue().equals("Bearer token123")));
+    }
+
+    @Test
+    void applyFilter_addRequestCookie_addsCookie() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.requestCookie.getValue(), "session", "abc123"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getRequestCookies().stream()
+                .anyMatch(rd -> rd.getKey().equals("session")));
+    }
+
+    @Test
+    void applyFilter_addThinkTime_insertsThinkTimeStep() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.thinkTime.getValue(), null, "1000,5000"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals(2, steps.size());
+        assertEquals("thinkTime", steps.get(1).getType());
+    }
+
+    @Test
+    void applyFilter_addSleepTime_insertsSleepStep() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.sleepTime.getValue(), null, "2000"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals(2, steps.size());
+        assertEquals("sleep", steps.get(1).getType());
+    }
+
+    // =====================================================================
+    // Condition types
+    // =====================================================================
+
+    @Test
+    void applyFilter_conditionMatches_usesRegex() {
+        ScriptStep step = createRequestStep("api.example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Matches", "api\\.example\\.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.host.getValue(), null, "new.com"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("new.com", step.getHostname());
+    }
+
+    @Test
+    void applyFilter_conditionDoesNotContain_excludesMatching() {
+        ScriptStep step1 = createRequestStep("example.com", "/path");
+        ScriptStep step2 = createRequestStep("other.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step1, step2));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Does not contain", "example"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.request.getValue(), null, null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals(1, steps.size());
+        assertEquals("example.com", steps.get(0).getHostname());
+    }
+
+    @Test
+    void applyFilter_conditionStartsWith_matchesPrefix() {
+        ScriptStep step = createRequestStep("example.com", "/api/v2/test");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Path", "Starts with", "/api/v2"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.path.getValue(), null, "/api/v3/test"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("/api/v3/test", step.getSimplePath());
+    }
+
+    // =====================================================================
+    // allConditionsMustPass
+    // =====================================================================
+
+    @Test
+    void applyFilter_allConditionsMustPass_requiresAllTrue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilterCondition c1 = createCondition("Hostname", "Contains", "example.com");
+        ScriptFilterCondition c2 = createCondition("Path", "Contains", "/other"); // won't match
+
+        ScriptFilter filter = new ScriptFilter();
+        filter.setFilterType(ScriptFilterType.INTERNAL);
+        filter.setAllConditionsMustPass(true);
+        filter.getConditions().add(c1);
+        filter.getConditions().add(c2);
+        filter.getActions().add(createAction(ScriptFilterActionType.remove, RemoveActionScope.request.getValue(), null, null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        // Should NOT be removed because second condition doesn't match
+        assertEquals(1, steps.size());
+    }
+
+    // =====================================================================
+    // filterOnFieldSets
+    // =====================================================================
+
+    @Test
+    void filterOnFieldSets_matchesOnPayload() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        step.setPayload("some body content with key=value");
+
+        ScriptFilterCondition condition = createCondition("Post Data", "Contains", "key=value");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(
+                step.getPostDatas(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    @Test
+    void filterOnFieldSets_returnsFalse_whenFieldsNull_andNoPayload() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        ScriptFilterCondition condition = createCondition("Post Data", "Contains", "anything");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(null, condition, step, List.of(step));
+        assertFalse(result);
+    }
+
+    // =====================================================================
+    // Remove actions on specific scopes
+    // =====================================================================
+
+    @Test
+    void applyFilter_removeQueryString_removesMatchingKey() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData qs = new RequestData();
+        qs.setKey("debug");
+        qs.setValue("true");
+        step.setQueryStrings(new HashSet<>(Set.of(qs)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.queryString.getValue(), "debug", null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getQueryStrings().isEmpty());
+    }
+
+    // =====================================================================
+    // Replace actions on specific scopes
+    // =====================================================================
+
+    @Test
+    void applyFilter_replaceRequestHeader_updatesValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData header = new RequestData();
+        header.setKey("Authorization");
+        header.setValue("old-token");
+        step.setRequestheaders(new HashSet<>(Set.of(header)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.requestHeader.getValue(), "Authorization", "new-token"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("new-token", header.getValue());
+    }
+
+    @Test
+    void applyFilter_replaceRequestCookie_updatesValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData cookie = new RequestData();
+        cookie.setKey("session");
+        cookie.setValue("old-session");
+        step.setRequestCookies(new HashSet<>(Set.of(cookie)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.requestCookie.getValue(), "session", "new-session"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("new-session", cookie.getValue());
+    }
+
+    @Test
+    void applyFilter_replaceQueryString_updatesValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData qs = new RequestData();
+        qs.setKey("page");
+        qs.setValue("1");
+        step.setQueryStrings(new HashSet<>(Set.of(qs)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.queryString.getValue(), "page", "2"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("2", qs.getValue());
+    }
+
+    @Test
+    void applyFilter_replacePostData_updatesValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData pd = new RequestData();
+        pd.setKey("username");
+        pd.setValue("oldUser");
+        step.setPostDatas(new HashSet<>(Set.of(pd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.postData.getValue(), "username", "newUser"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("newUser", pd.getValue());
+    }
+
+    @Test
+    void applyFilter_replaceValidation_updatesTypeAndValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("status");
+        rd.setValue("200");
+        rd.setType("bodyValidation");
+        step.setResponseData(new HashSet<>(Set.of(rd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.validation.getValue(), "status", "201"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("201", rd.getValue());
+        assertEquals("bodyValidation", rd.getType());
+    }
+
+    @Test
+    void applyFilter_replaceAssignment_updatesTypeAndValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("token");
+        rd.setValue("=oldAssignment");
+        rd.setType("bodyAssignment");
+        step.setResponseData(new HashSet<>(Set.of(rd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.assignment.getValue(), "token", "=newAssignment"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("=newAssignment", rd.getValue());
+        assertEquals("bodyAssignment", rd.getType());
+    }
+
+    @Test
+    void applyFilter_replaceResponseData_updatesTypeBasedOnValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("field");
+        rd.setValue("oldVal");
+        step.setResponseData(new HashSet<>(Set.of(rd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, "responseData", "field", "=assignment"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("=assignment", rd.getValue());
+        assertEquals("bodyAssignment", rd.getType());
+    }
+
+    @Test
+    void applyFilter_replaceResponseData_validationType() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("body");
+        rd.setValue("old");
+        step.setResponseData(new HashSet<>(Set.of(rd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, "responseData", "body", "==equality"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("==equality", rd.getValue());
+        assertEquals("bodyValidation", rd.getType()); // starts with == so it's validation
+    }
+
+    // =====================================================================
+    // Add actions on specific scopes
+    // =====================================================================
+
+    @Test
+    void applyFilter_addQueryString_addsEntry() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.queryString.getValue(), "newParam", "value"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getQueryStrings().stream().anyMatch(rd -> "newParam".equals(rd.getKey())));
+    }
+
+    @Test
+    void applyFilter_addPostData_addsEntry() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.postData.getValue(), "field", "value"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getPostDatas().stream().anyMatch(rd -> "field".equals(rd.getKey())));
+    }
+
+    @Test
+    void applyFilter_addResponseData_addsEntry() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.responseData.getValue(), "check", "expectedVal"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getResponseData().stream().anyMatch(rd -> "check".equals(rd.getKey())));
+    }
+
+    @Test
+    void applyFilter_addValidation_addsBodyValidation() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.validation.getValue(), "status", "200"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getResponseData().stream()
+                .anyMatch(rd -> "status".equals(rd.getKey()) && "bodyValidation".equals(rd.getType())));
+    }
+
+    @Test
+    void applyFilter_addAssignment_addsBodyAssignment() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.add, AddActionScope.assignment.getValue(), "token", "=extractToken"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getResponseData().stream()
+                .anyMatch(rd -> "token".equals(rd.getKey()) && "bodyAssignment".equals(rd.getType())));
+    }
+
+    // =====================================================================
+    // Remove actions on additional scopes
+    // =====================================================================
+
+    @Test
+    void applyFilter_removeRequestCookie_removesMatchingKey() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData cookie = new RequestData();
+        cookie.setKey("session");
+        cookie.setValue("abc");
+        step.setRequestCookies(new HashSet<>(Set.of(cookie)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.requestCookie.getValue(), "session", null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getRequestCookies().isEmpty());
+    }
+
+    @Test
+    void applyFilter_removeRequestHeader_removesMatchingKey() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData header = new RequestData();
+        header.setKey("X-Custom");
+        header.setValue("val");
+        step.setRequestheaders(new HashSet<>(Set.of(header)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.requestHeader.getValue(), "X-Custom", null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getRequestheaders().isEmpty());
+    }
+
+    @Test
+    void applyFilter_removePostData_removesMatchingKey() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData pd = new RequestData();
+        pd.setKey("field");
+        pd.setValue("val");
+        step.setPostDatas(new HashSet<>(Set.of(pd)));
+
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.remove, RemoveActionScope.postData.getValue(), "field", null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertTrue(step.getPostDatas().isEmpty());
+    }
+
+    // =====================================================================
+    // Condition - allConditionsMustPass = false (OR mode)
+    // =====================================================================
+
+    @Test
+    void applyFilter_anyConditionPasses_matchesOnFirst() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilterCondition c1 = createCondition("Hostname", "Contains", "example.com");
+        ScriptFilterCondition c2 = createCondition("Path", "Contains", "/other"); // won't match
+
+        ScriptFilter filter = new ScriptFilter();
+        filter.setFilterType(ScriptFilterType.INTERNAL);
+        filter.setAllConditionsMustPass(false); // OR mode
+        filter.getConditions().add(c1);
+        filter.getConditions().add(c2);
+        filter.getActions().add(createAction(ScriptFilterActionType.remove, RemoveActionScope.request.getValue(), null, null));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        // Should be removed because first condition matches (OR mode)
+        assertTrue(steps.isEmpty());
+    }
+
+    // =====================================================================
+    // Condition - Exist / Does not exist
+    // =====================================================================
+
+    @Test
+    void applyFilter_conditionExist_matchesNonEmptyHostname() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Exist", ""),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.host.getValue(), null, "replaced.com"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("replaced.com", step.getHostname());
+    }
+
+    @Test
+    void applyFilter_conditionDoesNotExist_matchesEmptyPath() {
+        ScriptStep step = createRequestStep("example.com", "");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Path", "Does not exist", ""),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.path.getValue(), null, "/default"));
+
+        ScriptFilterUtil.applyFilter(filter, steps);
+        assertEquals("/default", step.getSimplePath());
+    }
+
+    // =====================================================================
+    // filterOnFieldSets - additional coverage
+    // =====================================================================
+
+    @Test
+    void filterOnFieldSets_matchesOnFieldKeyValue() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("username");
+        rd.setValue("admin");
+        step.setPostDatas(new HashSet<>(Set.of(rd)));
+
+        ScriptFilterCondition condition = createCondition("Post Data", "Contains", "username=admin");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(step.getPostDatas(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    @Test
+    void filterOnFieldSets_matchesCondition_matchesRegex() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("id");
+        rd.setValue("12345");
+        step.setQueryStrings(new HashSet<>(Set.of(rd)));
+
+        ScriptFilterCondition condition = createCondition("Query String", "Matches", "id=\\d+");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(step.getQueryStrings(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    @Test
+    void filterOnFieldSets_startsWith_matchesPrefix() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("token");
+        rd.setValue("abc123");
+        step.setPostDatas(new HashSet<>(Set.of(rd)));
+
+        ScriptFilterCondition condition = createCondition("Post Data", "Starts with", "token=abc");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(step.getPostDatas(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    @Test
+    void filterOnFieldSets_doesNotContain_returnsTrueWhenNotPresent() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("other");
+        rd.setValue("value");
+        step.setPostDatas(new HashSet<>(Set.of(rd)));
+
+        ScriptFilterCondition condition = createCondition("Post Data", "Does not contain", "secret=value");
+
+        // "Does not contain" returns true when the value is NOT found
+        boolean result = ScriptFilterUtil.filterOnFieldSets(step.getPostDatas(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    @Test
+    void filterOnFieldSets_exist_returnsTrueWhenFieldsPresent() {
+        ScriptStep step = createRequestStep("example.com", "/path");
+        RequestData rd = new RequestData();
+        rd.setKey("data");
+        rd.setValue("val");
+        step.setPostDatas(new HashSet<>(Set.of(rd)));
+
+        ScriptFilterCondition condition = createCondition("Post Data", "Exist", "");
+
+        boolean result = ScriptFilterUtil.filterOnFieldSets(step.getPostDatas(), condition, step, List.of(step));
+        assertTrue(result);
+    }
+
+    // =====================================================================
+    // applyFilters with collection of ScriptFilter (static method overload)
+    // =====================================================================
+
+    @Test
+    void applyFilters_withCollection_appliesFiltersToSteps() {
+        ScriptStep step = createRequestStep("example.com", "/old");
+        List<ScriptStep> steps = new ArrayList<>(List.of(step));
+
+        ScriptFilter filter = createFilter(
+                createCondition("Hostname", "Contains", "example.com"),
+                createAction(ScriptFilterActionType.replace, ReplaceActionScope.path.getValue(), null, "/new"));
+
+        List<ScriptStep> result = ScriptFilterUtil.applyFilters(List.of(filter), steps);
+        assertEquals("/new", result.get(0).getSimplePath());
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private static ScriptStep createRequestStep(String hostname, String path) {
+        ScriptStep step = new ScriptStep();
+        step.setType("request");
+        step.setHostname(hostname);
+        step.setSimplePath(path);
+        step.setRequestheaders(new HashSet<>());
+        step.setRequestCookies(new HashSet<>());
+        step.setQueryStrings(new HashSet<>());
+        step.setPostDatas(new HashSet<>());
+        step.setResponseData(new HashSet<>());
+        return step;
+    }
+
+    private static ScriptFilterCondition createCondition(String scope, String condition, String value) {
+        ScriptFilterCondition c = new ScriptFilterCondition();
+        c.setScope(scope);
+        c.setCondition(condition);
+        c.setValue(value);
+        return c;
+    }
+
+    private static ScriptFilterAction createAction(ScriptFilterActionType action, String scope, String key, String value) {
+        ScriptFilterAction a = new ScriptFilterAction();
+        a.setAction(action);
+        a.setScope(scope);
+        a.setKey(key);
+        a.setValue(value);
+        return a;
+    }
+
+    private static ScriptFilter createFilter(ScriptFilterCondition condition, ScriptFilterAction action) {
+        ScriptFilter filter = new ScriptFilter();
+        filter.setFilterType(ScriptFilterType.INTERNAL);
+        filter.setAllConditionsMustPass(true);
+        filter.getConditions().add(condition);
+        filter.getActions().add(action);
+        return filter;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ScriptServiceUtilTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/rest/util/ScriptServiceUtilTest.java
@@ -1,0 +1,321 @@
+package com.intuit.tank.rest.mvc.rest.util;
+
+import com.intuit.tank.project.ExternalScript;
+import com.intuit.tank.project.RequestData;
+import com.intuit.tank.project.Script;
+import com.intuit.tank.project.ScriptStep;
+import com.intuit.tank.script.RequestDataPhase;
+import com.intuit.tank.script.models.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScriptServiceUtilTest {
+
+    // =====================================================================
+    // scriptToTransferObject / transferObjectToScript round-trip
+    // =====================================================================
+
+    @Test
+    void scriptToTransferObject_convertsAllFields() {
+        Script script = new Script();
+        script.setId(1);
+        script.setName("TestScript");
+        script.setComments("comment");
+        script.setCreator("user");
+        script.setProductName("product");
+        script.setRuntime(120);
+        script.setCreated(new Date());
+        script.setModified(new Date());
+        script.setScriptSteps(new ArrayList<>());
+
+        ScriptTO to = ScriptServiceUtil.scriptToTransferObject(script);
+
+        assertEquals(1, to.getId());
+        assertEquals("TestScript", to.getName());
+        assertEquals("comment", to.getComments());
+        assertEquals("user", to.getCreator());
+        assertEquals("product", to.getProductName());
+        assertEquals(120, to.getRuntime());
+        assertNotNull(to.getCreated());
+        assertNotNull(to.getModified());
+    }
+
+    @Test
+    void transferObjectToScript_convertsAllFields() {
+        ScriptTO to = ScriptTO.builder()
+                .withId(2)
+                .withName("FromTO")
+                .withComments("c")
+                .withCreator("admin")
+                .withProductName("prod")
+                .withRuntime(60)
+                .withCreated(new Date())
+                .withModified(new Date())
+                .withSteps(Collections.emptyList())
+                .build();
+
+        Script script = ScriptServiceUtil.transferObjectToScript(to);
+
+        assertEquals(2, script.getId());
+        assertEquals("FromTO", script.getName());
+        assertEquals("c", script.getComments());
+        assertEquals("admin", script.getCreator());
+    }
+
+    @Test
+    void transferObjectToScript_handlesNullId() {
+        ScriptTO to = ScriptTO.builder()
+                .withName("NoId")
+                .withSteps(Collections.emptyList())
+                .build();
+
+        Script script = ScriptServiceUtil.transferObjectToScript(to);
+        assertEquals(0, script.getId());
+    }
+
+    // =====================================================================
+    // scriptStepToTransferObject / transferObjectToScriptStep round-trip
+    // =====================================================================
+
+    @Test
+    void scriptStepToTransferObject_convertsStep() {
+        ScriptStep step = new ScriptStep();
+        step.setType("request");
+        step.setHostname("example.com");
+        step.setSimplePath("/api");
+        step.setMethod("GET");
+        step.setProtocol("https");
+        step.setStepIndex(5);
+        step.setLabel("Step Label");
+        step.setLoggingKey("login");
+
+        ScriptStepTO to = ScriptServiceUtil.scriptStepToTransferObject(step);
+
+        assertEquals("request", to.getType());
+        assertEquals("example.com", to.getHostname());
+        assertEquals("/api", to.getSimplePath());
+        assertEquals("GET", to.getMethod());
+        assertEquals("https", to.getProtocol());
+        assertEquals(5, to.getStepIndex());
+        assertEquals("login", to.getLoggingKey());
+    }
+
+    @Test
+    void transferObjectToScriptStep_convertsBack() {
+        ScriptStepTO to = ScriptStepTO.builder()
+                .withType("request")
+                .withHostname("example.com")
+                .withSimplePath("/path")
+                .withMethod("POST")
+                .withProtocol("http")
+                .withStepIndex(3)
+                .withName("step-name")
+                .withComments("comment")
+                .build();
+
+        ScriptStep step = ScriptServiceUtil.transferObjectToScriptStep(to);
+
+        assertEquals("request", step.getType());
+        assertEquals("example.com", step.getHostname());
+        assertEquals("/path", step.getSimplePath());
+        assertEquals("POST", step.getMethod());
+        assertEquals(3, step.getStepIndex());
+    }
+
+    @Test
+    void scriptStep_responseEncodeDecode_roundTrip() {
+        ScriptStep step = new ScriptStep();
+        step.setType("request");
+        step.setResponse("Hello World & <test>");
+
+        ScriptStepTO to = ScriptServiceUtil.scriptStepToTransferObject(step);
+        assertNotNull(to.getResponse());
+
+        ScriptStep back = ScriptServiceUtil.transferObjectToScriptStep(to);
+        assertEquals("Hello World & <test>", back.getResponse());
+    }
+
+    // =====================================================================
+    // requestDataToTransferObject / transferObjectToRequestData
+    // =====================================================================
+
+    @Test
+    void requestDataToTransferObject_convertsData() {
+        RequestData rd = new RequestData();
+        rd.setKey("Content-Type");
+        rd.setValue("application/json");
+        rd.setType("header");
+        rd.setPhase(RequestDataPhase.POST_REQUEST);
+
+        StepDataTO to = ScriptServiceUtil.requestDataToTransferObject(rd);
+
+        assertEquals("Content-Type", to.getKey());
+        assertEquals("application/json", to.getValue());
+        assertEquals("header", to.getType());
+        assertEquals("POST_REQUEST", to.getPhase());
+    }
+
+    @Test
+    void transferObjectToRequestData_convertsBack() {
+        StepDataTO to = StepDataTO.builder()
+                .withKey("Accept")
+                .withValue("text/html")
+                .withType("header")
+                .withPhase("POST_REQUEST")
+                .build();
+
+        RequestData rd = ScriptServiceUtil.transferObjectToRequestData(to);
+
+        assertEquals("Accept", rd.getKey());
+        assertEquals("text/html", rd.getValue());
+        assertEquals(RequestDataPhase.POST_REQUEST, rd.getPhase());
+    }
+
+    @Test
+    void transferObjectToRequestData_handlesNullPhase() {
+        StepDataTO to = StepDataTO.builder()
+                .withKey("key")
+                .withValue("val")
+                .withType("type")
+                .build();
+
+        RequestData rd = ScriptServiceUtil.transferObjectToRequestData(to);
+        assertEquals(RequestDataPhase.POST_REQUEST, rd.getPhase());
+    }
+
+    @Test
+    void transferObjectToRequestData_handlesInvalidPhase() {
+        StepDataTO to = StepDataTO.builder()
+                .withKey("key")
+                .withValue("val")
+                .withPhase("INVALID_PHASE")
+                .build();
+
+        RequestData rd = ScriptServiceUtil.transferObjectToRequestData(to);
+        assertEquals(RequestDataPhase.POST_REQUEST, rd.getPhase());
+    }
+
+    // =====================================================================
+    // scriptToScriptDescription / scriptDescriptionToScript
+    // =====================================================================
+
+    @Test
+    void scriptToScriptDescription_convertsBasicFields() {
+        Script script = new Script();
+        script.setId(10);
+        script.setName("MyScript");
+        script.setCreator("creator");
+        script.setCreated(new Date());
+        script.setModified(new Date());
+
+        ScriptDescription desc = ScriptServiceUtil.scriptToScriptDescription(script);
+
+        assertEquals(10, desc.getId());
+        assertEquals("MyScript", desc.getName());
+        assertEquals("creator", desc.getCreator());
+    }
+
+    @Test
+    void scriptDescriptionToScript_convertsBack() {
+        ScriptDescription desc = ScriptDescription.builder()
+                .withId(5)
+                .withName("FromDesc")
+                .withCreator("admin")
+                .withRuntime(30)
+                .build();
+
+        Script script = ScriptServiceUtil.scriptDescriptionToScript(desc);
+
+        assertEquals(5, script.getId());
+        assertEquals("FromDesc", script.getName());
+        assertEquals(30, script.getRuntime());
+    }
+
+    // =====================================================================
+    // externalScriptToTO / TOToExternalScript
+    // =====================================================================
+
+    @Test
+    void externalScriptToTO_convertsAllFields() {
+        ExternalScript es = new ExternalScript();
+        es.setId(3);
+        es.setName("ExtScript");
+        es.setCreator("user");
+        es.setProductName("product");
+        es.setScript("function test() {}");
+        es.setCreated(new Date());
+        es.setModified(new Date());
+
+        ExternalScriptTO to = ScriptServiceUtil.externalScriptToTO(es);
+
+        assertEquals(3, to.getId());
+        assertEquals("ExtScript", to.getName());
+        assertEquals("function test() {}", to.getScript());
+    }
+
+    @Test
+    void TOToExternalScript_convertsAllFields() {
+        ExternalScriptTO to = ExternalScriptTO.builder()
+                .withId(7)
+                .withName("ToEntity")
+                .withCreator("admin")
+                .withProductName("prod")
+                .withScript("code here")
+                .withCreated(new Date())
+                .withModified(new Date())
+                .build();
+
+        ExternalScript es = ScriptServiceUtil.TOToExternalScript(to);
+
+        assertEquals(7, es.getId());
+        assertEquals("ToEntity", es.getName());
+        assertEquals("code here", es.getScript());
+    }
+
+    @Test
+    void TOToExternalScript_handlesNullCreator() {
+        ExternalScriptTO to = ExternalScriptTO.builder()
+                .withId(0)
+                .withName("NoCreator")
+                .build();
+
+        ExternalScript es = ScriptServiceUtil.TOToExternalScript(to);
+        assertEquals("", es.getCreator());
+    }
+
+    @Test
+    void TOToExternalScript_skipsTimestampsForNewScript() {
+        ExternalScriptTO to = ExternalScriptTO.builder()
+                .withId(0)
+                .withName("New")
+                .withCreated(new Date())
+                .withModified(new Date())
+                .build();
+
+        ExternalScript es = ScriptServiceUtil.TOToExternalScript(to);
+        // id=0 means new, so created/modified should NOT be copied
+        assertNull(es.getCreated());
+        assertNull(es.getModified());
+    }
+
+    // =====================================================================
+    // copy
+    // =====================================================================
+
+    @Test
+    void copy_createsIndependentCopy() {
+        ScriptStepTO original = ScriptStepTO.builder()
+                .withType("request")
+                .withHostname("example.com")
+                .withStepIndex(1)
+                .build();
+
+        ScriptStepTO copy = ScriptServiceUtil.copy(original);
+
+        assertEquals(original.getHostname(), copy.getHostname());
+        assertEquals(original.getStepIndex(), copy.getStepIndex());
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/service/UserAutoDeletionServiceTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/service/UserAutoDeletionServiceTest.java
@@ -1,0 +1,602 @@
+package com.intuit.tank.rest.mvc.service;
+
+import com.intuit.tank.dao.UserDao;
+import com.intuit.tank.project.Group;
+import com.intuit.tank.project.User;
+import com.intuit.tank.vm.settings.TankConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class UserAutoDeletionServiceTest {
+
+    // =====================================================================
+    // performStartupUserDeletion - DRY RUN mode (auto-deletion disabled)
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_dryRunMode_doesNotDeleteUsers() {
+        try (MockedConstruction<TankConfig> tankConfigMock = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(2L);
+                         when(mock.findUsersEligibleForDeletion(730)).thenReturn(
+                                 List.of(createUser(1, "inactiveUser", false)));
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            // In DRY RUN mode, deleteUserData should never be called
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData(anyString());
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_noEligibleUsers_exitsEarly() {
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(0L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            // Should not call findUsersEligibleForDeletion when count is 0
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).findUsersEligibleForDeletion(anyInt());
+                verify(dao, never()).deleteUserData(anyString());
+            }
+        }
+    }
+
+    // =====================================================================
+    // performStartupUserDeletion - DELETION mode (auto-deletion enabled)
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_deletionMode_deletesEligibleUsers() {
+        User eligibleUser = createUser(1, "oldUser", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         // First call returns users for logging, second for batch processing, third returns empty to stop loop
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(eligibleUser))
+                                 .thenReturn(List.of(eligibleUser))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("oldUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            // Verify deleteUserData was called for the eligible user
+            boolean deleteWasCalled = false;
+            for (UserDao dao : userDaoMock.constructed()) {
+                try {
+                    verify(dao, atLeastOnce()).deleteUserData("oldUser");
+                    deleteWasCalled = true;
+                } catch (AssertionError e) {
+                    // This particular constructed DAO may not have been the one used for deletion
+                }
+            }
+            assertTrue(deleteWasCalled, "deleteUserData should have been called for eligible user");
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_skipsProtectedUsers() {
+        User adminUser = createUser(1, "admin", false);
+        User regularUser = createUser(2, "regularUser", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(2L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(adminUser, regularUser))
+                                 .thenReturn(List.of(adminUser, regularUser))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("regularUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            // Verify admin was never deleted, but regularUser was
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData("admin");
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_handlesExceptionGracefully() {
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenThrow(new RuntimeException("DB error"));
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            // Should not throw - exception is caught internally
+            assertDoesNotThrow(() -> service.performStartupUserDeletion());
+        }
+    }
+
+    // =====================================================================
+    // isProtectedUser (tested indirectly via deletion behavior)
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_protectsAnonymizedUsers() {
+        User anonymizedUser = createUser(1, "deleted_user_123", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(anonymizedUser))
+                                 .thenReturn(List.of(anonymizedUser))
+                                 .thenReturn(Collections.emptyList());
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData("deleted_user_123");
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_protectsPermittedUsers() {
+        User permittedUser = createUser(1, "serviceAccount", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(List.of("serviceAccount"));
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(permittedUser))
+                                 .thenReturn(List.of(permittedUser))
+                                 .thenReturn(Collections.emptyList());
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData("serviceAccount");
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_protectsUsersInAdminGroup() {
+        User adminGroupUser = createUser(1, "someUser", false);
+        adminGroupUser.addGroup(new Group("administrators"));
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(adminGroupUser))
+                                 .thenReturn(List.of(adminGroupUser))
+                                 .thenReturn(Collections.emptyList());
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData("someUser");
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_protectsUsersInSuperGroup() {
+        User superGroupUser = createUser(1, "anotherUser", false);
+        superGroupUser.addGroup(new Group("super-users"));
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(superGroupUser))
+                                 .thenReturn(List.of(superGroupUser))
+                                 .thenReturn(Collections.emptyList());
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            for (UserDao dao : userDaoMock.constructed()) {
+                verify(dao, never()).deleteUserData("anotherUser");
+            }
+        }
+    }
+
+    // =====================================================================
+    // performManualUserDeletion
+    // =====================================================================
+
+    @Test
+    void performManualUserDeletion_deletesEligibleUsers() {
+        User eligibleUser = createUser(1, "inactiveUser", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(365);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.findUsersEligibleForDeletion(365))
+                                 .thenReturn(List.of(eligibleUser))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("inactiveUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            int deleted = service.performManualUserDeletion();
+
+            assertEquals(1, deleted);
+        }
+    }
+
+    @Test
+    void performManualUserDeletion_throwsOnError() {
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenThrow(new RuntimeException("DB error"));
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            assertThrows(RuntimeException.class, () -> service.performManualUserDeletion());
+        }
+    }
+
+    // =====================================================================
+    // Batch processing
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_deletionMode_continuesBatchOnIndividualFailure() {
+        User failUser = createUser(1, "failUser", false);
+        User successUser = createUser(2, "successUser", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(2L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(failUser, successUser))  // logging call
+                                 .thenReturn(List.of(failUser, successUser))  // first batch
+                                 .thenReturn(Collections.emptyList());        // stop loop
+                         when(mock.deleteUserData("failUser")).thenThrow(new RuntimeException("Delete failed"));
+                         when(mock.deleteUserData("successUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            service.performStartupUserDeletion();
+
+            // successUser should still be processed despite failUser's exception
+            boolean successDeleted = false;
+            for (UserDao dao : userDaoMock.constructed()) {
+                try {
+                    verify(dao, atLeastOnce()).deleteUserData("successUser");
+                    successDeleted = true;
+                } catch (AssertionError e) {
+                    // not this DAO instance
+                }
+            }
+            assertTrue(successDeleted, "successUser should have been processed despite failUser exception");
+        }
+    }
+
+    // =====================================================================
+    // isNeverLoggedIn - edge cases via user creation
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_userNeverLoggedIn_logsCorrectReason() {
+        // A user who never logged in has lastLoginTs very close to creation time
+        User neverLoggedIn = createUser(1, "newUser", true); // neverLoggedIn = true
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(neverLoggedIn))
+                                 .thenReturn(List.of(neverLoggedIn))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("newUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            // Should complete without errors for never-logged-in users
+            assertDoesNotThrow(() -> service.performStartupUserDeletion());
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_userWithNullTimestamps_handledGracefully() {
+        User nullTsUser = new User();
+        nullTsUser.setName("nullTsUser");
+        nullTsUser.setId(1);
+        // created and lastLoginTs are null - isNeverLoggedIn should return true
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(nullTsUser))
+                                 .thenReturn(List.of(nullTsUser))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("nullTsUser")).thenReturn(1L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            // The logEligibleUsers method calls user.getCreated().toInstant() which will NPE
+            // for null created. This tests the outer exception handler.
+            assertDoesNotThrow(() -> service.performStartupUserDeletion());
+        }
+    }
+
+    // =====================================================================
+    // Config precedence - getRetentionDays and isAutoDeletionEnabled
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_retentionDaysFromSystemProperty() {
+        String originalProp = System.getProperty("tank.user.auto-deletion.retention-days");
+        try {
+            System.setProperty("tank.user.auto-deletion.retention-days", "365");
+
+            try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                         (mock, ctx) -> {
+                             when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
+                             when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                             when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                         });
+                 MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                         (mock, ctx) -> {
+                             // The service should use 365 (from sys prop), not 730 (from TankConfig)
+                             when(mock.countUsersEligibleForDeletion(365)).thenReturn(0L);
+                         })) {
+
+                UserAutoDeletionService service = new UserAutoDeletionService();
+                service.performStartupUserDeletion();
+
+                // Verify the DAO was queried with the system property value (365)
+                for (UserDao dao : userDaoMock.constructed()) {
+                    verify(dao, atMost(1)).countUsersEligibleForDeletion(365);
+                }
+            }
+        } finally {
+            if (originalProp == null) {
+                System.clearProperty("tank.user.auto-deletion.retention-days");
+            } else {
+                System.setProperty("tank.user.auto-deletion.retention-days", originalProp);
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_enabledViaSystemProperty() {
+        String originalProp = System.getProperty("tank.user.auto-deletion.enabled");
+        try {
+            System.setProperty("tank.user.auto-deletion.enabled", "true");
+
+            User user = createUser(1, "testUser", false);
+
+            try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                         (mock, ctx) -> {
+                             when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
+                             when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                             when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                         });
+                 MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                         (mock, ctx) -> {
+                             when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                             when(mock.findUsersEligibleForDeletion(730))
+                                     .thenReturn(List.of(user))
+                                     .thenReturn(List.of(user))
+                                     .thenReturn(Collections.emptyList());
+                             when(mock.deleteUserData("testUser")).thenReturn(1L);
+                         })) {
+
+                UserAutoDeletionService service = new UserAutoDeletionService();
+                service.performStartupUserDeletion();
+
+                // Should have attempted deletion since enabled via system property
+                boolean deleteWasCalled = false;
+                for (UserDao dao : userDaoMock.constructed()) {
+                    try {
+                        verify(dao, atLeastOnce()).deleteUserData("testUser");
+                        deleteWasCalled = true;
+                    } catch (AssertionError e) {
+                        // not this DAO instance
+                    }
+                }
+                assertTrue(deleteWasCalled, "Deletion should proceed when enabled via system property");
+            }
+        } finally {
+            if (originalProp == null) {
+                System.clearProperty("tank.user.auto-deletion.enabled");
+            } else {
+                System.setProperty("tank.user.auto-deletion.enabled", originalProp);
+            }
+        }
+    }
+
+    @Test
+    void performStartupUserDeletion_invalidRetentionDaysSysProp_fallsBackToTankConfig() {
+        String originalProp = System.getProperty("tank.user.auto-deletion.retention-days");
+        try {
+            System.setProperty("tank.user.auto-deletion.retention-days", "not-a-number");
+
+            try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                         (mock, ctx) -> {
+                             when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
+                             when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                             when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                         });
+                 MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                         (mock, ctx) -> {
+                             // Should fall back to TankConfig value of 730
+                             when(mock.countUsersEligibleForDeletion(730)).thenReturn(0L);
+                         })) {
+
+                UserAutoDeletionService service = new UserAutoDeletionService();
+                assertDoesNotThrow(() -> service.performStartupUserDeletion());
+            }
+        } finally {
+            if (originalProp == null) {
+                System.clearProperty("tank.user.auto-deletion.retention-days");
+            } else {
+                System.setProperty("tank.user.auto-deletion.retention-days", originalProp);
+            }
+        }
+    }
+
+    // =====================================================================
+    // deleteUserData return value handling
+    // =====================================================================
+
+    @Test
+    void performStartupUserDeletion_deleteReturnsZero_continuesProcessing() {
+        User user = createUser(1, "alreadyProcessed", false);
+
+        try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
+                     (mock, ctx) -> {
+                         when(mock.isUserAutoDeletionEnabled()).thenReturn(true);
+                         when(mock.getUserAutoDeletionRetentionDays()).thenReturn(730);
+                         when(mock.getUserAutoDeletionPermittedUsers()).thenReturn(Collections.emptyList());
+                     });
+             MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
+                     (mock, ctx) -> {
+                         when(mock.countUsersEligibleForDeletion(730)).thenReturn(1L);
+                         when(mock.findUsersEligibleForDeletion(730))
+                                 .thenReturn(List.of(user))
+                                 .thenReturn(List.of(user))
+                                 .thenReturn(Collections.emptyList());
+                         when(mock.deleteUserData("alreadyProcessed")).thenReturn(0L);
+                     })) {
+
+            UserAutoDeletionService service = new UserAutoDeletionService();
+            // Should complete without errors even when deleteUserData returns 0
+            assertDoesNotThrow(() -> service.performStartupUserDeletion());
+        }
+    }
+
+    // =====================================================================
+    // Helper methods
+    // =====================================================================
+
+    private static User createUser(int id, String name, boolean neverLoggedIn) {
+        Instant now = Instant.now();
+        User user = new User();
+        user.setId(id);
+        user.setName(name);
+        user.setCreated(Date.from(now.minusSeconds(86400 * 800))); // 800 days ago
+        if (neverLoggedIn) {
+            // lastLoginTs same as created time (within 1s threshold)
+            user.setLastLoginTs(user.getCreated().toInstant());
+        } else {
+            // lastLoginTs is some time after creation, but still old
+            user.setLastLoginTs(now.minusSeconds(86400 * 750));
+        }
+        return user;
+    }
+}

--- a/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/service/UserAutoDeletionServiceTest.java
+++ b/rest-mvc/impl/src/test/java/com/intuit/tank/rest/mvc/service/UserAutoDeletionServiceTest.java
@@ -439,10 +439,7 @@ class UserAutoDeletionServiceTest {
 
     @Test
     void performStartupUserDeletion_retentionDaysFromSystemProperty() {
-        String originalProp = System.getProperty("tank.user.auto-deletion.retention-days");
-        try {
-            System.setProperty("tank.user.auto-deletion.retention-days", "365");
-
+        withSystemProperty("tank.user.auto-deletion.retention-days", "365", () -> {
             try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                          (mock, ctx) -> {
                              when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
@@ -451,35 +448,24 @@ class UserAutoDeletionServiceTest {
                          });
                  MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
                          (mock, ctx) -> {
-                             // The service should use 365 (from sys prop), not 730 (from TankConfig)
                              when(mock.countUsersEligibleForDeletion(365)).thenReturn(0L);
                          })) {
 
                 UserAutoDeletionService service = new UserAutoDeletionService();
                 service.performStartupUserDeletion();
 
-                // Verify the DAO was queried with the system property value (365)
                 for (UserDao dao : userDaoMock.constructed()) {
                     verify(dao, atMost(1)).countUsersEligibleForDeletion(365);
                 }
             }
-        } finally {
-            if (originalProp == null) {
-                System.clearProperty("tank.user.auto-deletion.retention-days");
-            } else {
-                System.setProperty("tank.user.auto-deletion.retention-days", originalProp);
-            }
-        }
+        });
     }
 
     @Test
     void performStartupUserDeletion_enabledViaSystemProperty() {
-        String originalProp = System.getProperty("tank.user.auto-deletion.enabled");
-        try {
-            System.setProperty("tank.user.auto-deletion.enabled", "true");
+        User user = createUser(1, "testUser", false);
 
-            User user = createUser(1, "testUser", false);
-
+        withSystemProperty("tank.user.auto-deletion.enabled", "true", () -> {
             try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                          (mock, ctx) -> {
                              when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
@@ -499,7 +485,6 @@ class UserAutoDeletionServiceTest {
                 UserAutoDeletionService service = new UserAutoDeletionService();
                 service.performStartupUserDeletion();
 
-                // Should have attempted deletion since enabled via system property
                 boolean deleteWasCalled = false;
                 for (UserDao dao : userDaoMock.constructed()) {
                     try {
@@ -511,21 +496,12 @@ class UserAutoDeletionServiceTest {
                 }
                 assertTrue(deleteWasCalled, "Deletion should proceed when enabled via system property");
             }
-        } finally {
-            if (originalProp == null) {
-                System.clearProperty("tank.user.auto-deletion.enabled");
-            } else {
-                System.setProperty("tank.user.auto-deletion.enabled", originalProp);
-            }
-        }
+        });
     }
 
     @Test
     void performStartupUserDeletion_invalidRetentionDaysSysProp_fallsBackToTankConfig() {
-        String originalProp = System.getProperty("tank.user.auto-deletion.retention-days");
-        try {
-            System.setProperty("tank.user.auto-deletion.retention-days", "not-a-number");
-
+        withSystemProperty("tank.user.auto-deletion.retention-days", "not-a-number", () -> {
             try (MockedConstruction<TankConfig> ignored = Mockito.mockConstruction(TankConfig.class,
                          (mock, ctx) -> {
                              when(mock.isUserAutoDeletionEnabled()).thenReturn(false);
@@ -534,20 +510,13 @@ class UserAutoDeletionServiceTest {
                          });
                  MockedConstruction<UserDao> userDaoMock = Mockito.mockConstruction(UserDao.class,
                          (mock, ctx) -> {
-                             // Should fall back to TankConfig value of 730
                              when(mock.countUsersEligibleForDeletion(730)).thenReturn(0L);
                          })) {
 
                 UserAutoDeletionService service = new UserAutoDeletionService();
                 assertDoesNotThrow(() -> service.performStartupUserDeletion());
             }
-        } finally {
-            if (originalProp == null) {
-                System.clearProperty("tank.user.auto-deletion.retention-days");
-            } else {
-                System.setProperty("tank.user.auto-deletion.retention-days", originalProp);
-            }
-        }
+        });
     }
 
     // =====================================================================
@@ -583,6 +552,20 @@ class UserAutoDeletionServiceTest {
     // =====================================================================
     // Helper methods
     // =====================================================================
+
+    private static void withSystemProperty(String key, String value, Runnable action) {
+        String original = System.getProperty(key);
+        System.setProperty(key, value);
+        try {
+            action.run();
+        } finally {
+            if (original == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, original);
+            }
+        }
+    }
 
     private static User createUser(int id, String name, boolean neverLoggedIn) {
         Instant now = Instant.now();


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests to the `tank-rest-api-impl` module, raising line coverage from **58% to 85.8%** (2303/2683 lines). The module now has **453 tests** across 27 test files (25 new, 2 expanded).

### What's covered

**Service implementations** — every V2 service impl now has dedicated tests:
- `JobServiceV2Impl` (58 tests) — CRUD, job lifecycle, `addJobToQueue`, `buildJobConfiguration`, name generation
- `AgentServiceV2Impl` (22 tests) — settings, headers, clients, agent registration, instance lifecycle
- `ScriptServiceV2Impl` (36 tests) — 3 create paths, external scripts, downloads, error paths
- `ProjectServiceV2Impl` (13 tests) — create/update with test plan assembly, delete
- `DataFileServiceV2Impl` (13 tests) — upload with gzip handling, streaming content
- `FilterServiceV2Impl` (16 tests) — filter/group CRUD, `applyFilters` with group flattening
- `LogServiceV2Impl` (5 tests) — path traversal rejection, file reading
- `AdminTokenService` (6 tests) — token validation, SSM integration (mocked)

**Cloud/event components:**
- `JobEventSender` (60 tests) — job start/stop/kill/pause/resume, instance management, `checkJobStatus`
- `JobEventListener` (4 tests) — CDI event observer for abort/finish/kill events
- `MessageEventSender` (1 test) — event firing

**Utility classes:**
- `ScriptFilterUtil` (41 tests) — add/remove/replace actions across all scopes, condition types, field set matching
- `JobDetailFormatter` (15 tests) — HTML generation for increasing/standard workloads, cost calculation, error reporting
- `JobValidator` (7 tests) — variable tracking, best practice violations, duration calculation
- `ScriptServiceUtil` (17 tests) — all DTO round-trip conversions, edge cases
- `ProjectServiceUtil` (6 tests) — project-to-TO conversion with test plans/variables/data files
- `DataFileServiceUtil` (3 tests), `FilterServiceUtil` (2 tests), `JobServiceUtil` (1 test), `FileReader` (5 tests), `ResponseUtil` (2 tests)

**Infrastructure:**
- `GenericExceptionHandler` expanded (10 tests total) — all handler methods
- `ExceptionClassesTest` (13 tests) — all custom exception types
- `CustomWebMvcConfigurer` (2 tests), `LoggingInterceptor` (3 tests)

### Other changes

- Added `tank-rest-api-impl` to `jacoco-report-aggregator/pom.xml` for aggregated coverage reporting

## Test plan

- [x] `mvn test -f rest-mvc/impl/pom.xml` — 453 tests, 0 failures
- [x] `mvn clean test -P coverage -f rest-mvc/impl/pom.xml` — 85.8% line coverage
- [x] No production code changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)