### PR TITLE
fix: optimize WS file transfer with binary frames and larger chunks

### DIFF
--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -99,6 +100,16 @@ public class StartupWebSocketServer extends WebSocketServer {
             }
         } catch (Exception e) {
             logger.warn("Failed handling startup WS message: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, ByteBuffer message) {
+        try {
+            AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(message);
+            handleFileChunk(conn, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+        } catch (Exception e) {
+            logger.warn("Failed handling startup WS binary message: {}", e.getMessage(), e);
         }
     }
 
@@ -228,28 +239,38 @@ public class StartupWebSocketServer extends WebSocketServer {
     }
 
     private synchronized void handleFileChunk(WebSocket conn, AgentWsEnvelope envelope) {
-        if (currentFileStream == null || currentFileId == null || !currentFileId.equals(envelope.getFileId())) {
-            sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, "file_offer_not_found");
-            return;
-        }
-
         try {
             byte[] payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
                     ? new byte[0]
                     : Base64.getDecoder().decode(envelope.getChunkData());
+            handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
+        } catch (Exception e) {
+            closeCurrentFileQuietly();
+            sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+            harnessJarFuture.completeExceptionally(e);
+        }
+    }
+
+    private synchronized void handleFileChunk(WebSocket conn, String fileId, Integer chunkIndex, byte[] payload) {
+        if (currentFileStream == null || currentFileId == null || !currentFileId.equals(fileId)) {
+            sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
+            return;
+        }
+
+        try {
             currentFileStream.write(payload);
             receivedBytes += payload.length;
             receivedChunks++;
-            sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.chunk_received, null);
+            sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
 
             if (expectedBytes > 0 && receivedBytes >= expectedBytes) {
                 File completedFile = finalizeHarnessJar();
-                sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.complete, null);
+                sendFileAck(conn, fileId, chunkIndex, AckStatus.complete, null);
                 harnessJarFuture.complete(completedFile);
             }
         } catch (Exception e) {
             closeCurrentFileQuietly();
-            sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+            sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, e.getMessage());
             harnessJarFuture.completeExceptionally(e);
         }
     }

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -44,6 +44,7 @@ public class StartupWebSocketServer extends WebSocketServer {
     private int expectedChunks;
     private long receivedBytes;
     private long expectedBytes;
+    private long transferStartedAtNs;
 
     public StartupWebSocketServer(int port, String instanceId, String jobId, int capacity) {
         super(new InetSocketAddress(port));
@@ -216,6 +217,9 @@ public class StartupWebSocketServer extends WebSocketServer {
                 expectedChunks = offerTotalChunks;
                 receivedBytes = partialBytes;
                 expectedBytes = offerTotalBytes;
+                if (transferStartedAtNs == 0L) {
+                    transferStartedAtNs = System.nanoTime();
+                }
                 sendFileAckWithResume(conn, envelope.getFileId(), AckStatus.resume, partialBytes, resumeChunk);
                 return;
             }
@@ -230,6 +234,7 @@ public class StartupWebSocketServer extends WebSocketServer {
             expectedChunks = offerTotalChunks;
             receivedBytes = 0;
             expectedBytes = offerTotalBytes;
+            transferStartedAtNs = System.nanoTime();
             // Send explicit ok ack so controller doesn't wait 10s
             sendFileAck(conn, envelope.getFileId(), 0, AckStatus.ok, null);
         } catch (IOException e) {
@@ -297,9 +302,18 @@ public class StartupWebSocketServer extends WebSocketServer {
             Files.move(currentTempFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
         File completedFile = targetFile;
+        long durationMs = transferStartedAtNs > 0L
+                ? TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs)
+                : 0L;
+        double throughputMiBps = durationMs > 0
+                ? Math.round(((receivedBytes / (1024.0 * 1024.0)) / (durationMs / 1000.0)) * 100.0) / 100.0
+                : 0.0;
+        logger.info("Startup WS harness JAR received bytes={} chunks={}/{} durationMs={} throughputMiBps={}",
+                receivedBytes, receivedChunks, expectedChunks, durationMs, throughputMiBps);
         currentTempFile = null;
         targetFile = null;
         currentFileId = null;
+        transferStartedAtNs = 0L;
         return completedFile;
     }
 

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -19,6 +19,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -105,7 +106,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
                 case command -> handleCommand(connection, envelope);
                 case ping -> handlePing(connection, envelope);
                 case job_config -> handleJobConfig(envelope);
-                case file_offer -> handleFileOffer(envelope);
+                case file_offer -> handleFileOffer(connection, envelope);
                 case file_chunk -> handleFileChunk(connection, envelope);
                 case ack -> LOG.info(new ObjectMessage(Map.of("Message", "Received WS ack: " + envelope.getAckForType())));
                 case close -> {
@@ -116,6 +117,16 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             }
         } catch (IOException e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed parsing WS message: " + e.getMessage())));
+        }
+    }
+
+    @Override
+    public void onMessage(WebSocket connection, ByteBuffer message) {
+        try {
+            AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(message);
+            handleFileChunk(connection, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+        } catch (IOException e) {
+            LOG.warn(new ObjectMessage(Map.of("Message", "Failed parsing WS binary file chunk: " + e.getMessage())));
         }
     }
 
@@ -182,7 +193,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void handleFileOffer(AgentWsEnvelope envelope) {
+    private void handleFileOffer(WebSocket connection, AgentWsEnvelope envelope) {
         String fileId = envelope.getFileId();
         if (fileId == null || envelope.getFileName() == null) {
             return;
@@ -212,29 +223,40 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
                     new FileOutputStream(tempFile)
             );
             incomingFiles.put(fileId, state);
+            sendFileAck(connection, fileId, 0, AckStatus.ok, null);
         } catch (Exception e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed handling file_offer " + envelope.getFileName() + ": " + e.getMessage())));
+            sendFileAck(connection, fileId, 0, AckStatus.failed, e.getMessage());
         }
     }
 
     private void handleFileChunk(WebSocket connection, AgentWsEnvelope envelope) {
         String fileId = envelope.getFileId();
+        byte[] payload;
+        try {
+            payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
+                    ? new byte[0]
+                    : Base64.getDecoder().decode(envelope.getChunkData());
+        } catch (Exception e) {
+            sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+            return;
+        }
+        handleFileChunk(connection, fileId, envelope.getChunkIndex(), payload);
+    }
+
+    private void handleFileChunk(WebSocket connection, String fileId, Integer chunkIndex, byte[] payload) {
         IncomingFileState state = fileId != null ? incomingFiles.get(fileId) : null;
         if (state == null) {
-            sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.failed, "file_offer_not_found");
+            sendFileAck(connection, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
             return;
         }
 
         try {
-            byte[] payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
-                    ? new byte[0]
-                    : Base64.getDecoder().decode(envelope.getChunkData());
-
             if (state.totalChunks < 0 && payload.length == 0) {
                 finalizeFile(state);
                 incomingFiles.remove(fileId);
-                sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.complete, null);
-                markFileComplete(connection, fileId, envelope.getChunkIndex());
+                sendFileAck(connection, fileId, chunkIndex, AckStatus.complete, null);
+                markFileComplete(connection, fileId, chunkIndex);
                 return;
             }
 
@@ -242,18 +264,18 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             state.receivedBytes += payload.length;
             state.receivedChunks++;
 
-            sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.chunk_received, null);
+            sendFileAck(connection, fileId, chunkIndex, AckStatus.chunk_received, null);
 
             if (state.totalChunks >= 0 && state.receivedChunks >= state.totalChunks) {
                 finalizeFile(state);
                 incomingFiles.remove(fileId);
-                sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.complete, null);
-                markFileComplete(connection, fileId, envelope.getChunkIndex());
+                sendFileAck(connection, fileId, chunkIndex, AckStatus.complete, null);
+                markFileComplete(connection, fileId, chunkIndex);
             }
         } catch (Exception e) {
             incomingFiles.remove(fileId);
             state.closeQuietly();
-            sendFileAck(connection, fileId, envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+            sendFileAck(connection, fileId, chunkIndex, AckStatus.failed, e.getMessage());
         }
     }
 

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -303,6 +303,18 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             Files.move(state.tempFile.toPath(), state.targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
 
+        long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - state.transferStartedAtNs);
+        double throughputMiBps = durationMs > 0
+                ? Math.round(((state.receivedBytes / (1024.0 * 1024.0)) / (durationMs / 1000.0)) * 100.0) / 100.0
+                : 0.0;
+        LOG.info(new ObjectMessage(Map.of("Message",
+                "WS file received file=" + state.fileName
+                        + " type=" + state.fileType
+                        + " bytes=" + state.receivedBytes + "/" + state.totalBytes
+                        + " chunks=" + state.receivedChunks + "/" + state.totalChunks
+                        + " durationMs=" + durationMs
+                        + " throughputMiBps=" + throughputMiBps)));
+
         if (SUPPORT_ARCHIVE_FILE_TYPE.equalsIgnoreCase(state.fileType)) {
             unpackSupportArchive(state.targetFile);
             Files.deleteIfExists(state.targetFile.toPath());
@@ -487,6 +499,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         private final int totalChunks;
         private final boolean defaultDataFile;
         private final OutputStream outputStream;
+        private final long transferStartedAtNs;
         private long receivedBytes;
         private int receivedChunks;
 
@@ -501,6 +514,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             this.totalChunks = totalChunks;
             this.defaultDataFile = defaultDataFile;
             this.outputStream = outputStream;
+            this.transferStartedAtNs = System.nanoTime();
         }
 
         private void closeQuietly() {

--- a/api/src/main/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelope.java
+++ b/api/src/main/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelope.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -17,6 +19,7 @@ public class AgentWsEnvelope {
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public static final int PROTOCOL_VERSION = 1;
+    private static final int BINARY_FILE_CHUNK_MAGIC = 0x54574331;
 
     public enum Type {
         hello, command, ack, ping, pong, close,
@@ -231,6 +234,55 @@ public class AgentWsEnvelope {
 
     public static AgentWsEnvelope fromJson(String json) throws IOException {
         return MAPPER.readValue(json, AgentWsEnvelope.class);
+    }
+
+    public static ByteBuffer binaryFileChunk(String fileId, int chunkIndex, byte[] bytes, int offset, int len)
+            throws IOException {
+        if (fileId == null || fileId.isBlank()) {
+            throw new IOException("fileId is required for binary file chunk");
+        }
+        if (bytes == null) {
+            bytes = new byte[0];
+        }
+        if (offset < 0 || len < 0 || offset + len > bytes.length) {
+            throw new IOException("Invalid binary file chunk range");
+        }
+        byte[] fileIdBytes = fileId.getBytes(StandardCharsets.UTF_8);
+        if (fileIdBytes.length > 0xFFFF) {
+            throw new IOException("fileId too long for binary file chunk");
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + Integer.BYTES + Short.BYTES + fileIdBytes.length + len);
+        buffer.putInt(BINARY_FILE_CHUNK_MAGIC);
+        buffer.putInt(chunkIndex);
+        buffer.putShort((short) fileIdBytes.length);
+        buffer.put(fileIdBytes);
+        buffer.put(bytes, offset, len);
+        buffer.flip();
+        return buffer;
+    }
+
+    public static BinaryFileChunk fromBinaryFileChunk(ByteBuffer message) throws IOException {
+        ByteBuffer buffer = message.slice();
+        if (buffer.remaining() < Integer.BYTES + Integer.BYTES + Short.BYTES) {
+            throw new IOException("Invalid binary file chunk header");
+        }
+        int magic = buffer.getInt();
+        if (magic != BINARY_FILE_CHUNK_MAGIC) {
+            throw new IOException("Unsupported binary file chunk frame");
+        }
+        int chunkIndex = buffer.getInt();
+        int fileIdLength = Short.toUnsignedInt(buffer.getShort());
+        if (fileIdLength <= 0 || fileIdLength > buffer.remaining()) {
+            throw new IOException("Invalid binary file chunk fileId length");
+        }
+        byte[] fileIdBytes = new byte[fileIdLength];
+        buffer.get(fileIdBytes);
+        byte[] payload = new byte[buffer.remaining()];
+        buffer.get(payload);
+        return new BinaryFileChunk(new String(fileIdBytes, StandardCharsets.UTF_8), chunkIndex, payload);
+    }
+
+    public record BinaryFileChunk(String fileId, int chunkIndex, byte[] payload) {
     }
 
     // Factory methods for common frame types

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -27,8 +27,6 @@ import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,8 +46,10 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private static final String SETTINGS_FILE_NAME = "settings.xml";
     private static final String SCRIPT_FILE_NAME = "script.xml";
     private static final String LOCAL_CONTROLLER_ORIGIN = "http://localhost:8080";
-    private static final int DEFAULT_CHUNK_BYTES = 524288;
-    private static final int CHUNK_ACK_WINDOW = 4;
+    private static final int DEFAULT_CHUNK_BYTES =
+            Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 2 * 1024 * 1024));
+    private static final int CHUNK_ACK_WINDOW =
+            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 30_000L);
 
@@ -436,7 +436,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         if (content == null || content.length == 0) {
             pendingAcks.remove(fileId);
-            sendChunk(context, instanceId, jobId, fileId, 0, new byte[0], 0, connectionDeadlineMs);
+            sendChunk(context, instanceId, fileId, 0, new byte[0], 0, 0, connectionDeadlineMs);
             return true;
         }
 
@@ -478,23 +478,21 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 return false;
             }
             int len = Math.min(chunkBytes, content.length - offset);
