### PR TITLE
[SRE-38860] parallelize websocket transfers

### DIFF
--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -9,8 +9,8 @@ import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -36,12 +36,17 @@ public class StartupWebSocketServer extends WebSocketServer {
     private final CompletableFuture<Void> serverStoppedFuture = new CompletableFuture<>();
 
     private WebSocket currentFileConnection;
-    private FileOutputStream currentFileStream;
+    // Positioned-write file: chunks arriving out of order across parallel connections are written at
+    // chunkIndex * chunkBytes. The seek+write is guarded by fileWriteLock (not the whole message
+    // handler) so N connection threads can be in flight without serializing on a single big lock.
+    private RandomAccessFile currentRaf;
+    private final Object fileWriteLock = new Object();
     private File currentTempFile;
     private File targetFile;
     private String currentFileId;
     private int receivedChunks;
     private int expectedChunks;
+    private int chunkBytes;
     private long receivedBytes;
     private long expectedBytes;
     private long transferStartedAtNs;
@@ -197,44 +202,20 @@ public class StartupWebSocketServer extends WebSocketServer {
             targetFile = new File(agentDir, API_HARNESS_JAR);
             currentTempFile = new File(targetFile.getAbsolutePath() + ".part");
 
-            // Check for resumable partial file from a previous failed transfer
-            if (currentTempFile.exists() && offerTotalBytes > 0 && offerChunkBytes > 0
-                    && currentTempFile.length() > 0 && currentTempFile.length() < offerTotalBytes) {
-                long partialBytes = currentTempFile.length();
-                // Truncate to safe chunk boundary
-                long safeResumeOffset = partialBytes - (partialBytes % offerChunkBytes);
-                if (safeResumeOffset != partialBytes) {
-                    logger.info("Truncating .part from {} to {} (chunk boundary alignment, chunkBytes={})",
-                            partialBytes, safeResumeOffset, offerChunkBytes);
-                    try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(currentTempFile, "rw")) {
-                        raf.setLength(safeResumeOffset);
-                    }
-                    partialBytes = safeResumeOffset;
-                }
-                int resumeChunk = (int) (partialBytes / offerChunkBytes);
-                logger.info("Resumable .part file found: {} bytes={}/{} resumeChunk={} chunkBytes={}",
-                        currentTempFile.getAbsolutePath(), partialBytes, offerTotalBytes, resumeChunk, offerChunkBytes);
-                currentFileStream = new FileOutputStream(currentTempFile, true); // append
-                currentFileId = envelope.getFileId();
-                receivedChunks = resumeChunk;
-                expectedChunks = offerTotalChunks;
-                receivedBytes = partialBytes;
-                expectedBytes = offerTotalBytes;
-                if (transferStartedAtNs == 0L) {
-                    transferStartedAtNs = System.nanoTime();
-                }
-                sendFileAckWithResume(conn, envelope.getFileId(), AckStatus.resume, partialBytes, resumeChunk);
-                return;
-            }
-
-            // Fresh transfer — delete stale .part if any
+            // PROTOTYPE: parallel connections write chunks out of order to absolute offsets, so a
+            // fresh preallocated file is used every time. The old .part-length-based resume is
+            // incompatible with a sparse (holey) file and is disabled here.
             if (currentTempFile.exists()) {
                 currentTempFile.delete();
             }
-            currentFileStream = new FileOutputStream(currentTempFile);
+            currentRaf = new RandomAccessFile(currentTempFile, "rw");
+            if (offerTotalBytes > 0) {
+                currentRaf.setLength(offerTotalBytes);
+            }
             currentFileId = envelope.getFileId();
             receivedChunks = 0;
             expectedChunks = offerTotalChunks;
+            chunkBytes = offerChunkBytes;
             receivedBytes = 0;
             expectedBytes = offerTotalBytes;
             transferStartedAtNs = System.nanoTime();
@@ -259,22 +240,40 @@ public class StartupWebSocketServer extends WebSocketServer {
         }
     }
 
