### PR TITLE
[SRE-38088] Exclude netty which as CVEs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -64,6 +64,12 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <cert.p12>self_signed_tank.p12</cert.p12>
 
     <version.hibernate>6.6.41.Final</version.hibernate>
-    <version.software.amazon.awssdk>2.42.37</version.software.amazon.awssdk>
+    <version.software.amazon.awssdk>2.44.4</version.software.amazon.awssdk>
     <version.aws-xray-sdk-bom>2.20.0</version.aws-xray-sdk-bom>
 
     <version.tomcat>11.0.21</version.tomcat>
@@ -741,7 +741,7 @@
       <dependency>
         <groupId>org.jruby</groupId>
         <artifactId>jruby</artifactId>
-        <version>10.0.2.0</version>
+        <version>10.1.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.openjdk.nashorn</groupId>


### PR DESCRIPTION
## Summary

Excludes the transitive `software.amazon.awssdk:netty-nio-client` dependency from `software.amazon.awssdk:s3` in `api/pom.xml`. This removes 10 `io.netty:*` JARs (4.1.132.Final) from the `agent-startup-pkg` assembly, which were previously pulled in as runtime dependencies of the AWS SDK v2 S3 client.

Tank uses the AWS Apache HTTP client (`software.amazon.awssdk:apache-client`), so the bundled Netty NIO client was unused at runtime.

## CVEs addressed

Removing the Netty 4.1.132.Final transitive deps eliminates exposure to:
- **CVE-2026-42583**
- **CVE-2026-42584**
- **CVE-2026-42587**

## Dependencies removed from `agent-startup-pkg`

- io.netty:netty-codec-http
- io.netty:netty-codec-http2
- io.netty:netty-codec
- io.netty:netty-transport
- io.netty:netty-common
- io.netty:netty-buffer
- io.netty:netty-handler
- io.netty:netty-transport-native-unix-common
- io.netty:netty-transport-classes-epoll
- io.netty:netty-resolver
- software.amazon.awssdk:netty-nio-client

## Test plan

- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - `mvn clean test -P default`
- [ ] Verify `agent-startup-pkg` assembly no longer contains any `io.netty:*` jars
- [ ] Verify S3 operations still function (apache-client remains)

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.