-            sendChunk(context, instanceId, jobId, fileId, chunkIndex,
-                    Arrays.copyOfRange(content, offset, offset + len), len, connectionDeadlineMs);
+            sendChunk(context, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
             chunkIndex++;
         }
         return true;
     }
 
-    private void sendChunk(SessionContext context, String instanceId, String jobId, String fileId,
-                           int chunkIndex, byte[] bytes, int len, long connectionDeadlineMs)
+    private void sendChunk(SessionContext context, String instanceId, String fileId,
+                           int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
             throws IOException, InterruptedException {
         CompletableFuture<Void> gate = null;
         if ((chunkIndex + 1) % CHUNK_ACK_WINDOW == 0) {
             gate = new CompletableFuture<>();
             pendingChunkAcks.put(instanceId, new PendingChunkAck(fileId, chunkIndex, gate));
         }
-        String base64 = len == 0 ? "" : Base64.getEncoder().encodeToString(bytes);
-        sendEnvelope(context, AgentWsEnvelope.fileChunk(instanceId, jobId, fileId, chunkIndex, base64));
+        sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
         if (gate != null) {
             try {
                 long ackTimeoutMs = 30_000L;
@@ -524,13 +522,20 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
+    private void sendBinaryChunk(SessionContext context, ByteBuffer payload) {
+        synchronized (context.webSocket) {
+            context.webSocket.sendBinary(payload, true).join();
+        }
+    }
+
     private void sendEnvelope(SessionContext context, AgentWsEnvelope envelope) throws IOException {
         synchronized (context.webSocket) {
             context.webSocket.sendText(envelope.toJson(), true).join();
         }
     }
 
-    private void handleText(String instanceId, String text, CompletableFuture<AgentWsEnvelope> helloFuture) {
+    private void handleText(String instanceId, WebSocket webSocket, String text,
+                            CompletableFuture<AgentWsEnvelope> helloFuture) {
         try {
             AgentWsEnvelope envelope = AgentWsEnvelope.fromJson(text);
             if (envelope.getType() == null) {
@@ -541,13 +546,10 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             switch (envelope.getType()) {
                 case hello -> helloFuture.complete(envelope);
                 case ack -> handleAck(envelope);
-                case file_ack -> handleFileAck(agentId, envelope);
+                case file_ack -> handleFileAck(agentId, webSocket, envelope);
                 case status_update -> handleStatusUpdate(agentId, envelope);
                 case pong -> LOG.debug(new ObjectMessage(Map.of("Message", "[WS] Pong from " + agentId)));
-                case close -> {
-                    SessionContext ctx = sessions.get(agentId);
-                    onClosed(agentId, ctx != null ? ctx.webSocket : null);
-                }
+                case close -> onClosed(agentId, webSocket);
                 default -> {
                 }
             }
@@ -565,7 +567,24 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
-    private void handleFileAck(String instanceId, AgentWsEnvelope envelope) {
+    private void handleFileAck(String instanceId, WebSocket webSocket, AgentWsEnvelope envelope) {
+        SessionContext context = sessions.get(instanceId);
+        if (context == null) {
+            LOG.info(new ObjectMessage(Map.of("Message",
+                    "[WS] Ignoring file_ack for non-active session " + instanceId)));
+            return;
+        }
+        if (webSocket == null) {
+            LOG.info(new ObjectMessage(Map.of("Message",
+                    "[WS] Ignoring file_ack without WebSocket identity for " + instanceId)));
+            return;
+        }
+        if (context.webSocket != webSocket) {
+            LOG.info(new ObjectMessage(Map.of("Message",
+                    "[WS] Ignoring stale file_ack from previous session for " + instanceId)));
+            return;
+        }
+
         // Route offer-level acks (ok, resume, failed) to the pending offer future
         if (envelope.getFileId() != null && (envelope.getStatus() == AckStatus.ok
                 || envelope.getStatus() == AckStatus.resume
@@ -577,7 +596,6 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
         }
 
-        SessionContext context = sessions.get(instanceId);
         if (envelope.getStatus() == AckStatus.all_files_complete) {
             fileTransferReady.put(instanceId, true);
             agentWsState.put(instanceId, "ready");
@@ -586,19 +604,15 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 pendingChunkAcks.remove(instanceId, pending);
                 pending.future.complete(null);
             }
-            if (context != null) {
-                context.transferCompleteFuture.complete(null);
-            }
+            context.transferCompleteFuture.complete(null);
             return;
         }
 
         if (envelope.getStatus() == AckStatus.complete) {
-            if (context != null) {
-                int completed = context.completedFiles.merge(instanceId, 1, Integer::sum);
-                agentTransferProgress.put(instanceId, completed + "/" + context.expectedFiles + " files");
-                if (context.bootstrapTransfer && completed >= context.expectedFiles) {
-                    context.transferCompleteFuture.complete(null);
-                }
+            int completed = context.completedFiles.merge(instanceId, 1, Integer::sum);
+            agentTransferProgress.put(instanceId, completed + "/" + context.expectedFiles + " files");
+            if (context.bootstrapTransfer && completed >= context.expectedFiles) {
+                context.transferCompleteFuture.complete(null);
             }
         }
 
@@ -614,9 +628,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 pendingChunkAcks.remove(instanceId, pending);
                 pending.future.completeExceptionally(new IOException(envelope.getError()));
             }
-            if (context != null) {
-                context.transferCompleteFuture.completeExceptionally(new IOException(envelope.getError()));
-            }
+            context.transferCompleteFuture.completeExceptionally(new IOException(envelope.getError()));
         }
     }
 
@@ -640,14 +652,22 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                     "[WS] Ignoring close for non-active session " + instanceId)));
             return;
         }
-        if (webSocket != null && context.webSocket != webSocket) {
+        if (webSocket == null) {
+            LOG.info(new ObjectMessage(Map.of("Message",
+                    "[WS] Ignoring close without WebSocket identity for " + instanceId)));
+            return;
+        }
+        if (context.webSocket != webSocket) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring stale close from previous session for " + instanceId)));
             return;
         }
-        if (sessions.remove(instanceId, context)) {
-            context.markClosed();
+        if (!sessions.remove(instanceId, context)) {
+            LOG.info(new ObjectMessage(Map.of("Message",
+                    "[WS] Ignoring close for replaced session " + instanceId)));
+            return;
         }
+        context.markClosed();
         fileTransferReady.remove(instanceId);
         PendingChunkAck pending = pendingChunkAcks.remove(instanceId);
         if (pending != null) {
@@ -677,7 +697,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             if (last) {
                 String fullMessage = messageBuffer.toString();
                 messageBuffer.setLength(0);
-                handleText(instanceId, fullMessage, helloFuture);
+                handleText(instanceId, webSocket, fullMessage, helloFuture);
             }
             webSocket.request(1);
             return null;

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -47,9 +47,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private static final String SCRIPT_FILE_NAME = "script.xml";
     private static final String LOCAL_CONTROLLER_ORIGIN = "http://localhost:8080";
     private static final int DEFAULT_CHUNK_BYTES =
-            Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 4 * 1024 * 1024));
+            Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 2 * 1024 * 1024));
     private static final int CHUNK_ACK_WINDOW =
-            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 64));
+            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -47,9 +47,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private static final String SCRIPT_FILE_NAME = "script.xml";
     private static final String LOCAL_CONTROLLER_ORIGIN = "http://localhost:8080";
     private static final int DEFAULT_CHUNK_BYTES =