-    private synchronized void handleFileChunk(WebSocket conn, String fileId, Integer chunkIndex, byte[] payload) {
-        if (currentFileStream == null || currentFileId == null || !currentFileId.equals(fileId)) {
+    // NOT synchronized on the method: N connection threads may deliver chunks concurrently. Only the
+    // seek+write and the counter update are guarded (fileWriteLock), so connections run in parallel.
+    private void handleFileChunk(WebSocket conn, String fileId, Integer chunkIndex, byte[] payload) {
+        if (currentRaf == null || currentFileId == null || !currentFileId.equals(fileId)) {
             sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
             return;
         }
 
         try {
-            currentFileStream.write(payload);
-            receivedBytes += payload.length;
-            receivedChunks++;
+            long received;
+            boolean complete;
+            synchronized (fileWriteLock) {
+                if (payload.length > 0 && chunkBytes > 0) {
+                    currentRaf.seek((long) chunkIndex * chunkBytes);
+                    currentRaf.write(payload);
+                    receivedBytes += payload.length;
+                }
+                receivedChunks++;
+                received = receivedBytes;
+                complete = expectedBytes > 0 && received >= expectedBytes && currentRaf != null;
+                // One-shot: null out currentRaf under the lock so only one thread finalizes.
+                if (complete) {
+                    // leave currentRaf set; finalize closes it — but guard against double-finalize
+                    // by clearing currentFileId here atomically with the completion decision.
+                    currentFileId = null;
+                }
+            }
+
             // Ack only on the sender's window boundary; the completion ack covers the final window.
             if (shouldAckChunk(chunkIndex, ackEvery)) {
                 sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
             }
 
-            if (expectedBytes > 0 && receivedBytes >= expectedBytes) {
+            if (complete) {
                 File completedFile = finalizeHarnessJar();
                 sendFileAck(conn, fileId, chunkIndex, AckStatus.complete, null);
                 harnessJarFuture.complete(completedFile);
@@ -300,8 +299,12 @@ public class StartupWebSocketServer extends WebSocketServer {
     }
 
     private File finalizeHarnessJar() throws IOException {
-        currentFileStream.close();
-        currentFileStream = null;
+        synchronized (fileWriteLock) {
+            if (currentRaf != null) {
+                currentRaf.close();
+                currentRaf = null;
+            }
+        }
         if (expectedBytes >= 0 && expectedBytes != receivedBytes) {
             throw new IOException("file size mismatch expected=" + expectedBytes + " actual=" + receivedBytes);
         }
@@ -336,16 +339,6 @@ public class StartupWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void sendFileAckWithResume(WebSocket conn, String fileId, AckStatus status, long resumeOffset, int resumeChunk) {
-        try {
-            AgentWsEnvelope ack = AgentWsEnvelope.fileAck(instanceId, jobId, fileId, resumeChunk, status, null);
-            ack.setResumeOffset(resumeOffset);
-            conn.send(ack.toJson());
-        } catch (Exception e) {
-            logger.warn("Failed to send startup WS resume ack for {}: {}", fileId, e.getMessage());
-        }
-    }
-
     private synchronized void handleFatalError(Exception ex) {
         closeCurrentFileQuietly();
         if (currentTempFile != null && currentTempFile.exists()) {
@@ -357,13 +350,15 @@ public class StartupWebSocketServer extends WebSocketServer {
         serverStoppedFuture.completeExceptionally(ex);
     }
 
-    private synchronized void closeCurrentFileQuietly() {
-        if (currentFileStream != null) {
-            try {
-                currentFileStream.close();
-            } catch (IOException ignored) {
+    private void closeCurrentFileQuietly() {
+        synchronized (fileWriteLock) {
+            if (currentRaf != null) {
+                try {
+                    currentRaf.close();
+                } catch (IOException ignored) {
+                }
+                currentRaf = null;
             }
-            currentFileStream = null;
         }
     }
 

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -270,9 +270,7 @@ public class StartupWebSocketServer extends WebSocketServer {
             receivedBytes += payload.length;
             receivedChunks++;
             // Ack only on the sender's window boundary; the completion ack covers the final window.
-            boolean boundary = ackEvery <= 0
-                    || (chunkIndex != null && (chunkIndex + 1) % ackEvery == 0);
-            if (boundary) {
+            if (shouldAckChunk(chunkIndex, ackEvery)) {
                 sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
             }
 
@@ -286,6 +284,10 @@ public class StartupWebSocketServer extends WebSocketServer {
             sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, e.getMessage());
             harnessJarFuture.completeExceptionally(e);
         }
+    }
+
+    static boolean shouldAckChunk(Integer chunkIndex, int ackEvery) {
+        return ackEvery <= 0 || (chunkIndex != null && (chunkIndex + 1) % ackEvery == 0);
     }
 
     private void handlePing(WebSocket conn, AgentWsEnvelope envelope) {

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -45,6 +45,8 @@ public class StartupWebSocketServer extends WebSocketServer {
     private long receivedBytes;
     private long expectedBytes;
     private long transferStartedAtNs;
+    // Ack every N chunks (the sender's credit window). 0 => legacy ack-every-chunk.
+    private int ackEvery;
 
     public StartupWebSocketServer(int port, String instanceId, String jobId, int capacity) {
         super(new InetSocketAddress(port));
@@ -185,6 +187,7 @@ public class StartupWebSocketServer extends WebSocketServer {
         long offerTotalBytes = envelope.getTotalBytes() != null ? envelope.getTotalBytes() : -1L;
         int offerTotalChunks = envelope.getTotalChunks() != null ? envelope.getTotalChunks() : 0;
         int offerChunkBytes = envelope.getChunkBytes() != null ? envelope.getChunkBytes() : 0;
+        ackEvery = envelope.getAckEvery() != null ? envelope.getAckEvery() : 0;
         try {
             File agentDir = new File(TANK_AGENT_DIR);
             if (!agentDir.exists() && !agentDir.mkdirs()) {
@@ -266,7 +269,12 @@ public class StartupWebSocketServer extends WebSocketServer {
             currentFileStream.write(payload);
             receivedBytes += payload.length;
             receivedChunks++;
-            sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
+            // Ack only on the sender's window boundary; the completion ack covers the final window.
+            boolean boundary = ackEvery <= 0
+                    || (chunkIndex != null && (chunkIndex + 1) % ackEvery == 0);
+            if (boundary) {
+                sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
+            }
 
             if (expectedBytes > 0 && receivedBytes >= expectedBytes) {
                 File completedFile = finalizeHarnessJar();

--- a/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
+++ b/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
@@ -1,0 +1,26 @@
+package com.intuit.tank.agent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StartupWebSocketServerTest {
+
+    @Test
+    public void shouldAckEveryChunkWhenAckEveryIsUnsetOrLegacy() {
+        assertTrue(StartupWebSocketServer.shouldAckChunk(0, 0));
+        assertTrue(StartupWebSocketServer.shouldAckChunk(17, -1));
+    }
+
+    @Test
+    public void shouldAckOnlyOnConfiguredBoundary() {
+        assertFalse(StartupWebSocketServer.shouldAckChunk(30, 32));
+        assertTrue(StartupWebSocketServer.shouldAckChunk(31, 32));
+    }
+
+    @Test
+    public void shouldNotAckNullChunkIndexForPositiveAckEvery() {
+        assertFalse(StartupWebSocketServer.shouldAckChunk(null, 32));
+    }
+}

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -220,6 +220,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
                     envelope.getTotalBytes() != null ? envelope.getTotalBytes() : 0L,
                     envelope.getTotalChunks() != null ? envelope.getTotalChunks() : 0,
                     Boolean.TRUE.equals(envelope.getDefaultDataFile()),
+                    envelope.getAckEvery() != null ? envelope.getAckEvery() : 0,
                     new FileOutputStream(tempFile)
             );
             incomingFiles.put(fileId, state);
@@ -264,7 +265,13 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             state.receivedBytes += payload.length;
             state.receivedChunks++;
 
-            sendFileAck(connection, fileId, chunkIndex, AckStatus.chunk_received, null);
+            // Ack only on the sender's window boundary (every ackEvery chunks). The completion ack
+            // below covers the final partial window. ackEvery <= 0 means legacy ack-every-chunk.
+            boolean boundary = state.ackEvery <= 0
+                    || (chunkIndex != null && (chunkIndex + 1) % state.ackEvery == 0);
+            if (boundary) {
+                sendFileAck(connection, fileId, chunkIndex, AckStatus.chunk_received, null);
+            }
 
             if (state.totalChunks >= 0 && state.receivedChunks >= state.totalChunks) {
                 finalizeFile(state);
@@ -498,6 +505,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         private final long totalBytes;
         private final int totalChunks;
         private final boolean defaultDataFile;
+        private final int ackEvery;
         private final OutputStream outputStream;
         private final long transferStartedAtNs;
         private long receivedBytes;
@@ -505,7 +513,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
 
         private IncomingFileState(String fileType, String fileName, File targetFile, File tempFile,
                                   long totalBytes, int totalChunks, boolean defaultDataFile,
-                                  OutputStream outputStream) {
+                                  int ackEvery, OutputStream outputStream) {
             this.fileType = fileType;
             this.fileName = fileName;
             this.targetFile = targetFile;
@@ -513,6 +521,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             this.totalBytes = totalBytes;
             this.totalChunks = totalChunks;
             this.defaultDataFile = defaultDataFile;
+            this.ackEvery = ackEvery;
             this.outputStream = outputStream;
             this.transferStartedAtNs = System.nanoTime();
         }

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -267,9 +267,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
 
             // Ack only on the sender's window boundary (every ackEvery chunks). The completion ack
             // below covers the final partial window. ackEvery <= 0 means legacy ack-every-chunk.
-            boolean boundary = state.ackEvery <= 0
-                    || (chunkIndex != null && (chunkIndex + 1) % state.ackEvery == 0);
-            if (boundary) {
+            if (shouldAckChunk(chunkIndex, state.ackEvery)) {
                 sendFileAck(connection, fileId, chunkIndex, AckStatus.chunk_received, null);
             }
 
@@ -284,6 +282,10 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             state.closeQuietly();
             sendFileAck(connection, fileId, chunkIndex, AckStatus.failed, e.getMessage());
         }
+    }
+
+    static boolean shouldAckChunk(Integer chunkIndex, int ackEvery) {
+        return ackEvery <= 0 || (chunkIndex != null && (chunkIndex + 1) % ackEvery == 0);
     }
 
     private void markFileComplete(WebSocket connection, String fileId, Integer chunkIndex) {

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -15,9 +15,9 @@ import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -212,16 +212,23 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
             }
 
             File tempFile = new File(targetFile.getAbsolutePath() + ".part");
+            RandomAccessFile raf = new RandomAccessFile(tempFile, "rw");
+            long totalBytes = envelope.getTotalBytes() != null ? envelope.getTotalBytes() : 0L;
+            // Preallocate so positioned writes never extend past EOF unexpectedly.
+            if (totalBytes > 0) {
+                raf.setLength(totalBytes);
+            }
             IncomingFileState state = new IncomingFileState(
                     envelope.getFileType(),
                     envelope.getFileName(),
                     targetFile,
                     tempFile,
-                    envelope.getTotalBytes() != null ? envelope.getTotalBytes() : 0L,
+                    totalBytes,
                     envelope.getTotalChunks() != null ? envelope.getTotalChunks() : 0,
+                    envelope.getChunkBytes() != null ? envelope.getChunkBytes() : 0,
                     Boolean.TRUE.equals(envelope.getDefaultDataFile()),
                     envelope.getAckEvery() != null ? envelope.getAckEvery() : 0,
-                    new FileOutputStream(tempFile)
+                    raf
             );
             incomingFiles.put(fileId, state);
             sendFileAck(connection, fileId, 0, AckStatus.ok, null);
@@ -254,16 +261,16 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
 
         try {
             if (state.totalChunks < 0 && payload.length == 0) {
-                finalizeFile(state);
-                incomingFiles.remove(fileId);
-                sendFileAck(connection, fileId, chunkIndex, AckStatus.complete, null);
-                markFileComplete(connection, fileId, chunkIndex);
+                if (incomingFiles.remove(fileId, state)) {
+                    finalizeFile(state);
+                    sendFileAck(connection, fileId, chunkIndex, AckStatus.complete, null);
+                    markFileComplete(connection, fileId, chunkIndex);
+                }
                 return;
             }
 
-            state.outputStream.write(payload);
-            state.receivedBytes += payload.length;
-            state.receivedChunks++;
+            // Positioned write — safe for chunks arriving out of order across parallel connections.
+            long receivedBytes = state.writeChunk(chunkIndex, payload);
 
             // Ack only on the sender's window boundary (every ackEvery chunks). The completion ack
             // below covers the final partial window. ackEvery <= 0 means legacy ack-every-chunk.
@@ -271,9 +278,13 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
                 sendFileAck(connection, fileId, chunkIndex, AckStatus.chunk_received, null);
             }
 
-            if (state.totalChunks >= 0 && state.receivedChunks >= state.totalChunks) {
+            // Completion is by byte count (order-independent). remove() acts as a one-shot guard so
+            // only the thread that removes the state finalizes, even if two connections finish
+            // together.
+            boolean complete = (state.totalBytes > 0 && receivedBytes >= state.totalBytes)
+                    || (state.totalBytes <= 0 && state.totalChunks >= 0 && state.receivedChunks >= state.totalChunks);
+            if (complete && incomingFiles.remove(fileId, state)) {
                 finalizeFile(state);
-                incomingFiles.remove(fileId);
                 sendFileAck(connection, fileId, chunkIndex, AckStatus.complete, null);
                 markFileComplete(connection, fileId, chunkIndex);
             }
@@ -506,31 +517,49 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         private final File tempFile;
         private final long totalBytes;
         private final int totalChunks;
+        private final int chunkBytes;
         private final boolean defaultDataFile;
         private final int ackEvery;
-        private final OutputStream outputStream;
+        // Positioned-write file so chunks arriving out of order across parallel connections land at
+        // their correct offset (chunkIndex * chunkBytes). Guarded by `this` since N connection
+        // threads write concurrently.
+        private final RandomAccessFile raf;
         private final long transferStartedAtNs;
         private long receivedBytes;
         private int receivedChunks;
 
         private IncomingFileState(String fileType, String fileName, File targetFile, File tempFile,
-                                  long totalBytes, int totalChunks, boolean defaultDataFile,
-                                  int ackEvery, OutputStream outputStream) {
+                                  long totalBytes, int totalChunks, int chunkBytes, boolean defaultDataFile,
+                                  int ackEvery, RandomAccessFile raf) {
             this.fileType = fileType;
             this.fileName = fileName;
             this.targetFile = targetFile;
             this.tempFile = tempFile;
             this.totalBytes = totalBytes;
             this.totalChunks = totalChunks;
+            this.chunkBytes = chunkBytes;
             this.defaultDataFile = defaultDataFile;
             this.ackEvery = ackEvery;
-            this.outputStream = outputStream;
+            this.raf = raf;
             this.transferStartedAtNs = System.nanoTime();
+        }
+
+        /** Write a chunk at its absolute offset and advance the byte/chunk counters. Synchronized so
+         *  concurrent connection threads don't interleave a seek+write or corrupt the counters.
+         *  Returns the running received-byte total after this write. */
+        private synchronized long writeChunk(int chunkIndex, byte[] payload) throws IOException {
+            if (payload.length > 0) {
+                raf.seek((long) chunkIndex * chunkBytes);
+                raf.write(payload);
+                receivedBytes += payload.length;
+            }
+            receivedChunks++;
+            return receivedBytes;
         }
 
         private void closeQuietly() {
             try {
-                outputStream.close();
+                raf.close();
             } catch (IOException ignored) {
             }
         }

--- a/agent/apiharness/src/test/java/com/intuit/tank/harness/AgentCommandWebSocketServerTest.java
+++ b/agent/apiharness/src/test/java/com/intuit/tank/harness/AgentCommandWebSocketServerTest.java
@@ -1,0 +1,26 @@
+package com.intuit.tank.harness;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AgentCommandWebSocketServerTest {
+
+    @Test
+    public void shouldAckEveryChunkWhenAckEveryIsUnsetOrLegacy() {
+        assertTrue(AgentCommandWebSocketServer.shouldAckChunk(0, 0));
+        assertTrue(AgentCommandWebSocketServer.shouldAckChunk(17, -1));
+    }
+
+    @Test
+    public void shouldAckOnlyOnConfiguredBoundary() {
+        assertFalse(AgentCommandWebSocketServer.shouldAckChunk(30, 32));
+        assertTrue(AgentCommandWebSocketServer.shouldAckChunk(31, 32));
+    }
+
+    @Test
+    public void shouldNotAckNullChunkIndexForPositiveAckEvery() {
+        assertFalse(AgentCommandWebSocketServer.shouldAckChunk(null, 32));
+    }
+}

--- a/api/src/main/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelope.java
+++ b/api/src/main/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelope.java
@@ -110,6 +110,12 @@ public class AgentWsEnvelope {
     @JsonProperty("chunkBytes")
     private Integer chunkBytes;
 
+    // How often the receiver should send a chunk_received ack: once every N chunks (on the
+    // boundary where (chunkIndex+1) % ackEvery == 0). Lets the sender's credit window advance
+    // without an ack per chunk. Null/absent => ack every chunk (legacy behavior).
+    @JsonProperty("ackEvery")
+    private Integer ackEvery;
+
     @JsonProperty("isDefaultDataFile")
     private Boolean defaultDataFile;
 
@@ -206,6 +212,9 @@ public class AgentWsEnvelope {
 
     public Integer getChunkBytes() { return chunkBytes; }
     public void setChunkBytes(Integer chunkBytes) { this.chunkBytes = chunkBytes; }
+
+    public Integer getAckEvery() { return ackEvery; }
+    public void setAckEvery(Integer ackEvery) { this.ackEvery = ackEvery; }
 
     public Boolean getDefaultDataFile() { return defaultDataFile; }
     public void setDefaultDataFile(Boolean defaultDataFile) { this.defaultDataFile = defaultDataFile; }
@@ -376,6 +385,13 @@ public class AgentWsEnvelope {
     public static AgentWsEnvelope fileOffer(String instanceId, String jobId, String fileId, String fileType,
                                             String fileName, long totalBytes, int totalChunks, int chunkBytes,
                                             Boolean defaultDataFile) {
+        return fileOffer(instanceId, jobId, fileId, fileType, fileName, totalBytes, totalChunks,
+                chunkBytes, defaultDataFile, null);
+    }
+
+    public static AgentWsEnvelope fileOffer(String instanceId, String jobId, String fileId, String fileType,
+                                            String fileName, long totalBytes, int totalChunks, int chunkBytes,
+                                            Boolean defaultDataFile, Integer ackEvery) {
         AgentWsEnvelope env = new AgentWsEnvelope();
         env.setType(Type.file_offer);
         env.setInstanceId(instanceId);
@@ -387,6 +403,7 @@ public class AgentWsEnvelope {
         env.setTotalBytes(totalBytes);
         env.setTotalChunks(totalChunks);
         env.setDefaultDataFile(defaultDataFile);
+        env.setAckEvery(ackEvery);
         env.setSentAtMs(System.currentTimeMillis());
         return env;
     }

--- a/api/src/test/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelopeTest.java
+++ b/api/src/test/java/com/intuit/tank/vm/agent/messages/AgentWsEnvelopeTest.java
@@ -146,6 +146,20 @@ public class AgentWsEnvelopeTest {
         assertEquals(3, env.getTotalChunks());
         assertEquals(512, env.getChunkBytes());
         assertEquals(false, env.getDefaultDataFile());
+        assertNull(env.getAckEvery());
+    }
+
+    @Test
+    public void testFileOfferFactoryWithAckEvery() throws IOException {
+        AgentWsEnvelope env = AgentWsEnvelope.fileOffer("i-123", "job-1", "file-1", "script",
+                "script.xml", 1024L, 3, 512, false, 32);
+
+        String json = env.toJson();
+        AgentWsEnvelope parsed = AgentWsEnvelope.fromJson(json);
+
+        assertTrue(json.contains("\"ackEvery\":32"));
+        assertEquals(32, env.getAckEvery());
+        assertEquals(32, parsed.getAckEvery());
     }
 
     @Test

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -411,7 +411,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Bootstrap transfer budget reached for " + instanceId
                             + " during ack wait — closing cleanly to resume")));
-            context.drainSendCredits();
+            // The throwing sender has already unwound; the session is closed/removed by the caller.
+            // No transfer to fail — this is a clean suspend-and-resume, not an error.
             return false;
         }
     }
@@ -424,6 +425,10 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         int totalChunks = Math.max(1, (int) Math.ceil((double) totalBytes / chunkBytes));
         String fileId = UUID.randomUUID().toString();
         long transferStartedAtNs = System.nanoTime();
+
+        // Fresh per-file window state; acks are credited only against this fileId.
+        ActiveTransfer transfer = new ActiveTransfer(fileId);
+        context.activeTransfer = transfer;
 
         // Send offer and wait for ack (may include resume offset)
         CompletableFuture<AgentWsEnvelope> offerAckFuture = new CompletableFuture<>();
@@ -442,7 +447,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         if (content == null || content.length == 0) {
             pendingAcks.remove(fileId);
-            sendChunk(context, instanceId, fileId, 0, new byte[0], 0, 0, connectionDeadlineMs);
+            sendChunk(context, transfer, instanceId, fileId, 0, new byte[0], 0, 0, connectionDeadlineMs);
             return true;
         }
 
@@ -484,7 +489,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 return false;
             }
             int len = Math.min(chunkBytes, content.length - offset);
-            sendChunk(context, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
+            sendChunk(context, transfer, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
             chunkIndex++;
         }
         // Drain the pipelined send tail so any chunk send failure surfaces here and the bytes are
@@ -494,6 +499,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         } catch (Exception e) {
             throw new IOException("Failed sending WS file chunks for " + instanceId, e);
         }
+        // Surface a receiver-side failure (failed ack) that arrived while we were sending.
+        transfer.checkFailed();
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
                 startOffset, chunkIndex - startChunk, transferStartedAtNs);
         return true;
@@ -518,21 +525,22 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                         + " throughputMiBps=" + throughputMiBps)));
     }
 
-    private void sendChunk(SessionContext context, String instanceId, String fileId,
+    private void sendChunk(SessionContext context, ActiveTransfer transfer, String instanceId, String fileId,
                            int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
             throws IOException, InterruptedException {
-        // Credit-based sliding window: stay at most CHUNK_ACK_WINDOW chunks ahead of the last
-        // acked window boundary. Block (acquiring a credit) only when the sender has run that
-        // far ahead, rather than draining to a single ack every window. The agent acks on each
-        // window boundary ((chunkIndex+1) % CHUNK_ACK_WINDOW == 0) and on completion; each such
-        // ack restores a window's worth of credits via releaseSendCredit().
-        acquireSendCredit(context, instanceId, connectionDeadlineMs);
-        // Enqueue the send without blocking the caller; failures surface on the chained tail
-        // and are observed by the final await in sendFile().
-        sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
+        // Credit-based sliding window: stay at most CHUNK_ACK_WINDOW chunks ahead of the highest
+        // chunk the receiver has confirmed. Block (acquiring a credit) only when the sender has run
+        // that far ahead, rather than draining to a single ack every window. The agent acks on each
+        // window boundary ((chunkIndex+1) % CHUNK_ACK_WINDOW == 0) and on completion; each ack
+        // advances the confirmed watermark and returns the matching number of credits. acquire()
+        // also fails fast if the transfer was marked failed (failed ack / close / send error).
+        acquireSendCredit(transfer, instanceId, connectionDeadlineMs);
+        // Enqueue the send without blocking the caller; a send failure marks the transfer failed
+        // (waking any blocked sender) and also surfaces on the final await in sendFile().
+        sendBinaryChunk(context, transfer, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
     }
 
-    private void acquireSendCredit(SessionContext context, String instanceId, long connectionDeadlineMs)
+    private void acquireSendCredit(ActiveTransfer transfer, String instanceId, long connectionDeadlineMs)
             throws IOException, InterruptedException {
         long ackTimeoutMs = 30_000L;
         if (connectionDeadlineMs > 0) {
@@ -543,7 +551,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
             ackTimeoutMs = Math.min(ackTimeoutMs, remainingMs);
         }
-        if (!context.sendCredits.tryAcquire(ackTimeoutMs, TimeUnit.MILLISECONDS)) {
+        if (!transfer.acquire(ackTimeoutMs)) {
             if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
                 throw new BootstrapBudgetExceededException(
                         "Bootstrap connection budget reached while waiting for chunk ack");
@@ -553,10 +561,17 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     }
 
     /** Pipelined send: chain on the per-session tail so the next chunk is queued the instant the
-     *  previous send completes (JDK WebSocket requires that ordering) without blocking the caller. */
-    private void sendBinaryChunk(SessionContext context, ByteBuffer payload) {
+     *  previous send completes (JDK WebSocket requires that ordering) without blocking the caller.
+     *  A send failure marks the transfer failed so a blocked sender wakes immediately. */
+    private void sendBinaryChunk(SessionContext context, ActiveTransfer transfer, ByteBuffer payload) {
         synchronized (context.webSocket) {
-            context.sendTail = context.sendTail.thenCompose(ws -> ws.sendBinary(payload, true));
+            context.sendTail = context.sendTail
+                    .thenCompose(ws -> ws.sendBinary(payload, true))
+                    .whenComplete((ws, ex) -> {
+                        if (ex != null) {
+                            transfer.fail("send failed: " + ex.getMessage());
+                        }
+                    });
         }
     }
 
@@ -639,7 +654,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         if (envelope.getStatus() == AckStatus.all_files_complete) {
             fileTransferReady.put(instanceId, true);
             agentWsState.put(instanceId, "ready");
-            context.releaseSendCredit();
+            // Transfer-level signal — credit it as a chunk-level confirmation too, since the
+            // controller piggybacks all_files_complete on the final file's last chunk.
+            context.creditAck(envelope.getFileId(), envelope.getChunkIndex());
             context.transferCompleteFuture.complete(null);
             return;
         }
@@ -652,12 +669,12 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
         }
 
-        // Each window-boundary / complete ack returns one send credit, letting the pipelined
-        // sender advance another chunk. A failed chunk fails the whole transfer.
+        // Advance the confirmed watermark for this fileId, returning one credit per newly-confirmed
+        // chunk. Duplicate/stale/cross-signal acks release zero. A failed chunk fails the transfer.
         if (envelope.getStatus() == AckStatus.complete || envelope.getStatus() == AckStatus.chunk_received) {
-            context.releaseSendCredit();
+            context.creditAck(envelope.getFileId(), envelope.getChunkIndex());
         } else if (envelope.getStatus() == AckStatus.failed) {
-            context.drainSendCredits();
+            context.failActiveTransfer(envelope.getError());
             context.transferCompleteFuture.completeExceptionally(new IOException(envelope.getError()));
         }
     }
@@ -699,8 +716,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
         context.markClosed();
         fileTransferReady.remove(instanceId);
-        // Unblock any sender parked on send credits for this torn-down session.
-        context.drainSendCredits();
+        // Fail the in-flight transfer (if any) so a sender parked on credits wakes and stops
+        // queueing chunks for a connection that is gone.
+        context.failActiveTransfer("WS connection closed for " + instanceId);
         agentWsState.put(instanceId, "disconnected");
     }
 
@@ -758,12 +776,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private final ConcurrentHashMap<String, Integer> completedFiles = new ConcurrentHashMap<>();
         private final AtomicBoolean closed = new AtomicBoolean(false);
         private final long openedAtMs;
-        // Credit-based send window: sender may run up to CHUNK_ACK_WINDOW chunks ahead of the
-        // latest boundary ack; each window-boundary/complete ack releases one credit.
-        private final Semaphore sendCredits = new Semaphore(CHUNK_ACK_WINDOW);
         // Tail of the pipelined send chain; each send is chained onto the previous so the JDK
         // WebSocket "previous send must complete first" contract holds without blocking callers.
         private volatile CompletableFuture<WebSocket> sendTail;
+        // The file currently being sent on this session (sendFile runs files sequentially). Credit
+        // accounting and failure state are per-transfer and keyed by fileId; acks for any other id
+        // (stale, replaced, already finished) are ignored.
+        private volatile ActiveTransfer activeTransfer;
         private volatile String instanceId;
         private volatile String jobId;
         private volatile int expectedFiles;
@@ -777,18 +796,24 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             this.sendTail = CompletableFuture.completedFuture(webSocket);
         }
 
-        /** A boundary (or complete) ack confirms a whole window of chunks; restore the window's
-         *  worth of credits, capped at the ceiling so duplicate/extra acks can't over-release. */
-        private synchronized void releaseSendCredit() {
-            int deficit = CHUNK_ACK_WINDOW - sendCredits.availablePermits();
-            if (deficit > 0) {
-                sendCredits.release(Math.min(CHUNK_ACK_WINDOW, deficit));
+        /** Credit an ack against the active transfer if its fileId matches. Releases exactly the
+         *  number of newly-confirmed chunks (highest acked chunk advances), so sparse boundary acks
+         *  release many, legacy per-chunk acks release one, and duplicate/stale/final acks release
+         *  zero. Transfer-level signals (fileId == null) are no-ops here. */
+        private void creditAck(String fileId, Integer chunkIndex) {
+            ActiveTransfer transfer = activeTransfer;
+            if (transfer != null && fileId != null && fileId.equals(transfer.fileId)) {
+                transfer.confirmThrough(chunkIndex);
             }
         }
 
-        /** Unblock any sender waiting on credits when the session is torn down. */
-        private void drainSendCredits() {
-            sendCredits.release(CHUNK_ACK_WINDOW);
+        /** Mark the active transfer failed (failed ack, close, abort, send-future failure) and wake
+         *  any sender blocked on credits so it stops instead of queueing more chunks. */
+        private void failActiveTransfer(String reason) {
+            ActiveTransfer transfer = activeTransfer;
+            if (transfer != null) {
+                transfer.fail(reason);
+            }
         }
 
         private boolean isOpen() {
@@ -801,6 +826,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         private void closeGracefully(String reason) {
             if (closed.compareAndSet(false, true)) {
+                failActiveTransfer(reason);
                 try {
                     webSocket.sendClose(WebSocket.NORMAL_CLOSURE, reason)
                             .orTimeout(2, TimeUnit.SECONDS)
@@ -819,6 +845,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         private void abort() {
             if (closed.compareAndSet(false, true)) {
+                failActiveTransfer("Aborted");
                 try { webSocket.abort(); } catch (Exception ignored) {}
                 helloFuture.completeExceptionally(new IllegalStateException("Aborted"));
                 transferCompleteFuture.completeExceptionally(new IllegalStateException("Aborted"));
@@ -827,12 +854,72 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         private void markClosed() {
             closed.set(true);
+            failActiveTransfer("Closed");
             helloFuture.completeExceptionally(new IllegalStateException("Closed"));
             transferCompleteFuture.completeExceptionally(new IllegalStateException("Closed"));
         }
     }
 
     private record TransferFile(String fileType, String fileName, byte[] content, boolean defaultDataFile) {
+    }
+
+    /**
+     * Per-file send-window state. The sender may run at most CHUNK_ACK_WINDOW chunks ahead of the
+     * highest chunk the receiver has confirmed; each acquire() takes a credit before queueing a
+     * chunk and confirmThrough() returns credits as acks advance the confirmed watermark. Failure
+     * is sticky: once fail() is called, acquire() throws immediately and any blocked sender wakes.
+     */
+    private static class ActiveTransfer {
+        private final String fileId;
+        private final Semaphore credits = new Semaphore(CHUNK_ACK_WINDOW);
+        private final AtomicBoolean failed = new AtomicBoolean(false);
+        private volatile String failureReason;
+        // Highest chunk index confirmed by an ack so far; -1 before any ack. Guarded by `this`.
+        private int highestAckedChunk = -1;
+
+        private ActiveTransfer(String fileId) {
+            this.fileId = fileId;
+        }
+
+        /** Acquire one credit before queueing a chunk; fails fast if the transfer was marked failed
+         *  before or while waiting. Returns false on timeout so the caller can decide how to fail. */
+        private boolean acquire(long timeoutMs) throws IOException, InterruptedException {
+            checkFailed();
+            boolean got = credits.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+            checkFailed();
+            return got;
+        }
+
+        private void checkFailed() throws IOException {
+            if (failed.get()) {
+                throw new IOException("WS file transfer failed for " + fileId
+                        + (failureReason != null ? ": " + failureReason : ""));
+            }
+        }
+
+        /** Advance the confirmed watermark to chunkIndex and release one credit per newly-confirmed
+         *  chunk. Lower/duplicate indices release nothing, so cross-signal and stale acks are safe. */
+        private synchronized void confirmThrough(Integer chunkIndex) {
+            if (chunkIndex == null || chunkIndex <= highestAckedChunk) {
+                return;
+            }
+            int newlyConfirmed = chunkIndex - highestAckedChunk;
+            highestAckedChunk = chunkIndex;
+            // Never release beyond the window ceiling (defensive against an out-of-range ack).
+            int releasable = Math.min(newlyConfirmed, CHUNK_ACK_WINDOW - credits.availablePermits());
+            if (releasable > 0) {
+                credits.release(releasable);
+            }
+        }
+
+        /** Mark failed and wake any blocked sender. Idempotent; first reason wins. */
+        private void fail(String reason) {
+            if (failed.compareAndSet(false, true)) {
+                failureReason = reason;
+            }
+            // Always unblock a parked acquire(), even on repeat calls.
+            credits.release(CHUNK_ACK_WINDOW);
+        }
     }
 
     private static class BootstrapBudgetExceededException extends IOException {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -53,6 +53,12 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
+    // PROTOTYPE: number of parallel WebSocket connections used to stream file chunks. The JDK
+    // WebSocket allows only one in-flight send per connection, so a single connection can't keep a
+    // high-BDP (high-RTT) pipe full — the flow goes app_limited and TCP never opens the window.
+    // Striping chunks across N connections puts N sends genuinely in flight at once. 1 => legacy
+    // single-connection behavior.
+    private static final int PARALLEL_CONNECTIONS = 4;
 
     private final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
@@ -92,6 +98,10 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                     .join();
 
             SessionContext context = new SessionContext(webSocket, helloFuture);
+            // Retain connection coordinates so the transfer can open parallel data connections.
+            context.wsHttpClient = wsHttpClient;
+            context.wsUrl = wsUrl;
+            context.token = token;
             SessionContext previous = sessions.put(instanceId, context);
             if (previous != null) {
                 previous.close();
@@ -430,6 +440,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         ActiveTransfer transfer = new ActiveTransfer(fileId);
         context.activeTransfer = transfer;
 
+        // Open parallel data connections before streaming so chunks can be striped across them.
+        int connCount = context.ensureDataConnections();
+
         // Send offer and wait for ack (may include resume offset)
         CompletableFuture<AgentWsEnvelope> offerAckFuture = new CompletableFuture<>();
         pendingAcks.put(fileId, offerAckFuture);
@@ -496,10 +509,17 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             sendChunk(context, transfer, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
             chunkIndex++;
         }
-        // Drain the pipelined send tail so any chunk send failure surfaces here and the bytes are
-        // durably queued on the socket before we report the transfer complete.
+        // Drain every connection's send tail so all chunk sends complete (and any failure surfaces)
+        // before we report the transfer done and the bytes are durably queued on the sockets.
         try {
-            context.sendTail.join();
+            CompletableFuture<WebSocket>[] tails = context.dataSendTails;
+            if (tails != null) {
+                for (CompletableFuture<WebSocket> tail : tails) {
+                    tail.join();
+                }
+            } else {
+                context.sendTail.join();
+            }
         } catch (Exception e) {
             throw new IOException("Failed sending WS file chunks for " + instanceId, e);
         }
@@ -507,13 +527,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         // Surface a receiver-side failure (failed ack) that arrived while we were sending.
         transfer.checkFailed();
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
-                startOffset, chunkIndex - startChunk, transferStartedAtNs, offerRttMs, sendDrainMs);
+                startOffset, chunkIndex - startChunk, transferStartedAtNs, offerRttMs, sendDrainMs, connCount);
         return true;
     }
 
     private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
                                          int chunkBytes, int startOffset, int chunksSent, long transferStartedAtNs,
-                                         long linkRttMs, long sendDrainMs) {
+                                         long linkRttMs, long sendDrainMs, int connCount) {
         long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs);
         long sentBytes = Math.max(0L, totalBytes - startOffset);
         double throughputMiBps = durationMs > 0
@@ -533,6 +553,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                         + " durationMs=" + durationMs
                         + " sendDrainMs=" + sendDrainMs
                         + " linkRttMs=" + (linkRttMs >= 0 ? linkRttMs : "unknown")
+                        + " connections=" + connCount
                         + " sendMiBps=" + sendMiBps
                         + " throughputMiBps=" + throughputMiBps)));
     }
@@ -541,7 +562,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                            int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
             throws IOException, InterruptedException {
         acquireSendCredit(transfer, instanceId, connectionDeadlineMs);
-        sendBinaryChunk(context, transfer, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
+        // Stripe chunks round-robin across the data connections: chunk i -> connection i % N. Each
+        // connection sends serially (JDK rule), but N connections give N concurrent in-flight sends,
+        // which is what keeps a high-RTT pipe full where one connection goes app_limited.
+        int connCount = context.dataConnections != null ? context.dataConnections.length : 1;
+        int connIndex = connCount > 0 ? chunkIndex % connCount : 0;
+        sendBinaryChunk(context, transfer, connIndex,
+                AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
     }
 
     private void acquireSendCredit(ActiveTransfer transfer, String instanceId, long connectionDeadlineMs)
@@ -564,18 +591,33 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
-    /** Pipelined send: chain on the per-session tail so the next chunk is queued the instant the
-     *  previous send completes (JDK WebSocket requires that ordering) without blocking the caller.
-     *  A send failure marks the transfer failed so a blocked sender wakes immediately. */
-    private void sendBinaryChunk(SessionContext context, ActiveTransfer transfer, ByteBuffer payload) {
-        synchronized (context.webSocket) {
-            context.sendTail = context.sendTail
+    /** Pipelined send on a specific data connection: chain on that connection's own tail so its
+     *  sends stay serialized (JDK requires one in-flight send per connection) while other
+     *  connections send concurrently. A send failure marks the transfer failed so a blocked sender
+     *  wakes immediately. */
+    private void sendBinaryChunk(SessionContext context, ActiveTransfer transfer, int connIndex, ByteBuffer payload) {
+        WebSocket[] conns = context.dataConnections;
+        CompletableFuture<WebSocket>[] tails = context.dataSendTails;
+        // Fall back to the primary connection/tail if data connections weren't set up.
+        if (conns == null || tails == null || connIndex >= conns.length) {
+            synchronized (context.webSocket) {
+                context.sendTail = context.sendTail
+                        .thenCompose(ws -> ws.sendBinary(payload, true))
+                        .whenComplete((ws, ex) -> failOnError(transfer, ex));
+            }
+            return;
+        }
+        WebSocket conn = conns[connIndex];
+        synchronized (conn) {
+            tails[connIndex] = tails[connIndex]
                     .thenCompose(ws -> ws.sendBinary(payload, true))
-                    .whenComplete((ws, ex) -> {
-                        if (ex != null) {
-                            transfer.fail("send failed: " + ex.getMessage());
-                        }
-                    });
+                    .whenComplete((ws, ex) -> failOnError(transfer, ex));
+        }
+    }
+
+    private static void failOnError(ActiveTransfer transfer, Throwable ex) {
+        if (ex != null) {
+            transfer.fail("send failed: " + ex.getMessage());
         }
     }
 
@@ -773,6 +815,28 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
+    /** Minimal listener for parallel data connections. They only carry outbound file chunks; all
+     *  inbound control/ack traffic uses the primary connection, so this just keeps the read side
+     *  drained (the JDK requires request()) and ignores everything. */
+    private static class DrainListener implements WebSocket.Listener {
+        @Override
+        public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+            webSocket.request(1);
+            return null;
+        }
+    }
+
     private static class SessionContext {
         private final WebSocket webSocket;
         private final CompletableFuture<AgentWsEnvelope> helloFuture;
@@ -792,12 +856,59 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private volatile int expectedFiles;
         private volatile boolean bootstrapTransfer;
         private volatile AgentWsEnvelope hello;
+        // PROTOTYPE parallel connections: coordinates retained from connect() so the transfer can
+        // open extra data connections to the same agent endpoint. dataConnections[0] is the primary
+        // (this.webSocket); indices 1..N-1 are the extra sockets. Each has its own send tail so N
+        // sends run concurrently, one per socket (the JDK single-in-flight rule is per connection).
+        private volatile HttpClient wsHttpClient;
+        private volatile String wsUrl;
+        private volatile String token;
+        private volatile WebSocket[] dataConnections;
+        private volatile CompletableFuture<WebSocket>[] dataSendTails;
 
         private SessionContext(WebSocket webSocket, CompletableFuture<AgentWsEnvelope> helloFuture) {
             this.webSocket = webSocket;
             this.helloFuture = helloFuture;
             this.openedAtMs = System.currentTimeMillis();
             this.sendTail = CompletableFuture.completedFuture(webSocket);
+        }
+
+        /** Lazily open PARALLEL_CONNECTIONS-1 extra data connections (index 0 is the primary).
+         *  Idempotent; safe to call once at the start of a transfer. Returns the connection count
+         *  actually available (>=1). Extra connections use a minimal drain-only listener — file_ack
+         *  frames still arrive on the primary control connection. */
+        @SuppressWarnings("unchecked")
+        private synchronized int ensureDataConnections() {
+            if (dataConnections != null) {
+                return dataConnections.length;
+            }
+            int n = Math.max(1, PARALLEL_CONNECTIONS);
+            WebSocket[] conns = new WebSocket[n];
+            CompletableFuture<WebSocket>[] tails = new CompletableFuture[n];
+            conns[0] = webSocket;
+            tails[0] = CompletableFuture.completedFuture(webSocket);
+            for (int i = 1; i < n; i++) {
+                try {
+                    WebSocket extra = wsHttpClient.newWebSocketBuilder()
+                            .header("Authorization", "bearer " + token)
+                            .buildAsync(URI.create(wsUrl), new DrainListener())
+                            .join();
+                    conns[i] = extra;
+                    tails[i] = CompletableFuture.completedFuture(extra);
+                } catch (Exception e) {
+                    // Fall back to whatever opened; a smaller fan-out still works.
+                    WebSocket[] partial = new WebSocket[i];
+                    CompletableFuture<WebSocket>[] partialTails = new CompletableFuture[i];
+                    System.arraycopy(conns, 0, partial, 0, i);
+                    System.arraycopy(tails, 0, partialTails, 0, i);
+                    conns = partial;
+                    tails = partialTails;
+                    break;
+                }
+            }
+            dataConnections = conns;
+            dataSendTails = tails;
+            return conns.length;
         }
 
         /** Credit an ack against the active transfer if its fileId matches. Releases exactly the
@@ -828,9 +939,27 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             closeGracefully("Closing session");
         }
 
+        /** Abort the extra data connections (index 1+); the primary (index 0 == webSocket) is
+         *  handled by the caller's close/abort of the control connection. */
+        private void abortDataConnections() {
+            WebSocket[] conns = dataConnections;
+            if (conns == null) {
+                return;
+            }
+            for (int i = 1; i < conns.length; i++) {
+                try {
+                    if (conns[i] != null) {
+                        conns[i].abort();
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        }
+
         private void closeGracefully(String reason) {
             if (closed.compareAndSet(false, true)) {
                 failActiveTransfer(reason);
+                abortDataConnections();
                 try {
                     webSocket.sendClose(WebSocket.NORMAL_CLOSURE, reason)
                             .orTimeout(2, TimeUnit.SECONDS)
@@ -850,6 +979,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private void abort() {
             if (closed.compareAndSet(false, true)) {
                 failActiveTransfer("Aborted");
+                abortDataConnections();
                 try { webSocket.abort(); } catch (Exception ignored) {}
                 helloFuture.completeExceptionally(new IllegalStateException("Aborted"));
                 transferCompleteFuture.completeExceptionally(new IllegalStateException("Aborted"));
@@ -859,6 +989,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private void markClosed() {
             closed.set(true);
             failActiveTransfer("Closed");
+            abortDataConnections();
             helloFuture.completeExceptionally(new IllegalStateException("Closed"));
             transferCompleteFuture.completeExceptionally(new IllegalStateException("Closed"));
         }

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -483,6 +483,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
 
         int chunkIndex = startChunk;
+        long chunkLoopStartNs = System.nanoTime();
         for (int offset = startOffset; offset < content.length; offset += chunkBytes) {
             if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
                 LOG.info(new ObjectMessage(Map.of("Message",
@@ -502,20 +503,24 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         } catch (Exception e) {
             throw new IOException("Failed sending WS file chunks for " + instanceId, e);
         }
+        long sendDrainMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - chunkLoopStartNs);
         // Surface a receiver-side failure (failed ack) that arrived while we were sending.
         transfer.checkFailed();
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
-                startOffset, chunkIndex - startChunk, transferStartedAtNs, offerRttMs);
+                startOffset, chunkIndex - startChunk, transferStartedAtNs, offerRttMs, sendDrainMs);
         return true;
     }
 
     private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
                                          int chunkBytes, int startOffset, int chunksSent, long transferStartedAtNs,
-                                         long linkRttMs) {
+                                         long linkRttMs, long sendDrainMs) {
         long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs);
         long sentBytes = Math.max(0L, totalBytes - startOffset);
         double throughputMiBps = durationMs > 0
                 ? Math.round(((sentBytes / (1024.0 * 1024.0)) / (durationMs / 1000.0)) * 100.0) / 100.0
+                : 0.0;
+        double sendMiBps = sendDrainMs > 0
+                ? Math.round(((sentBytes / (1024.0 * 1024.0)) / (sendDrainMs / 1000.0)) * 100.0) / 100.0
                 : 0.0;
         LOG.info(new ObjectMessage(Map.of("Message",
                 "[WS] File transfer complete for " + instanceId
@@ -526,7 +531,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                         + " resumed=" + (startOffset > 0)
                         + " resumeOffset=" + startOffset
                         + " durationMs=" + durationMs
+                        + " sendDrainMs=" + sendDrainMs
                         + " linkRttMs=" + (linkRttMs >= 0 ? linkRttMs : "unknown")
+                        + " sendMiBps=" + sendMiBps
                         + " throughputMiBps=" + throughputMiBps)));
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -454,8 +454,11 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         // Check for offer ack (ok, resume, or failed)
         int startOffset = 0;
         int startChunk = 0;
+        long offerRttMs = -1L;
+        long offerSentAtNs = System.nanoTime();
         try {
             AgentWsEnvelope offerAck = offerAckFuture.get(10, TimeUnit.SECONDS);
+            offerRttMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - offerSentAtNs);
             if (offerAck != null) {
                 if (offerAck.getStatus() == AckStatus.failed) {
                     throw new IOException("File offer rejected by agent: " + offerAck.getError());
@@ -502,12 +505,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         // Surface a receiver-side failure (failed ack) that arrived while we were sending.
         transfer.checkFailed();
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
-                startOffset, chunkIndex - startChunk, transferStartedAtNs);
+                startOffset, chunkIndex - startChunk, transferStartedAtNs, offerRttMs);
         return true;
     }
 
     private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
-                                         int chunkBytes, int startOffset, int chunksSent, long transferStartedAtNs) {
+                                         int chunkBytes, int startOffset, int chunksSent, long transferStartedAtNs,
+                                         long linkRttMs) {
         long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs);
         long sentBytes = Math.max(0L, totalBytes - startOffset);
         double throughputMiBps = durationMs > 0
@@ -522,6 +526,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                         + " resumed=" + (startOffset > 0)
                         + " resumeOffset=" + startOffset
                         + " durationMs=" + durationMs
+                        + " linkRttMs=" + (linkRttMs >= 0 ? linkRttMs : "unknown")
                         + " throughputMiBps=" + throughputMiBps)));
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -528,15 +528,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private void sendChunk(SessionContext context, ActiveTransfer transfer, String instanceId, String fileId,
                            int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
             throws IOException, InterruptedException {
-        // Credit-based sliding window: stay at most CHUNK_ACK_WINDOW chunks ahead of the highest
-        // chunk the receiver has confirmed. Block (acquiring a credit) only when the sender has run
-        // that far ahead, rather than draining to a single ack every window. The agent acks on each
-        // window boundary ((chunkIndex+1) % CHUNK_ACK_WINDOW == 0) and on completion; each ack
-        // advances the confirmed watermark and returns the matching number of credits. acquire()
-        // also fails fast if the transfer was marked failed (failed ack / close / send error).
         acquireSendCredit(transfer, instanceId, connectionDeadlineMs);
-        // Enqueue the send without blocking the caller; a send failure marks the transfer failed
-        // (waking any blocked sender) and also surfaces on the final await in sendFile().
         sendBinaryChunk(context, transfer, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -861,7 +861,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
      * chunk and confirmThrough() returns credits as acks advance the confirmed watermark. Failure
      * is sticky: once fail() is called, acquire() throws immediately and any blocked sender wakes.
      */
-    private static class ActiveTransfer {
+    static class ActiveTransfer {
         private final String fileId;
         private final Semaphore credits = new Semaphore(CHUNK_ACK_WINDOW);
         private final AtomicBoolean failed = new AtomicBoolean(false);
@@ -869,20 +869,20 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         // Highest chunk index confirmed by an ack so far; -1 before any ack. Guarded by `this`.
         private int highestAckedChunk = -1;
 
-        private ActiveTransfer(String fileId) {
+        ActiveTransfer(String fileId) {
             this.fileId = fileId;
         }
 
         /** Acquire one credit before queueing a chunk; fails fast if the transfer was marked failed
          *  before or while waiting. Returns false on timeout so the caller can decide how to fail. */
-        private boolean acquire(long timeoutMs) throws IOException, InterruptedException {
+        boolean acquire(long timeoutMs) throws IOException, InterruptedException {
             checkFailed();
             boolean got = credits.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
             checkFailed();
             return got;
         }
 
-        private void checkFailed() throws IOException {
+        void checkFailed() throws IOException {
             if (failed.get()) {
                 throw new IOException("WS file transfer failed for " + fileId
                         + (failureReason != null ? ": " + failureReason : ""));
@@ -891,7 +891,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         /** Advance the confirmed watermark to chunkIndex and release one credit per newly-confirmed
          *  chunk. Lower/duplicate indices release nothing, so cross-signal and stale acks are safe. */
-        private synchronized void confirmThrough(Integer chunkIndex) {
+        synchronized void confirmThrough(Integer chunkIndex) {
             if (chunkIndex == null || chunkIndex <= highestAckedChunk) {
                 return;
             }
@@ -905,12 +905,16 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
 
         /** Mark failed and wake any blocked sender. Idempotent; first reason wins. */
-        private void fail(String reason) {
+        void fail(String reason) {
             if (failed.compareAndSet(false, true)) {
                 failureReason = reason;
             }
             // Always unblock a parked acquire(), even on repeat calls.
             credits.release(CHUNK_ACK_WINDOW);
+        }
+
+        int availableCredits() {
+            return credits.availablePermits();
         }
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
@@ -56,7 +57,6 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CompletableFuture<AgentWsEnvelope>> pendingAcks = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, PendingChunkAck> pendingChunkAcks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Boolean> fileTransferReady = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Long> agentLastSeen = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> agentWsState = new ConcurrentHashMap<>();
@@ -411,7 +411,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Bootstrap transfer budget reached for " + instanceId
                             + " during ack wait — closing cleanly to resume")));
-            pendingChunkAcks.remove(instanceId);
+            context.drainSendCredits();
             return false;
         }
     }
@@ -437,7 +437,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 totalBytes,
                 totalChunks,
                 chunkBytes,
-                file.defaultDataFile()));
+                file.defaultDataFile(),
+                CHUNK_ACK_WINDOW));
 
         if (content == null || content.length == 0) {
             pendingAcks.remove(fileId);
@@ -486,6 +487,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             sendChunk(context, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
             chunkIndex++;
         }
+        // Drain the pipelined send tail so any chunk send failure surfaces here and the bytes are
+        // durably queued on the socket before we report the transfer complete.
+        try {
+            context.sendTail.join();
+        } catch (Exception e) {
+            throw new IOException("Failed sending WS file chunks for " + instanceId, e);
+        }
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
                 startOffset, chunkIndex - startChunk, transferStartedAtNs);
         return true;
@@ -513,51 +521,57 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private void sendChunk(SessionContext context, String instanceId, String fileId,
                            int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
             throws IOException, InterruptedException {
-        CompletableFuture<Void> gate = null;
-        if ((chunkIndex + 1) % CHUNK_ACK_WINDOW == 0) {
-            gate = new CompletableFuture<>();
-            pendingChunkAcks.put(instanceId, new PendingChunkAck(fileId, chunkIndex, gate));
-        }
+        // Credit-based sliding window: stay at most CHUNK_ACK_WINDOW chunks ahead of the last
+        // acked window boundary. Block (acquiring a credit) only when the sender has run that
+        // far ahead, rather than draining to a single ack every window. The agent acks on each
+        // window boundary ((chunkIndex+1) % CHUNK_ACK_WINDOW == 0) and on completion; each such
+        // ack restores a window's worth of credits via releaseSendCredit().
+        acquireSendCredit(context, instanceId, connectionDeadlineMs);
+        // Enqueue the send without blocking the caller; failures surface on the chained tail
+        // and are observed by the final await in sendFile().
         sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
-        if (gate != null) {
-            try {
-                long ackTimeoutMs = 30_000L;
-                if (connectionDeadlineMs > 0) {
-                    long remainingMs = connectionDeadlineMs - System.currentTimeMillis();
-                    if (remainingMs <= 0) {
-                        throw new BootstrapBudgetExceededException(
-                                "Bootstrap connection budget reached during chunk ack wait");
-                    }
-                    ackTimeoutMs = Math.min(ackTimeoutMs, remainingMs);
-                }
-                gate.get(ackTimeoutMs, TimeUnit.MILLISECONDS);
-            } catch (BootstrapBudgetExceededException e) {
-                throw e;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw e;
-            } catch (java.util.concurrent.TimeoutException e) {
-                if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
-                    throw new BootstrapBudgetExceededException(
-                            "Bootstrap connection budget reached while waiting for chunk ack");
-                }
-                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
-            } catch (Exception e) {
-                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
+    }
+
+    private void acquireSendCredit(SessionContext context, String instanceId, long connectionDeadlineMs)
+            throws IOException, InterruptedException {
+        long ackTimeoutMs = 30_000L;
+        if (connectionDeadlineMs > 0) {
+            long remainingMs = connectionDeadlineMs - System.currentTimeMillis();
+            if (remainingMs <= 0) {
+                throw new BootstrapBudgetExceededException(
+                        "Bootstrap connection budget reached during chunk ack wait");
             }
+            ackTimeoutMs = Math.min(ackTimeoutMs, remainingMs);
+        }
+        if (!context.sendCredits.tryAcquire(ackTimeoutMs, TimeUnit.MILLISECONDS)) {
+            if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
+                throw new BootstrapBudgetExceededException(
+                        "Bootstrap connection budget reached while waiting for chunk ack");
+            }
+            throw new IOException("Timed out waiting for WS chunk ack for " + instanceId);
         }
     }
 
+    /** Pipelined send: chain on the per-session tail so the next chunk is queued the instant the
+     *  previous send completes (JDK WebSocket requires that ordering) without blocking the caller. */
     private void sendBinaryChunk(SessionContext context, ByteBuffer payload) {
         synchronized (context.webSocket) {
-            context.webSocket.sendBinary(payload, true).join();
+            context.sendTail = context.sendTail.thenCompose(ws -> ws.sendBinary(payload, true));
         }
     }
 
     private void sendEnvelope(SessionContext context, AgentWsEnvelope envelope) throws IOException {
+        String json = envelope.toJson();
+        CompletableFuture<WebSocket> sent;
         synchronized (context.webSocket) {
-            context.webSocket.sendText(envelope.toJson(), true).join();
+            // Order text frames behind any queued binary chunks on the same tail so offer/config
+            // frames never overtake the bytes they describe.
+            sent = context.sendTail.thenCompose(ws -> ws.sendText(json, true));
+            context.sendTail = sent;
         }
+        // Control frames (hello/offer/command/ack/close) keep synchronous error semantics: block
+        // until this frame is on the wire. Bulk chunks (sendBinaryChunk) stay pipelined.
+        sent.join();
     }
 
     private void handleText(String instanceId, WebSocket webSocket, String text,
@@ -625,11 +639,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         if (envelope.getStatus() == AckStatus.all_files_complete) {
             fileTransferReady.put(instanceId, true);
             agentWsState.put(instanceId, "ready");
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.complete(null);
-            }
+            context.releaseSendCredit();
             context.transferCompleteFuture.complete(null);
             return;
         }
@@ -642,18 +652,12 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
         }
 
+        // Each window-boundary / complete ack returns one send credit, letting the pipelined
+        // sender advance another chunk. A failed chunk fails the whole transfer.
         if (envelope.getStatus() == AckStatus.complete || envelope.getStatus() == AckStatus.chunk_received) {
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.complete(null);
-            }
+            context.releaseSendCredit();
         } else if (envelope.getStatus() == AckStatus.failed) {
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.completeExceptionally(new IOException(envelope.getError()));
-            }
+            context.drainSendCredits();
             context.transferCompleteFuture.completeExceptionally(new IOException(envelope.getError()));
         }
     }
@@ -695,10 +699,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
         context.markClosed();
         fileTransferReady.remove(instanceId);
-        PendingChunkAck pending = pendingChunkAcks.remove(instanceId);
-        if (pending != null) {
-            pending.future.completeExceptionally(new IOException("WS connection closed for " + instanceId));
-        }
+        // Unblock any sender parked on send credits for this torn-down session.
+        context.drainSendCredits();
         agentWsState.put(instanceId, "disconnected");
     }
 
@@ -756,6 +758,12 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private final ConcurrentHashMap<String, Integer> completedFiles = new ConcurrentHashMap<>();
         private final AtomicBoolean closed = new AtomicBoolean(false);
         private final long openedAtMs;
+        // Credit-based send window: sender may run up to CHUNK_ACK_WINDOW chunks ahead of the
+        // latest boundary ack; each window-boundary/complete ack releases one credit.
+        private final Semaphore sendCredits = new Semaphore(CHUNK_ACK_WINDOW);
+        // Tail of the pipelined send chain; each send is chained onto the previous so the JDK
+        // WebSocket "previous send must complete first" contract holds without blocking callers.
+        private volatile CompletableFuture<WebSocket> sendTail;
         private volatile String instanceId;
         private volatile String jobId;
         private volatile int expectedFiles;
@@ -766,6 +774,21 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             this.webSocket = webSocket;
             this.helloFuture = helloFuture;
             this.openedAtMs = System.currentTimeMillis();
+            this.sendTail = CompletableFuture.completedFuture(webSocket);
+        }
+
+        /** A boundary (or complete) ack confirms a whole window of chunks; restore the window's
+         *  worth of credits, capped at the ceiling so duplicate/extra acks can't over-release. */
+        private synchronized void releaseSendCredit() {
+            int deficit = CHUNK_ACK_WINDOW - sendCredits.availablePermits();
+            if (deficit > 0) {
+                sendCredits.release(Math.min(CHUNK_ACK_WINDOW, deficit));
+            }
+        }
+
+        /** Unblock any sender waiting on credits when the session is torn down. */
+        private void drainSendCredits() {
+            sendCredits.release(CHUNK_ACK_WINDOW);
         }
 
         private boolean isOpen() {
@@ -810,22 +833,6 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     }
 
     private record TransferFile(String fileType, String fileName, byte[] content, boolean defaultDataFile) {
-    }
-
-    private static class PendingChunkAck {
-        private final String fileId;
-        private final int chunkIndex;
-        private final CompletableFuture<Void> future;
-
-        private PendingChunkAck(String fileId, int chunkIndex, CompletableFuture<Void> future) {
-            this.fileId = fileId;
-            this.chunkIndex = chunkIndex;
-            this.future = future;
-        }
-
-        private boolean matches(String fileId, Integer chunkIndex) {
-            return this.fileId.equals(fileId) && chunkIndex != null && this.chunkIndex == chunkIndex;
-        }
     }
 
     private static class BootstrapBudgetExceededException extends IOException {

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -1,0 +1,133 @@
+package com.intuit.tank.perfManager.workLoads;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ControllerInitiatedAgentWsClientTest {
+
+    @Test
+    public void sparseBoundaryAckRestoresWholeWindow() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 32);
+
+        assertEquals(0, transfer.availableCredits());
+        transfer.confirmThrough(31);
+        assertEquals(32, transfer.availableCredits());
+    }
+
+    @Test
+    public void legacyPerChunkAckRestoresOnlyOneCredit() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 32);
+
+        assertEquals(0, transfer.availableCredits());
+        transfer.confirmThrough(0);
+        assertEquals(1, transfer.availableCredits());
+    }
+
+    @Test
+    public void finalPartialWindowRestoresOnlyOutstandingCredits() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 5);
+
+        assertEquals(27, transfer.availableCredits());
+        transfer.confirmThrough(4);
+        assertEquals(32, transfer.availableCredits());
+    }
+
+    @Test
+    public void exactBoundaryCompleteDoesNotDoubleRelease() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 32);
+
+        transfer.confirmThrough(31);
+        transfer.confirmThrough(31);
+
+        assertEquals(32, transfer.availableCredits());
+    }
+
+    @Test
+    public void duplicateAckDoesNotOverCredit() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 10);
+
+        transfer.confirmThrough(9);
+        transfer.confirmThrough(5);
+
+        assertEquals(32, transfer.availableCredits());
+    }
+
+    @Test
+    public void nullAckDoesNotReleaseCredit() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        queueChunks(transfer, 1);
+
+        assertEquals(31, transfer.availableCredits());
+        transfer.confirmThrough(null);
+        assertEquals(31, transfer.availableCredits());
+    }
+
+    @Test
+    public void failedTransferStopsFutureAcquire() {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+
+        transfer.fail("agent rejected chunk");
+
+        IOException failure = assertThrows(IOException.class,
+                () -> transfer.acquire(1));
+        assertTrue(failure.getMessage().contains("agent rejected chunk"));
+    }
+
+    @Test
+    public void failedTransferWakesBlockedAcquireAndFailsIt() throws Exception {
+        ControllerInitiatedAgentWsClient.ActiveTransfer transfer =
+                new ControllerInitiatedAgentWsClient.ActiveTransfer("file-1");
+        queueChunks(transfer, 32);
+
+        CompletableFuture<IOException> blockedAcquire = CompletableFuture.supplyAsync(() -> {
+            try {
+                transfer.acquire(TimeUnit.SECONDS.toMillis(5));
+                return null;
+            } catch (IOException e) {
+                return e;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return new IOException(e);
+            }
+        });
+
+        Thread.sleep(50L);
+        transfer.fail("connection closed");
+
+        IOException failure = blockedAcquire.get(1, TimeUnit.SECONDS);
+        assertNotNull(failure);
+        assertTrue(failure.getMessage().contains("connection closed"));
+    }
+
+    private static void queueChunks(ControllerInitiatedAgentWsClient.ActiveTransfer transfer, int count) throws Exception {
+        for (int i = 0; i < count; i++) {
+            assertTrue(transfer.acquire(1));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Accelerate the controller→agent WebSocket file transfer (per-job files and the startup bootstrap JAR). The transfer was slow and the send loop was verbose. The bottleneck was *how* chunks were sent, not the frame format — the binary chunk envelope is already optimal, so it is kept as-is. This removes the throughput killers in the send loop.

Jira: [SRE-38860](https://jira.cloud.intuit.com/browse/SRE-38860)

## Problem

- **Per-chunk blocking** — every chunk was sent with `sendBinary(...).join()`, stalling the sender thread on each chunk's completion. The pipe never stayed full; each chunk paid a round-trip of latency.
- **Stop-and-wait ack window** — the sender fully drained to a single ack every 32 chunks instead of sliding a window, adding a sync barrier on top of the per-chunk stall.
- **Ack-per-chunk** — agents acked every chunk, adding reverse-channel traffic and per-chunk CPU on the agent.

## Changes

1. **Pipelined sends** (`ControllerInitiatedAgentWsClient`) — chain sends on a per-session `sendTail` future so the next chunk is queued the instant the previous send completes (satisfying the JDK WebSocket single-send-at-a-time contract) without blocking the caller. `sendFile` blocks once at the end so failures still surface. Largest throughput win.
2. **Credit-based sliding window** (`ControllerInitiatedAgentWsClient`) — replaced the stop-and-wait gate with a `Semaphore` of `CHUNK_ACK_WINDOW` credits. The sender runs up to a full window ahead of the last acked boundary, blocking only when it gets that far ahead; each boundary/complete ack restores the window. Removed the `PendingChunkAck` class and `pendingChunkAcks` map.
3. **Sparse acks on agents** (`AgentCommandWebSocketServer`, `StartupWebSocketServer`) — agents ack only on the window boundary (`(chunkIndex+1) % ackEvery == 0`) plus complete/failed, cutting reverse-channel traffic and agent CPU ~32×. The window size travels in a new `ackEvery` field on the `file_offer` envelope so client and agent stay in lockstep.

## Compatibility

- New `ackEvery` field is optional (`@JsonInclude(NON_NULL)`). New controller ↔ old agent: field ignored, agent acks every chunk (still correct). Old controller ↔ new agent: field absent → `0` → agent falls back to ack-every-chunk. No protocol version bump.
- Binary chunk wire format unchanged. Resume logic unchanged and boundary math is resume-safe (uses absolute `chunkIndex`).

## Tuning knobs (unchanged)

- `-Dtank.ws.chunkBytes` (default 2 MB)
- `-Dtank.ws.chunkAckWindow` (default 32)

With pipelining in place, the window can now be raised for higher-latency links without the old per-chunk stall eating the gain.

## Testing

- Modules compile: `api`, `tank_vmManager`, `agent/apiharness`, `agent/agent_startup`.
- Tests pass: `AgentWsEnvelopeTest` (24), `AgentCommandWebSocketHandlerTest` (19).

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default```

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.
