### PR TITLE
Enable auto github actions

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,7 @@
+{
+  "plugins": ["maven"],
+  "owner": "intuit",
+  "repo": "Tank",
+  "name": "Kevin McGoldrick",
+  "email": "kevin_mcgoldrick@intuit.com"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,24 +2,29 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # important: auto needs full git history
+          fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - run: npm ci
+          node-version: 20
 
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: auto shipit
+        run: npx auto shipit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # important: auto needs full git history
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm ci
+
+      - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: auto shipit


### PR DESCRIPTION
Adds `auto` release automation for the Tank repo:
- New `.autorc` configures the `auto` CLI with the Maven plugin and Intuit/Tank as the target repo.
- New `.github/workflows/release.yml` runs on every push to `master`, sets up Node 18, installs deps, and runs `auto shipit` using the `GH_TOKEN` secret to cut releases automatically.

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default```

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.