-            Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 2 * 1024 * 1024));
+            Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 4 * 1024 * 1024));
     private static final int CHUNK_ACK_WINDOW =
-            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
+            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 64));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -51,7 +51,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private static final int CHUNK_ACK_WINDOW =
             Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
-            Long.getLong("tank.ws.bootstrap.maxConnectionMs", 30_000L);
+            Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
 
     private final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
@@ -260,7 +260,11 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
     private boolean pushStartupBootstrapJar(String agentId, SessionContext context, long transferTimeoutMillis)
             throws Exception {
-        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId + " needs startup bootstrap — pushing harness JAR")));
+        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId
+                + " needs startup bootstrap — pushing harness JAR"
+                + " chunkBytes=" + DEFAULT_CHUNK_BYTES
+                + " ackWindow=" + CHUNK_ACK_WINDOW
+                + " maxConnectionMs=" + MAX_BOOTSTRAP_CONNECTION_MS)));
         File harnessJar = findHarnessJar();
         if (harnessJar == null || !harnessJar.exists() || !harnessJar.isFile()) {
             LOG.error(new ObjectMessage(Map.of("Message", "[WS] Harness JAR not found on controller for startup bootstrap")));
@@ -419,6 +423,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         long totalBytes = content != null ? content.length : 0L;
         int totalChunks = Math.max(1, (int) Math.ceil((double) totalBytes / chunkBytes));
         String fileId = UUID.randomUUID().toString();
+        long transferStartedAtNs = System.nanoTime();
 
         // Send offer and wait for ack (may include resume offset)
         CompletableFuture<AgentWsEnvelope> offerAckFuture = new CompletableFuture<>();
@@ -481,7 +486,28 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             sendChunk(context, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
             chunkIndex++;
         }
+        logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
+                startOffset, chunkIndex - startChunk, transferStartedAtNs);
         return true;
+    }
+
+    private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
+                                         int chunkBytes, int startOffset, int chunksSent, long transferStartedAtNs) {
+        long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs);
+        long sentBytes = Math.max(0L, totalBytes - startOffset);
+        double throughputMiBps = durationMs > 0
+                ? Math.round(((sentBytes / (1024.0 * 1024.0)) / (durationMs / 1000.0)) * 100.0) / 100.0
+                : 0.0;
+        LOG.info(new ObjectMessage(Map.of("Message",
+                "[WS] File transfer complete for " + instanceId
+                        + " file=" + file.fileName()
+                        + " bytes=" + totalBytes
+                        + " chunks=" + chunksSent + "/" + totalChunks
+                        + " chunkBytes=" + chunkBytes
+                        + " resumed=" + (startOffset > 0)
+                        + " resumeOffset=" + startOffset
+                        + " durationMs=" + durationMs
+                        + " throughputMiBps=" + throughputMiBps)));
     }
 
     private void sendChunk(SessionContext context, String instanceId, String fileId,


### PR DESCRIPTION
## Summary

Fixes slow cross-region agent bootstrap by switching WebSocket file transfer chunks from base64 text frames to binary frames.

This reduces overhead during controller-to-agent bootstrap file delivery, especially for EAST controller -> WEST agent traffic, where bootstrap was taking ~4-5 minutes before this work. Also increases the bootstrap connection budget and adds transfer timing/throughput logs so we can see whether future bottlenecks are network, reconnects, or transfer behavior.

## What Changed

- Added binary WebSocket file chunk support for startup bootstrap and harness file transfer.
- Updated controller transfer logic to send binary chunks instead of base64-encoded JSON payloads.
- Added agent-side binary chunk handling for both startup and apiharness WS servers.
- Increased startup bootstrap connection budget to reduce reconnect/resume loops on slower cross-region transfers.
- Added transfer completion metrics: duration, chunk count, chunk size, resume offset, throughput.


Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.