### PR TITLE
[SRE-38860] Accelerate WebSocket transfer via HTTP/2 (RFC 8441) migration

### DIFF
--- a/agent/agent_startup/pom.xml
+++ b/agent/agent_startup/pom.xml
@@ -20,10 +20,14 @@
       <artifactId>api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Jetty 12 WebSocket server with HTTP/2 (RFC 8441) support -->
     <dependency>
-      <groupId>org.java-websocket</groupId>
-      <artifactId>Java-WebSocket</artifactId>
-      <version>1.5.6</version>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>jetty-websocket-jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-server</artifactId>
     </dependency>
   </dependencies>
 

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -241,7 +241,7 @@ public class StartupWebSocketServer {
 
             if (expectedBytes > 0 && receivedBytes >= expectedBytes) {
                 File completedFile = finalizeHarnessJar();
-                sendFileAck(conn, fileId, chunkIndex, AckStatus.complete, null);
+                sendFileAckSync(conn, fileId, chunkIndex, AckStatus.complete, null);
                 harnessJarFuture.complete(completedFile);
             }
         } catch (Exception e) {
@@ -294,6 +294,18 @@ public class StartupWebSocketServer {
             sendText(conn, ack.toJson());
         } catch (Exception e) {
             logger.warn("Failed to send startup WS file ack for {}: {}", fileId, e.getMessage());
+        }
+    }
+
+    /** Sends a file ack and blocks until the frame is flushed, so it cannot be lost on shutdown. */
+    private void sendFileAckSync(Session conn, String fileId, Integer chunkIndex, AckStatus status, String error) {
+        try {
+            AgentWsEnvelope ack = AgentWsEnvelope.fileAck(instanceId, jobId, fileId, chunkIndex, status, error);
+            Callback.Completable callback = new Callback.Completable();
+            conn.sendText(ack.toJson(), callback);
+            callback.get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            logger.warn("Failed to send startup WS file ack (sync) for {}: {}", fileId, e.getMessage());
         }
     }
 

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -38,6 +38,9 @@ public class StartupWebSocketServer {
     private static final String SUPPORT_JAR_FILE_TYPE = "support_jar";
     // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
     private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
+    // Raise Jetty's 30s default WS idle timeout so a slow/paused bootstrap transfer isn't dropped.
+    private static final long WS_IDLE_TIMEOUT_MS =
+            Math.max(60_000L, Long.getLong("tank.ws.idleTimeoutMs", 600_000L));
 
     private final int port;
     private final String instanceId;
@@ -84,11 +87,13 @@ public class StartupWebSocketServer {
         ServerConnector connector = new ServerConnector(server, http11, h2c);
         connector.setPort(port);
         connector.setReuseAddress(reuseAddr);
+        connector.setIdleTimeout(WS_IDLE_TIMEOUT_MS);
         server.addConnector(connector);
 
         WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
             container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
             container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.setIdleTimeout(java.time.Duration.ofMillis(WS_IDLE_TIMEOUT_MS));
             container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new StartupEndpoint(this));
         });
         server.setHandler(wsHandler);

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -89,7 +89,7 @@ public class StartupWebSocketServer {
         WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
             container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
             container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
-            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new StartupEndpoint());
+            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new StartupEndpoint(this));
         });
         server.setHandler(wsHandler);
 
@@ -353,17 +353,23 @@ public class StartupWebSocketServer {
      * Per-connection Jetty WebSocket endpoint. {@code AutoDemanding} means Jetty automatically demands
      * the next frame after each callback returns, matching the old library's push-style delivery.
      */
-    private class StartupEndpoint implements Session.Listener.AutoDemanding {
+    public static class StartupEndpoint implements Session.Listener.AutoDemanding {
 
+        private final StartupWebSocketServer server;
         private Session session;
+
+        private StartupEndpoint(StartupWebSocketServer server) {
+            this.server = server;
+        }
 
         @Override
         public void onWebSocketOpen(Session session) {
             this.session = session;
             logger.info("Controller connected to startup WS server from {}", session.getRemoteSocketAddress());
             try {
-                AgentWsEnvelope hello = AgentWsEnvelope.hello(instanceId, jobId, agentSessionId, null, capacity, true);
-                sendText(session, hello.toJson());
+                AgentWsEnvelope hello = AgentWsEnvelope.hello(
+                        server.instanceId, server.jobId, server.agentSessionId, null, server.capacity, true);
+                server.sendText(session, hello.toJson());
             } catch (Exception e) {
                 logger.warn("Failed to send startup WS hello: {}", e.getMessage());
                 session.close();
@@ -379,9 +385,9 @@ public class StartupWebSocketServer {
                     return;
                 }
                 switch (envelope.getType()) {
-                    case file_offer -> handleFileOffer(session, envelope);
+                    case file_offer -> server.handleFileOffer(session, envelope);
                     case file_chunk -> handleTextFileChunk(session, envelope);
-                    case ping -> handlePing(session, envelope);
+                    case ping -> server.handlePing(session, envelope);
                     case ack -> logger.info("Startup WS received ack: {}", envelope.getAckForType());
                     case close -> session.close();
                     default -> logger.info("Startup WS ignoring frame type: {}", envelope.getType());
@@ -395,7 +401,7 @@ public class StartupWebSocketServer {
         public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
             try {
                 AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(payload);
-                handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+                server.handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
                 callback.succeed();
             } catch (Exception e) {
                 logger.warn("Failed handling startup WS binary message: {}", e.getMessage(), e);
@@ -408,18 +414,18 @@ public class StartupWebSocketServer {
                 byte[] payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
                         ? new byte[0]
                         : java.util.Base64.getDecoder().decode(envelope.getChunkData());
-                handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
+                server.handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
             } catch (Exception e) {
-                closeCurrentFileQuietly();
-                sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
-                harnessJarFuture.completeExceptionally(e);
+                server.closeCurrentFileQuietly();
+                server.sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+                server.harnessJarFuture.completeExceptionally(e);
             }
         }
 
         @Override
         public void onWebSocketClose(int statusCode, String reason) {
             logger.info("Startup WS connection closed code={} reason={}", statusCode, reason);
-            resetFileStateForRetry(session);
+            server.resetFileStateForRetry(session);
         }
 
         @Override
@@ -427,10 +433,10 @@ public class StartupWebSocketServer {
             logger.warn("Startup WS error: {}", cause.getMessage(), cause);
             if (session == null) {
                 logger.error("Startup WS server-level error — preserving partial file for restart");
-                handleFatalError(cause instanceof Exception ? (Exception) cause : new IOException(cause));
+                server.handleFatalError(cause instanceof Exception ? (Exception) cause : new IOException(cause));
                 return;
             }
-            resetFileStateForRetry(session);
+            server.resetFileStateForRetry(session);
         }
     }
 }

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -4,30 +4,42 @@ import com.intuit.tank.vm.agent.messages.AgentWsEnvelope;
 import com.intuit.tank.vm.agent.messages.AgentWsEnvelope.AckStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.java_websocket.WebSocket;
-import org.java_websocket.handshake.ClientHandshake;
-import org.java_websocket.server.WebSocketServer;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeHandler;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-public class StartupWebSocketServer extends WebSocketServer {
+/**
+ * Agent-side WebSocket server that receives the harness JAR pushed by the controller during startup
+ * bootstrap. Runs over WebSocket-over-HTTP/2 (RFC 8441) using Jetty 12; the same connector also
+ * accepts HTTP/1.1 WebSocket upgrades so a controller may negotiate either transport via ALPN/prior
+ * knowledge.
+ */
+public class StartupWebSocketServer {
 
     private static final Logger logger = LogManager.getLogger(StartupWebSocketServer.class);
     private static final String TANK_AGENT_DIR = "/opt/tank_agent";
     private static final String API_HARNESS_JAR = "apiharness-1.0-all.jar";
     private static final String SUPPORT_JAR_FILE_TYPE = "support_jar";
+    // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
+    private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
 
+    private final int port;
     private final String instanceId;
     private final String jobId;
     private final int capacity;
@@ -35,7 +47,10 @@ public class StartupWebSocketServer extends WebSocketServer {
     private final CompletableFuture<File> harnessJarFuture = new CompletableFuture<>();
     private final CompletableFuture<Void> serverStoppedFuture = new CompletableFuture<>();
 
-    private WebSocket currentFileConnection;
+    private final Server server;
+    private boolean reuseAddr;
+
+    private Session currentFileConnection;
     private FileOutputStream currentFileStream;
     private File currentTempFile;
     private File targetFile;
@@ -47,93 +62,62 @@ public class StartupWebSocketServer extends WebSocketServer {
     private long transferStartedAtNs;
 
     public StartupWebSocketServer(int port, String instanceId, String jobId, int capacity) {
-        super(new InetSocketAddress(port));
+        this.port = port;
         this.instanceId = instanceId;
         this.jobId = jobId;
         this.capacity = capacity;
+        this.server = new Server();
     }
 
-    @Override
-    public void run() {
+    public void setReuseAddr(boolean reuseAddr) {
+        this.reuseAddr = reuseAddr;
+    }
+
+    /** Starts the embedded Jetty server. Mirrors the previous blocking-start contract. */
+    public void start() throws IOException {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        HttpConnectionFactory http11 = new HttpConnectionFactory(httpConfig);
+        // h2c cleartext HTTP/2 — enables the RFC 8441 extended CONNECT upgrade path.
+        HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(httpConfig);
+        h2c.setConnectProtocolEnabled(true);
+
+        ServerConnector connector = new ServerConnector(server, http11, h2c);
+        connector.setPort(port);
+        connector.setReuseAddress(reuseAddr);
+        server.addConnector(connector);
+
+        WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
+            container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new StartupEndpoint());
+        });
+        server.setHandler(wsHandler);
+
         try {
-            super.run();
-        } catch (Throwable t) {
-            logger.error("Startup WS server thread crashed", t);
-            serverStoppedFuture.completeExceptionally(t);
+            server.start();
+        } catch (Exception e) {
+            throw new IOException("Failed to start startup WS server on port " + port, e);
+        }
+        logger.info("Startup WS server started on port {}", port);
+    }
+
+    /** Stops the embedded server. Signature kept for callers migrating from the old library. */
+    public void stop(long timeoutMillis) throws InterruptedException {
+        try {
+            server.setStopTimeout(timeoutMillis);
+            server.stop();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (Exception e) {
+            logger.warn("Error stopping startup WS server: {}", e.getMessage());
         } finally {
             if (!harnessJarFuture.isDone()) {
                 resetFileStateForRetry(null);
-                logger.warn("Startup WS server thread exited before harness JAR was received");
-            } else {
-                logger.info("Startup WS server thread exited");
+                logger.warn("Startup WS server stopped before harness JAR was received");
             }
             serverStoppedFuture.complete(null);
         }
-    }
-
-    @Override
-    public void onOpen(WebSocket conn, ClientHandshake handshake) {
-        logger.info("Controller connected to startup WS server from {}", conn.getRemoteSocketAddress());
-        try {
-            AgentWsEnvelope hello = AgentWsEnvelope.hello(instanceId, jobId, agentSessionId, null, capacity, true);
-            conn.send(hello.toJson());
-        } catch (Exception e) {
-            logger.warn("Failed to send startup WS hello: {}", e.getMessage());
-            conn.close();
-        }
-    }
-
-    @Override
-    public void onMessage(WebSocket conn, String message) {
-        try {
-            AgentWsEnvelope envelope = AgentWsEnvelope.fromJson(message);
-            if (envelope.getType() == null) {
-                logger.warn("Startup WS frame missing type");
-                return;
-            }
-            switch (envelope.getType()) {
-                case file_offer -> handleFileOffer(conn, envelope);
-                case file_chunk -> handleFileChunk(conn, envelope);
-                case ping -> handlePing(conn, envelope);
-                case ack -> logger.info("Startup WS received ack: {}", envelope.getAckForType());
-                case close -> conn.close();
-                default -> logger.info("Startup WS ignoring frame type: {}", envelope.getType());
-            }
-        } catch (Exception e) {
-            logger.warn("Failed handling startup WS message: {}", e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public void onMessage(WebSocket conn, ByteBuffer message) {
-        try {
-            AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(message);
-            handleFileChunk(conn, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
-        } catch (Exception e) {
-            logger.warn("Failed handling startup WS binary message: {}", e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
-        logger.info("Startup WS connection closed code={} reason={} remote={}", code, reason, remote);
-        resetFileStateForRetry(conn);
-    }
-
-    @Override
-    public void onError(WebSocket conn, Exception ex) {
-        logger.warn("Startup WS error: {}", ex.getMessage(), ex);
-        if (conn == null) {
-            logger.error("Startup WS server-level error — preserving partial file for restart");
-            handleFatalError(ex);
-            return;
-        }
-        resetFileStateForRetry(conn);
-    }
-
-    @Override
-    public void onStart() {
-        logger.info("Startup WS server started on {}", getAddress());
     }
 
     public File awaitHarnessJar(long timeoutMillis) {
@@ -173,7 +157,7 @@ public class StartupWebSocketServer extends WebSocketServer {
         return serverStoppedFuture.isDone();
     }
 
-    private synchronized void handleFileOffer(WebSocket conn, AgentWsEnvelope envelope) {
+    private synchronized void handleFileOffer(Session conn, AgentWsEnvelope envelope) {
         String fileName = new File(envelope.getFileName() != null ? envelope.getFileName() : "").getName();
         String fileType = envelope.getFileType();
         if (!API_HARNESS_JAR.equals(fileName) && !SUPPORT_JAR_FILE_TYPE.equalsIgnoreCase(fileType)) {
@@ -243,20 +227,7 @@ public class StartupWebSocketServer extends WebSocketServer {
         }
     }
 
-    private synchronized void handleFileChunk(WebSocket conn, AgentWsEnvelope envelope) {
-        try {
-            byte[] payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
-                    ? new byte[0]
-                    : Base64.getDecoder().decode(envelope.getChunkData());
-            handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
-        } catch (Exception e) {
-            closeCurrentFileQuietly();
-            sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
-            harnessJarFuture.completeExceptionally(e);
-        }
-    }
-
-    private synchronized void handleFileChunk(WebSocket conn, String fileId, Integer chunkIndex, byte[] payload) {
+    private synchronized void handleFileChunk(Session conn, String fileId, Integer chunkIndex, byte[] payload) {
         if (currentFileStream == null || currentFileId == null || !currentFileId.equals(fileId)) {
             sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
             return;
@@ -280,10 +251,10 @@ public class StartupWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void handlePing(WebSocket conn, AgentWsEnvelope envelope) {
+    private void handlePing(Session conn, AgentWsEnvelope envelope) {
         try {
             AgentWsEnvelope pong = AgentWsEnvelope.pong(instanceId, agentSessionId, envelope.getPingId(), null);
-            conn.send(pong.toJson());
+            sendText(conn, pong.toJson());
         } catch (Exception e) {
             logger.warn("Failed to send startup WS pong: {}", e.getMessage());
         }
@@ -317,23 +288,27 @@ public class StartupWebSocketServer extends WebSocketServer {
         return completedFile;
     }
 
-    private void sendFileAck(WebSocket conn, String fileId, Integer chunkIndex, AckStatus status, String error) {
+    private void sendFileAck(Session conn, String fileId, Integer chunkIndex, AckStatus status, String error) {
         try {
             AgentWsEnvelope ack = AgentWsEnvelope.fileAck(instanceId, jobId, fileId, chunkIndex, status, error);
-            conn.send(ack.toJson());
+            sendText(conn, ack.toJson());
         } catch (Exception e) {
             logger.warn("Failed to send startup WS file ack for {}: {}", fileId, e.getMessage());
         }
     }
 
-    private void sendFileAckWithResume(WebSocket conn, String fileId, AckStatus status, long resumeOffset, int resumeChunk) {
+    private void sendFileAckWithResume(Session conn, String fileId, AckStatus status, long resumeOffset, int resumeChunk) {
         try {
             AgentWsEnvelope ack = AgentWsEnvelope.fileAck(instanceId, jobId, fileId, resumeChunk, status, null);
             ack.setResumeOffset(resumeOffset);
-            conn.send(ack.toJson());
+            sendText(conn, ack.toJson());
         } catch (Exception e) {
             logger.warn("Failed to send startup WS resume ack for {}: {}", fileId, e.getMessage());
         }
+    }
+
+    private void sendText(Session conn, String text) {
+        conn.sendText(text, Callback.NOOP);
     }
 
     private synchronized void handleFatalError(Exception ex) {
@@ -357,7 +332,7 @@ public class StartupWebSocketServer extends WebSocketServer {
         }
     }
 
-    private synchronized void resetFileStateForRetry(WebSocket conn) {
+    private synchronized void resetFileStateForRetry(Session conn) {
         if (currentFileConnection != null && conn != null && conn != currentFileConnection) {
             logger.info("Ignoring stale startup WS reset from previous connection");
             return;
@@ -372,5 +347,90 @@ public class StartupWebSocketServer extends WebSocketServer {
         // Reset only the stream and connection-specific state
         currentFileId = null;
         logger.info("Startup WS connection state reset — .part file preserved for resume");
+    }
+
+    /**
+     * Per-connection Jetty WebSocket endpoint. {@code AutoDemanding} means Jetty automatically demands
+     * the next frame after each callback returns, matching the old library's push-style delivery.
+     */
+    private class StartupEndpoint implements Session.Listener.AutoDemanding {
+
+        private Session session;
+
+        @Override
+        public void onWebSocketOpen(Session session) {
+            this.session = session;
+            logger.info("Controller connected to startup WS server from {}", session.getRemoteSocketAddress());
+            try {
+                AgentWsEnvelope hello = AgentWsEnvelope.hello(instanceId, jobId, agentSessionId, null, capacity, true);
+                sendText(session, hello.toJson());
+            } catch (Exception e) {
+                logger.warn("Failed to send startup WS hello: {}", e.getMessage());
+                session.close();
+            }
+        }
+
+        @Override
+        public void onWebSocketText(String message) {
+            try {
+                AgentWsEnvelope envelope = AgentWsEnvelope.fromJson(message);
+                if (envelope.getType() == null) {
+                    logger.warn("Startup WS frame missing type");
+                    return;
+                }
+                switch (envelope.getType()) {
+                    case file_offer -> handleFileOffer(session, envelope);
+                    case file_chunk -> handleTextFileChunk(session, envelope);
+                    case ping -> handlePing(session, envelope);
+                    case ack -> logger.info("Startup WS received ack: {}", envelope.getAckForType());
+                    case close -> session.close();
+                    default -> logger.info("Startup WS ignoring frame type: {}", envelope.getType());
+                }
+            } catch (Exception e) {
+                logger.warn("Failed handling startup WS message: {}", e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
+            try {
+                AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(payload);
+                handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+                callback.succeed();
+            } catch (Exception e) {
+                logger.warn("Failed handling startup WS binary message: {}", e.getMessage(), e);
+                callback.fail(e);
+            }
+        }
+
+        private void handleTextFileChunk(Session conn, AgentWsEnvelope envelope) {
+            try {
+                byte[] payload = envelope.getChunkData() == null || envelope.getChunkData().isEmpty()
+                        ? new byte[0]
+                        : java.util.Base64.getDecoder().decode(envelope.getChunkData());
+                handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
+            } catch (Exception e) {
+                closeCurrentFileQuietly();
+                sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
+                harnessJarFuture.completeExceptionally(e);
+            }
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason) {
+            logger.info("Startup WS connection closed code={} reason={}", statusCode, reason);
+            resetFileStateForRetry(session);
+        }
+
+        @Override
+        public void onWebSocketError(Throwable cause) {
+            logger.warn("Startup WS error: {}", cause.getMessage(), cause);
+            if (session == null) {
+                logger.error("Startup WS server-level error — preserving partial file for restart");
+                handleFatalError(cause instanceof Exception ? (Exception) cause : new IOException(cause));
+                return;
+            }
+            resetFileStateForRetry(session);
+        }
     }
 }

--- a/agent/apiharness/pom.xml
+++ b/agent/apiharness/pom.xml
@@ -74,10 +74,14 @@
       <artifactId>nashorn-core</artifactId>
     </dependency>
 
+    <!-- Jetty 12 WebSocket server with HTTP/2 (RFC 8441) support -->
     <dependency>
-      <groupId>org.java-websocket</groupId>
-      <artifactId>Java-WebSocket</artifactId>
-      <version>1.5.6</version>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>jetty-websocket-jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-server</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -10,15 +10,19 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ObjectMessage;
-import org.java_websocket.WebSocket;
-import org.java_websocket.handshake.ClientHandshake;
-import org.java_websocket.server.WebSocketServer;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeHandler;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
@@ -39,20 +43,31 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
-public class AgentCommandWebSocketServer extends WebSocketServer {
+/**
+ * Agent-side WebSocket server that receives job config, settings/script/data files, and control
+ * commands pushed by the controller. Runs over WebSocket-over-HTTP/2 (RFC 8441) using Jetty 12; the
+ * same connector also accepts HTTP/1.1 WebSocket upgrades for transition compatibility.
+ */
+public class AgentCommandWebSocketServer {
 
     private static final Logger LOG = LogManager.getLogger(AgentCommandWebSocketServer.class);
     private static final int MAX_APPLIED_COMMAND_IDS = 10_000;
     private static final String AGENT_HOME_DIR = "/opt/tank_agent";
     private static final String SUPPORT_ARCHIVE_FILE_TYPE = "support_archive";
     private static final String DEFAULT_SUPPORT_ARCHIVE_NAME = "agent-support-files.zip";
+    // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
+    private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
 
+    private final int port;
     private final String instanceId;
     private final String jobId;
     private final int capacity;
     private final String agentSessionId;
 
-    private final AtomicReference<WebSocket> activeConnection = new AtomicReference<>();
+    private final Server server;
+    private boolean reuseAddr = true;
+
+    private final AtomicReference<Session> activeConnection = new AtomicReference<>();
     private final Set<String> appliedCommandIds = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, IncomingFileState> incomingFiles = new ConcurrentHashMap<>();
     private final AtomicInteger completedFiles = new AtomicInteger(0);
@@ -63,38 +78,66 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
     private volatile CompletableFuture<Void> transferCompleteFuture = new CompletableFuture<>();
     private volatile int expectedFiles = -1;
     private volatile AgentTestStartData receivedJobConfig;
-    private volatile WebSocket transferCompleteAckWebSocket;
+    private volatile Session transferCompleteAckWebSocket;
     private volatile String transferCompleteAckFileId;
     private volatile Integer transferCompleteAckChunkIndex;
 
     public AgentCommandWebSocketServer(int port, String instanceId, String jobId, int capacity) {
-        super(new InetSocketAddress(port));
-        setReuseAddr(true);
+        this.port = port;
         this.instanceId = instanceId;
         this.jobId = jobId;
         this.capacity = capacity;
         this.agentSessionId = UUID.randomUUID().toString();
+        this.server = new Server();
     }
 
-    @Override
-    public void onOpen(WebSocket connection, ClientHandshake handshake) {
+    public void setReuseAddr(boolean reuseAddr) {
+        this.reuseAddr = reuseAddr;
+    }
+
+    public void start() throws IOException {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        HttpConnectionFactory http11 = new HttpConnectionFactory(httpConfig);
+        HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(httpConfig);
+        h2c.setConnectProtocolEnabled(true);
+
+        ServerConnector connector = new ServerConnector(server, http11, h2c);
+        connector.setPort(port);
+        connector.setReuseAddress(reuseAddr);
+        server.addConnector(connector);
+
+        WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
+            container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new CommandEndpoint());
+        });
+        server.setHandler(wsHandler);
+
+        try {
+            server.start();
+        } catch (Exception e) {
+            throw new IOException("Failed to start agent WS control server on port " + port, e);
+        }
+        LOG.info(new ObjectMessage(Map.of("Message", "Agent WS control server started for " + instanceId + " on port " + port)));
+    }
+
+    private void onConnectionEstablished(Session connection) {
         LOG.info(new ObjectMessage(Map.of("Message",
                 "Controller WS connected to agent " + instanceId + " from " + connection.getRemoteSocketAddress())));
-        WebSocket previous = activeConnection.getAndSet(connection);
+        Session previous = activeConnection.getAndSet(connection);
         if (previous != null && previous != connection && previous.isOpen()) {
             previous.close();
         }
         try {
             AgentWsEnvelope hello = AgentWsEnvelope.hello(instanceId, jobId, agentSessionId, lastAppliedCommandId, capacity);
-            connection.send(hello.toJson());
+            sendText(connection, hello.toJson());
         } catch (IOException e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed to send WS hello: " + e.getMessage())));
             connection.close();
         }
     }
 
-    @Override
-    public void onMessage(WebSocket connection, String message) {
+    private void onTextMessage(Session connection, String message) {
         try {
             AgentWsEnvelope envelope = AgentWsEnvelope.fromJson(message);
             if (envelope.getType() == null) {
@@ -120,17 +163,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    @Override
-    public void onMessage(WebSocket connection, ByteBuffer message) {
-        try {
-            AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(message);
-            handleFileChunk(connection, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
-        } catch (IOException e) {
-            LOG.warn(new ObjectMessage(Map.of("Message", "Failed parsing WS binary file chunk: " + e.getMessage())));
-        }
-    }
-
-    private void handleCommand(WebSocket connection, AgentWsEnvelope envelope) {
+    private void handleCommand(Session connection, AgentWsEnvelope envelope) {
         String commandId = envelope.getCommandId();
         String command = envelope.getCommand();
 
@@ -163,10 +196,10 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         return "start".equalsIgnoreCase(command) || "run".equalsIgnoreCase(command);
     }
 
-    private void handlePing(WebSocket connection, AgentWsEnvelope envelope) {
+    private void handlePing(Session connection, AgentWsEnvelope envelope) {
         try {
             AgentWsEnvelope pong = AgentWsEnvelope.pong(instanceId, agentSessionId, envelope.getPingId(), lastAppliedCommandId);
-            connection.send(pong.toJson());
+            sendText(connection, pong.toJson());
         } catch (IOException e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed to send pong: " + e.getMessage())));
         }
@@ -193,7 +226,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void handleFileOffer(WebSocket connection, AgentWsEnvelope envelope) {
+    private void handleFileOffer(Session connection, AgentWsEnvelope envelope) {
         String fileId = envelope.getFileId();
         if (fileId == null || envelope.getFileName() == null) {
             return;
@@ -230,7 +263,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void handleFileChunk(WebSocket connection, AgentWsEnvelope envelope) {
+    private void handleFileChunk(Session connection, AgentWsEnvelope envelope) {
         String fileId = envelope.getFileId();
         byte[] payload;
         try {
@@ -244,7 +277,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         handleFileChunk(connection, fileId, envelope.getChunkIndex(), payload);
     }
 
-    private void handleFileChunk(WebSocket connection, String fileId, Integer chunkIndex, byte[] payload) {
+    private void handleFileChunk(Session connection, String fileId, Integer chunkIndex, byte[] payload) {
         IncomingFileState state = fileId != null ? incomingFiles.get(fileId) : null;
         if (state == null) {
             sendFileAck(connection, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
@@ -279,7 +312,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void markFileComplete(WebSocket connection, String fileId, Integer chunkIndex) {
+    private void markFileComplete(Session connection, String fileId, Integer chunkIndex) {
         int done = completedFiles.incrementAndGet();
         CompletableFuture<Void> currentTransferCompleteFuture = transferCompleteFuture;
         if (expectedFiles > 0 && done >= expectedFiles && !currentTransferCompleteFuture.isDone()) {
@@ -381,23 +414,23 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         return new File(envelope.getFileName());
     }
 
-    private void sendFileAck(WebSocket connection, String fileId, Integer chunkIndex, AckStatus status, String error) {
+    private void sendFileAck(Session connection, String fileId, Integer chunkIndex, AckStatus status, String error) {
         try {
             AgentWsEnvelope ack = AgentWsEnvelope.fileAck(instanceId, jobId, fileId, chunkIndex, status, error);
-            connection.send(ack.toJson());
+            sendText(connection, ack.toJson());
         } catch (IOException e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed to send file ack for " + fileId + ": " + e.getMessage())));
         }
     }
 
-    private void prepareTransferCompleteAck(WebSocket connection, String fileId, Integer chunkIndex) {
+    private void prepareTransferCompleteAck(Session connection, String fileId, Integer chunkIndex) {
         transferCompleteAckWebSocket = connection;
         transferCompleteAckFileId = fileId;
         transferCompleteAckChunkIndex = chunkIndex;
     }
 
     private void sendTransferCompleteAckIfReady() {
-        WebSocket connection = transferCompleteAckWebSocket;
+        Session connection = transferCompleteAckWebSocket;
         if (!initialBootstrapReady.get() || connection == null || !connection.isOpen()) {
             return;
         }
@@ -406,31 +439,24 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
         }
     }
 
-    private void sendAck(WebSocket connection, String commandId, AckStatus status, String error) {
+    private void sendAck(Session connection, String commandId, AckStatus status, String error) {
         try {
             AgentWsEnvelope ack = AgentWsEnvelope.ack(instanceId, "command", commandId, status);
             ack.setError(error);
-            connection.send(ack.toJson());
+            sendText(connection, ack.toJson());
         } catch (IOException e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed to send command ack: " + e.getMessage())));
         }
     }
 
-    @Override
-    public void onClose(WebSocket connection, int code, String reason, boolean remote) {
+    private void sendText(Session connection, String text) {
+        connection.sendText(text, Callback.NOOP);
+    }
+
+    private void onConnectionClosed(Session connection, int code, String reason) {
         LOG.info(new ObjectMessage(Map.of("Message",
                 "Controller WS disconnected from agent " + instanceId + " code=" + code + " reason=" + reason)));
         activeConnection.compareAndSet(connection, null);
-    }
-
-    @Override
-    public void onError(WebSocket connection, Exception ex) {
-        LOG.error(new ObjectMessage(Map.of("Message", "Agent WS server transport error: " + ex.getMessage())), ex);
-    }
-
-    @Override
-    public void onStart() {
-        LOG.info(new ObjectMessage(Map.of("Message", "Agent WS control server started for " + instanceId)));
     }
 
     public boolean awaitInitialTransfer(long timeoutMillis) {
@@ -456,7 +482,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
     }
 
     public boolean sendStatusUpdate(CloudVmStatus instanceStatus) {
-        WebSocket connection = activeConnection.get();
+        Session connection = activeConnection.get();
         if (connection == null || !connection.isOpen()) {
             return false;
         }
@@ -465,7 +491,7 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
                     ? instanceStatus.getJobId()
                     : jobId;
             AgentWsEnvelope update = AgentWsEnvelope.statusUpdate(instanceId, statusJobId, instanceStatus);
-            connection.send(update.toJson());
+            sendText(connection, update.toJson());
             return true;
         } catch (Exception e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "Failed sending WS status update: " + e.getMessage())));
@@ -474,19 +500,61 @@ public class AgentCommandWebSocketServer extends WebSocketServer {
     }
 
     public void closeServer() {
-        WebSocket connection = activeConnection.getAndSet(null);
+        Session connection = activeConnection.getAndSet(null);
         if (connection != null && connection.isOpen()) {
             try {
                 AgentWsEnvelope closeEnvelope = AgentWsEnvelope.close(instanceId, "agent_shutdown", "Agent shutting down");
-                connection.send(closeEnvelope.toJson());
+                sendText(connection, closeEnvelope.toJson());
             } catch (IOException ignored) {
             }
             connection.close();
         }
         try {
-            stop();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            server.stop();
+        } catch (Exception e) {
+            LOG.warn(new ObjectMessage(Map.of("Message", "Error stopping agent WS server: " + e.getMessage())));
+        }
+    }
+
+    /**
+     * Per-connection Jetty WebSocket endpoint. {@code AutoDemanding} means Jetty automatically demands
+     * the next frame after each callback returns, matching the old library's push-style delivery.
+     */
+    private class CommandEndpoint implements Session.Listener.AutoDemanding {
+
+        private Session session;
+
+        @Override
+        public void onWebSocketOpen(Session session) {
+            this.session = session;
+            onConnectionEstablished(session);
+        }
+
+        @Override
+        public void onWebSocketText(String message) {
+            onTextMessage(session, message);
+        }
+
+        @Override
+        public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
+            try {
+                AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(payload);
+                handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+                callback.succeed();
+            } catch (IOException e) {
+                LOG.warn(new ObjectMessage(Map.of("Message", "Failed parsing WS binary file chunk: " + e.getMessage())));
+                callback.fail(e);
+            }
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason) {
+            onConnectionClosed(session, statusCode, reason);
+        }
+
+        @Override
+        public void onWebSocketError(Throwable cause) {
+            LOG.error(new ObjectMessage(Map.of("Message", "Agent WS server transport error: " + cause.getMessage())), cause);
         }
     }
 

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -57,6 +57,11 @@ public class AgentCommandWebSocketServer {
     private static final String DEFAULT_SUPPORT_ARCHIVE_NAME = "agent-support-files.zip";
     // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
     private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
+    // Jetty's default WS idle timeout is 30s. The controller may hold the connection idle while it
+    // waits for a whole fleet of agents to become ready before broadcasting START, so raise it well
+    // past that window to avoid the connection being closed with "Connection Idle Timeout".
+    private static final long WS_IDLE_TIMEOUT_MS =
+            Math.max(60_000L, Long.getLong("tank.ws.idleTimeoutMs", 600_000L));
 
     private final int port;
     private final String instanceId;
@@ -104,11 +109,13 @@ public class AgentCommandWebSocketServer {
         ServerConnector connector = new ServerConnector(server, http11, h2c);
         connector.setPort(port);
         connector.setReuseAddress(reuseAddr);
+        connector.setIdleTimeout(WS_IDLE_TIMEOUT_MS);
         server.addConnector(connector);
 
         WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
             container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
             container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+            container.setIdleTimeout(java.time.Duration.ofMillis(WS_IDLE_TIMEOUT_MS));
             container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new CommandEndpoint(this));
         });
         server.setHandler(wsHandler);

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/AgentCommandWebSocketServer.java
@@ -109,7 +109,7 @@ public class AgentCommandWebSocketServer {
         WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(server, container -> {
             container.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
             container.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
-            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new CommandEndpoint());
+            container.addMapping("/", (upgradeRequest, upgradeResponse, callback) -> new CommandEndpoint(this));
         });
         server.setHandler(wsHandler);
 
@@ -520,26 +520,31 @@ public class AgentCommandWebSocketServer {
      * Per-connection Jetty WebSocket endpoint. {@code AutoDemanding} means Jetty automatically demands
      * the next frame after each callback returns, matching the old library's push-style delivery.
      */
-    private class CommandEndpoint implements Session.Listener.AutoDemanding {
+    public static class CommandEndpoint implements Session.Listener.AutoDemanding {
 
+        private final AgentCommandWebSocketServer owner;
         private Session session;
+
+        private CommandEndpoint(AgentCommandWebSocketServer owner) {
+            this.owner = owner;
+        }
 
         @Override
         public void onWebSocketOpen(Session session) {
             this.session = session;
-            onConnectionEstablished(session);
+            owner.onConnectionEstablished(session);
         }
 
         @Override
         public void onWebSocketText(String message) {
-            onTextMessage(session, message);
+            owner.onTextMessage(session, message);
         }
 
         @Override
         public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
             try {
                 AgentWsEnvelope.BinaryFileChunk chunk = AgentWsEnvelope.fromBinaryFileChunk(payload);
-                handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
+                owner.handleFileChunk(session, chunk.fileId(), chunk.chunkIndex(), chunk.payload());
                 callback.succeed();
             } catch (IOException e) {
                 LOG.warn(new ObjectMessage(Map.of("Message", "Failed parsing WS binary file chunk: " + e.getMessage())));
@@ -549,7 +554,7 @@ public class AgentCommandWebSocketServer {
 
         @Override
         public void onWebSocketClose(int statusCode, String reason) {
-            onConnectionClosed(session, statusCode, reason);
+            owner.onConnectionClosed(session, statusCode, reason);
         }
 
         @Override

--- a/agent/http_client_3/pom.xml
+++ b/agent/http_client_3/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/agent/http_client_4/pom.xml
+++ b/agent/http_client_4/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/agent/http_client_jdk/pom.xml
+++ b/agent/http_client_jdk/pom.xml
@@ -38,7 +38,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -89,7 +89,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <version.wiremock>3.13.2</version.wiremock>
     <version.jackson>2.22.0</version.jackson>
     <version.log4j>2.25.4</version.log4j>
+    <version.jetty>12.0.30</version.jetty>
 
     <!-- maven-compiler-plugin -->
     <version.compiler.plugin>3.14.1</version.compiler.plugin>
@@ -776,7 +777,7 @@
       </dependency>
       <dependency>
         <groupId>org.wiremock</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-jetty12</artifactId>
         <version>${version.wiremock}</version>
         <scope>test</scope>
       </dependency>
@@ -789,6 +790,13 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${version.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${version.jetty}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tank_vmManager/pom.xml
+++ b/tank_vmManager/pom.xml
@@ -75,5 +75,15 @@
       <artifactId>serializer</artifactId>
     </dependency>
 
+    <!-- Jetty 12 WebSocket client over HTTP/2 (RFC 8441) for controller-initiated agent file push -->
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>jetty-websocket-jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client-transport</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -13,6 +13,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ObjectMessage;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -20,10 +27,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -32,12 +37,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
+/**
+ * Controller-side client that pushes bootstrap and job files to agents over WebSocket-over-HTTP/2
+ * (RFC 8441) using the Jetty 12 WebSocket client. File chunks are pipelined with a bounded in-flight
+ * (sliding) window rather than a fixed stop-and-wait ack gate, so throughput is independent of RTT.
+ */
 @ApplicationScoped
 public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
@@ -48,20 +57,24 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private static final String LOCAL_CONTROLLER_ORIGIN = "http://localhost:8080";
     private static final int DEFAULT_CHUNK_BYTES =
             Math.max(1, Integer.getInteger("tank.ws.chunkBytes", 2 * 1024 * 1024));
-    private static final int CHUNK_ACK_WINDOW =
-            Math.max(1, Integer.getInteger("tank.ws.chunkAckWindow", 32));
+    // Bounded number of unacked chunks allowed in flight before the sender blocks for credit.
+    private static final int CHUNK_WINDOW =
+            Math.max(1, Integer.getInteger("tank.ws.chunkWindow", 32));
     private static final long MAX_BOOTSTRAP_CONNECTION_MS =
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
+    // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
+    private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
 
-    private final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+    private final java.net.http.HttpClient httpClient =
+            java.net.http.HttpClient.newBuilder().build();
     private final ConcurrentHashMap<String, SessionContext> sessions = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CompletableFuture<AgentWsEnvelope>> pendingAcks = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, PendingChunkAck> pendingChunkAcks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Boolean> fileTransferReady = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Long> agentLastSeen = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> agentWsState = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> agentTransferProgress = new ConcurrentHashMap<>();
     private volatile byte[] cachedHarnessJarBytes;
+    private volatile WebSocketClient wsClient;
 
     private volatile VMTracker vmTracker;
 
@@ -72,6 +85,25 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         this.vmTracker = vmTracker;
     }
 
+    private WebSocketClient webSocketClient() throws Exception {
+        WebSocketClient client = wsClient;
+        if (client == null) {
+            synchronized (this) {
+                client = wsClient;
+                if (client == null) {
+                    HTTP2Client http2Client = new HTTP2Client();
+                    HttpClient jettyHttpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+                    client = new WebSocketClient(jettyHttpClient);
+                    client.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
+                    client.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+                    client.start();
+                    wsClient = client;
+                }
+            }
+        }
+        return client;
+    }
+
     public Optional<AgentWsEnvelope> connect(String instanceId, String wsUrl, String token, long helloTimeoutMillis) {
         try {
             SessionContext existing = sessions.get(instanceId);
@@ -80,18 +112,17 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
 
             CompletableFuture<AgentWsEnvelope> helloFuture = new CompletableFuture<>();
-            Listener listener = new Listener(instanceId, helloFuture);
+            Endpoint endpoint = new Endpoint(instanceId, helloFuture);
 
-            HttpClient wsHttpClient = HttpClient.newBuilder()
-                    .version(HttpClient.Version.HTTP_1_1)
-                    .connectTimeout(java.time.Duration.ofSeconds(10))
-                    .build();
-            WebSocket webSocket = wsHttpClient.newWebSocketBuilder()
-                    .header("Authorization", "bearer " + token)
-                    .buildAsync(URI.create(wsUrl), listener)
-                    .join();
+            ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+            upgradeRequest.setHeader("Authorization", "bearer " + token);
 
-            SessionContext context = new SessionContext(webSocket, helloFuture);
+            Session session = webSocketClient()
+                    .connect(endpoint, URI.create(wsUrl), upgradeRequest)
+                    .get(10, TimeUnit.SECONDS);
+
+            SessionContext context = new SessionContext(session, endpoint, helloFuture);
+            endpoint.context = context;
             SessionContext previous = sessions.put(instanceId, context);
             if (previous != null) {
                 previous.close();
@@ -263,7 +294,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         LOG.info(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId
                 + " needs startup bootstrap — pushing harness JAR"
                 + " chunkBytes=" + DEFAULT_CHUNK_BYTES
-                + " ackWindow=" + CHUNK_ACK_WINDOW
+                + " window=" + CHUNK_WINDOW
                 + " maxConnectionMs=" + MAX_BOOTSTRAP_CONNECTION_MS)));
         File harnessJar = findHarnessJar();
         if (harnessJar == null || !harnessJar.exists() || !harnessJar.isFile()) {
@@ -411,7 +442,6 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Bootstrap transfer budget reached for " + instanceId
                             + " during ack wait — closing cleanly to resume")));
-            pendingChunkAcks.remove(instanceId);
             return false;
         }
     }
@@ -439,9 +469,13 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 chunkBytes,
                 file.defaultDataFile()));
 
+        // Fresh in-flight window state for this file.
+        ChunkWindow window = new ChunkWindow(fileId);
+        context.chunkWindow = window;
+
         if (content == null || content.length == 0) {
             pendingAcks.remove(fileId);
-            sendChunk(context, instanceId, fileId, 0, new byte[0], 0, 0, connectionDeadlineMs);
+            sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, 0, new byte[0], 0, 0));
             return true;
         }
 
@@ -482,13 +516,78 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                                 + "/" + totalBytes + " — will reconnect and resume")));
                 return false;
             }
+            // Bounded in-flight window: block only when too many chunks are unacked.
+            awaitWindowCredit(window, chunkIndex, connectionDeadlineMs, instanceId);
             int len = Math.min(chunkBytes, content.length - offset);
-            sendChunk(context, instanceId, fileId, chunkIndex, content, offset, len, connectionDeadlineMs);
+            sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, content, offset, len));
+            window.onSent(chunkIndex);
             chunkIndex++;
         }
+        // Drain the window: wait until all sent chunks have been acked.
+        awaitWindowDrained(window, chunkIndex - 1, connectionDeadlineMs, instanceId);
         logFileTransferComplete(instanceId, file, totalBytes, totalChunks, chunkBytes,
                 startOffset, chunkIndex - startChunk, transferStartedAtNs);
         return true;
+    }
+
+    /** Blocks until fewer than CHUNK_WINDOW chunks are outstanding (unacked) for this file. */
+    private void awaitWindowCredit(ChunkWindow window, int nextChunkIndex, long connectionDeadlineMs, String instanceId)
+            throws IOException, InterruptedException {
+        int lowestAllowed = nextChunkIndex - CHUNK_WINDOW + 1;
+        waitForAckedThrough(window, lowestAllowed - 1, connectionDeadlineMs, instanceId);
+    }
+
+    /** Blocks until every chunk up through lastChunkIndex has been acked. */
+    private void awaitWindowDrained(ChunkWindow window, int lastChunkIndex, long connectionDeadlineMs, String instanceId)
+            throws IOException, InterruptedException {
+        if (lastChunkIndex < 0) {
+            return;
+        }
+        waitForAckedThrough(window, lastChunkIndex, connectionDeadlineMs, instanceId);
+    }
+
+    private void waitForAckedThrough(ChunkWindow window, int requiredAckedIndex, long connectionDeadlineMs,
+                                     String instanceId) throws IOException, InterruptedException {
+        while (true) {
+            // Atomically re-check the window and obtain the future to await, closing the race where an
+            // ack could land between the check and the wait.
+            CompletableFuture<Void> advance = window.awaitAdvanceIfBelow(requiredAckedIndex);
+            if (advance == null) {
+                if (window.failure() != null) {
+                    throw new IOException(window.failure());
+                }
+                return;
+            }
+            long ackTimeoutMs = 30_000L;
+            if (connectionDeadlineMs > 0) {
+                long remainingMs = connectionDeadlineMs - System.currentTimeMillis();
+                if (remainingMs <= 0) {
+                    throw new BootstrapBudgetExceededException(
+                            "Bootstrap connection budget reached during chunk ack wait");
+                }
+                ackTimeoutMs = Math.min(ackTimeoutMs, remainingMs);
+            }
+            try {
+                advance.get(ackTimeoutMs, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            } catch (java.util.concurrent.TimeoutException e) {
+                if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
+                    throw new BootstrapBudgetExceededException(
+                            "Bootstrap connection budget reached while waiting for chunk ack");
+                }
+                if (window.failure() != null) {
+                    throw new IOException(window.failure());
+                }
+                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
+            } catch (Exception e) {
+                if (window.failure() != null) {
+                    throw new IOException(window.failure());
+                }
+                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
+            }
+        }
     }
 
     private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
@@ -510,57 +609,23 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                         + " throughputMiBps=" + throughputMiBps)));
     }
 
-    private void sendChunk(SessionContext context, String instanceId, String fileId,
-                           int chunkIndex, byte[] bytes, int offset, int len, long connectionDeadlineMs)
-            throws IOException, InterruptedException {
-        CompletableFuture<Void> gate = null;
-        if ((chunkIndex + 1) % CHUNK_ACK_WINDOW == 0) {
-            gate = new CompletableFuture<>();
-            pendingChunkAcks.put(instanceId, new PendingChunkAck(fileId, chunkIndex, gate));
-        }
-        sendBinaryChunk(context, AgentWsEnvelope.binaryFileChunk(fileId, chunkIndex, bytes, offset, len));
-        if (gate != null) {
-            try {
-                long ackTimeoutMs = 30_000L;
-                if (connectionDeadlineMs > 0) {
-                    long remainingMs = connectionDeadlineMs - System.currentTimeMillis();
-                    if (remainingMs <= 0) {
-                        throw new BootstrapBudgetExceededException(
-                                "Bootstrap connection budget reached during chunk ack wait");
-                    }
-                    ackTimeoutMs = Math.min(ackTimeoutMs, remainingMs);
-                }
-                gate.get(ackTimeoutMs, TimeUnit.MILLISECONDS);
-            } catch (BootstrapBudgetExceededException e) {
-                throw e;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw e;
-            } catch (java.util.concurrent.TimeoutException e) {
-                if (connectionDeadlineMs > 0 && System.currentTimeMillis() >= connectionDeadlineMs) {
-                    throw new BootstrapBudgetExceededException(
-                            "Bootstrap connection budget reached while waiting for chunk ack");
-                }
-                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
-            } catch (Exception e) {
-                throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
-            }
-        }
-    }
-
     private void sendBinaryChunk(SessionContext context, ByteBuffer payload) {
-        synchronized (context.webSocket) {
-            context.webSocket.sendBinary(payload, true).join();
+        Callback.Completable callback = new Callback.Completable();
+        synchronized (context.session) {
+            context.session.sendBinary(payload, callback);
         }
+        callback.join();
     }
 
     private void sendEnvelope(SessionContext context, AgentWsEnvelope envelope) throws IOException {
-        synchronized (context.webSocket) {
-            context.webSocket.sendText(envelope.toJson(), true).join();
+        Callback.Completable callback = new Callback.Completable();
+        synchronized (context.session) {
+            context.session.sendText(envelope.toJson(), callback);
         }
+        callback.join();
     }
 
-    private void handleText(String instanceId, WebSocket webSocket, String text,
+    private void handleText(String instanceId, Session session, String text,
                             CompletableFuture<AgentWsEnvelope> helloFuture) {
         try {
             AgentWsEnvelope envelope = AgentWsEnvelope.fromJson(text);
@@ -572,10 +637,10 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             switch (envelope.getType()) {
                 case hello -> helloFuture.complete(envelope);
                 case ack -> handleAck(envelope);
-                case file_ack -> handleFileAck(agentId, webSocket, envelope);
+                case file_ack -> handleFileAck(agentId, session, envelope);
                 case status_update -> handleStatusUpdate(agentId, envelope);
                 case pong -> LOG.debug(new ObjectMessage(Map.of("Message", "[WS] Pong from " + agentId)));
-                case close -> onClosed(agentId, webSocket);
+                case close -> onClosed(agentId, session);
                 default -> {
                 }
             }
@@ -593,19 +658,19 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
-    private void handleFileAck(String instanceId, WebSocket webSocket, AgentWsEnvelope envelope) {
+    private void handleFileAck(String instanceId, Session session, AgentWsEnvelope envelope) {
         SessionContext context = sessions.get(instanceId);
         if (context == null) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring file_ack for non-active session " + instanceId)));
             return;
         }
-        if (webSocket == null) {
+        if (session == null) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring file_ack without WebSocket identity for " + instanceId)));
             return;
         }
-        if (context.webSocket != webSocket) {
+        if (context.session != session) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring stale file_ack from previous session for " + instanceId)));
             return;
@@ -625,10 +690,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         if (envelope.getStatus() == AckStatus.all_files_complete) {
             fileTransferReady.put(instanceId, true);
             agentWsState.put(instanceId, "ready");
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.complete(null);
+            ChunkWindow window = context.chunkWindow;
+            if (window != null && window.matchesFile(envelope.getFileId())) {
+                window.onAck(envelope.getChunkIndex());
             }
             context.transferCompleteFuture.complete(null);
             return;
@@ -643,16 +707,14 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
 
         if (envelope.getStatus() == AckStatus.complete || envelope.getStatus() == AckStatus.chunk_received) {
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.complete(null);
+            ChunkWindow window = context.chunkWindow;
+            if (window != null && window.matchesFile(envelope.getFileId())) {
+                window.onAck(envelope.getChunkIndex());
             }
         } else if (envelope.getStatus() == AckStatus.failed) {
-            PendingChunkAck pending = pendingChunkAcks.get(instanceId);
-            if (pending != null && pending.matches(envelope.getFileId(), envelope.getChunkIndex())) {
-                pendingChunkAcks.remove(instanceId, pending);
-                pending.future.completeExceptionally(new IOException(envelope.getError()));
+            ChunkWindow window = context.chunkWindow;
+            if (window != null && window.matchesFile(envelope.getFileId())) {
+                window.onFailure(envelope.getError());
             }
             context.transferCompleteFuture.completeExceptionally(new IOException(envelope.getError()));
         }
@@ -671,19 +733,19 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
-    private void onClosed(String instanceId, WebSocket webSocket) {
+    private void onClosed(String instanceId, Session session) {
         SessionContext context = sessions.get(instanceId);
         if (context == null) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring close for non-active session " + instanceId)));
             return;
         }
-        if (webSocket == null) {
+        if (session == null) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring close without WebSocket identity for " + instanceId)));
             return;
         }
-        if (context.webSocket != webSocket) {
+        if (context.session != session) {
             LOG.info(new ObjectMessage(Map.of("Message",
                     "[WS] Ignoring stale close from previous session for " + instanceId)));
             return;
@@ -695,62 +757,50 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
         context.markClosed();
         fileTransferReady.remove(instanceId);
-        PendingChunkAck pending = pendingChunkAcks.remove(instanceId);
-        if (pending != null) {
-            pending.future.completeExceptionally(new IOException("WS connection closed for " + instanceId));
+        ChunkWindow window = context.chunkWindow;
+        if (window != null) {
+            window.onFailure("WS connection closed for " + instanceId);
         }
         agentWsState.put(instanceId, "disconnected");
     }
 
-    private class Listener implements WebSocket.Listener {
+    private class Endpoint implements Session.Listener.AutoDemanding {
         private final String instanceId;
         private final CompletableFuture<AgentWsEnvelope> helloFuture;
-        private final StringBuilder messageBuffer = new StringBuilder();
+        private volatile SessionContext context;
+        private Session session;
 
-        private Listener(String instanceId, CompletableFuture<AgentWsEnvelope> helloFuture) {
+        private Endpoint(String instanceId, CompletableFuture<AgentWsEnvelope> helloFuture) {
             this.instanceId = instanceId;
             this.helloFuture = helloFuture;
         }
 
         @Override
-        public void onOpen(WebSocket webSocket) {
-            webSocket.request(1);
+        public void onWebSocketOpen(Session session) {
+            this.session = session;
         }
 
         @Override
-        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
-            messageBuffer.append(data);
-            if (last) {
-                String fullMessage = messageBuffer.toString();
-                messageBuffer.setLength(0);
-                handleText(instanceId, webSocket, fullMessage, helloFuture);
-            }
-            webSocket.request(1);
-            return null;
+        public void onWebSocketText(String message) {
+            handleText(instanceId, session, message, helloFuture);
         }
 
         @Override
-        public CompletionStage<?> onPing(WebSocket webSocket, ByteBuffer message) {
-            webSocket.request(1);
-            return null;
+        public void onWebSocketClose(int statusCode, String reason) {
+            onClosed(instanceId, session);
         }
 
         @Override
-        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-            onClosed(instanceId, webSocket);
-            return null;
-        }
-
-        @Override
-        public void onError(WebSocket webSocket, Throwable error) {
+        public void onWebSocketError(Throwable cause) {
             LOG.warn(new ObjectMessage(Map.of("Message",
-                    "[WS] Controller initiated WS listener error for " + instanceId + ": " + error.getMessage())));
-            onClosed(instanceId, webSocket);
+                    "[WS] Controller initiated WS listener error for " + instanceId + ": " + cause.getMessage())));
+            onClosed(instanceId, session);
         }
     }
 
     private static class SessionContext {
-        private final WebSocket webSocket;
+        private final Session session;
+        private final Endpoint endpoint;
         private final CompletableFuture<AgentWsEnvelope> helloFuture;
         private final CompletableFuture<Void> transferCompleteFuture = new CompletableFuture<>();
         private final ConcurrentHashMap<String, Integer> completedFiles = new ConcurrentHashMap<>();
@@ -761,15 +811,17 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private volatile int expectedFiles;
         private volatile boolean bootstrapTransfer;
         private volatile AgentWsEnvelope hello;
+        private volatile ChunkWindow chunkWindow;
 
-        private SessionContext(WebSocket webSocket, CompletableFuture<AgentWsEnvelope> helloFuture) {
-            this.webSocket = webSocket;
+        private SessionContext(Session session, Endpoint endpoint, CompletableFuture<AgentWsEnvelope> helloFuture) {
+            this.session = session;
+            this.endpoint = endpoint;
             this.helloFuture = helloFuture;
             this.openedAtMs = System.currentTimeMillis();
         }
 
         private boolean isOpen() {
-            return !closed.get() && !webSocket.isInputClosed() && !webSocket.isOutputClosed();
+            return !closed.get() && session.isOpen();
         }
 
         private void close() {
@@ -779,15 +831,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private void closeGracefully(String reason) {
             if (closed.compareAndSet(false, true)) {
                 try {
-                    webSocket.sendClose(WebSocket.NORMAL_CLOSURE, reason)
-                            .orTimeout(2, TimeUnit.SECONDS)
-                            .exceptionally(t -> {
-                                webSocket.abort();
-                                return webSocket;
-                            })
-                            .join();
+                    session.close(org.eclipse.jetty.websocket.api.StatusCode.NORMAL, reason, Callback.NOOP);
                 } catch (Exception e) {
-                    try { webSocket.abort(); } catch (Exception ignored) {}
+                    try { session.disconnect(); } catch (Exception ignored) {}
                 }
                 helloFuture.completeExceptionally(new IllegalStateException(reason));
                 transferCompleteFuture.completeExceptionally(new IllegalStateException(reason));
@@ -796,7 +842,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         private void abort() {
             if (closed.compareAndSet(false, true)) {
-                try { webSocket.abort(); } catch (Exception ignored) {}
+                try { session.disconnect(); } catch (Exception ignored) {}
                 helloFuture.completeExceptionally(new IllegalStateException("Aborted"));
                 transferCompleteFuture.completeExceptionally(new IllegalStateException("Aborted"));
             }
@@ -812,19 +858,70 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private record TransferFile(String fileType, String fileName, byte[] content, boolean defaultDataFile) {
     }
 
-    private static class PendingChunkAck {
+    /**
+     * Tracks the sliding send window for a single file transfer. The sender advances
+     * {@code highestAckedChunk} as contiguous {@code chunk_received}/{@code complete} acks arrive and
+     * blocks only when the number of unacked chunks reaches {@link #CHUNK_WINDOW}.
+     */
+    private static class ChunkWindow {
         private final String fileId;
-        private final int chunkIndex;
-        private final CompletableFuture<Void> future;
+        private final java.util.BitSet ackedChunks = new java.util.BitSet();
+        private int highestContiguousAcked = -1;
+        private volatile String failure;
+        private volatile CompletableFuture<Void> advance = new CompletableFuture<>();
 
-        private PendingChunkAck(String fileId, int chunkIndex, CompletableFuture<Void> future) {
+        private ChunkWindow(String fileId) {
             this.fileId = fileId;
-            this.chunkIndex = chunkIndex;
-            this.future = future;
         }
 
-        private boolean matches(String fileId, Integer chunkIndex) {
-            return this.fileId.equals(fileId) && chunkIndex != null && this.chunkIndex == chunkIndex;
+        private boolean matchesFile(String otherFileId) {
+            return fileId.equals(otherFileId);
+        }
+
+        private synchronized void onSent(int chunkIndex) {
+            // no-op bookkeeping hook; kept for symmetry / future metrics
+        }
+
+        private synchronized void onAck(Integer chunkIndex) {
+            if (chunkIndex == null || chunkIndex < 0) {
+                return;
+            }
+            ackedChunks.set(chunkIndex);
+            while (ackedChunks.get(highestContiguousAcked + 1)) {
+                highestContiguousAcked++;
+            }
+            signal();
+        }
+
+        private synchronized void onFailure(String error) {
+            this.failure = error != null ? error : "chunk transfer failed";
+            signal();
+        }
+
+        private synchronized String failure() {
+            return failure;
+        }
+
+        /**
+         * If the window has already acked through {@code requiredAckedIndex} (or failed), returns null.
+         * Otherwise returns a fresh future that completes the next time an ack advances the window or a
+         * failure occurs. Synchronized so the check and future handoff are atomic with {@link #onAck}.
+         */
+        private synchronized CompletableFuture<Void> awaitAdvanceIfBelow(int requiredAckedIndex) {
+            if (highestContiguousAcked >= requiredAckedIndex || failure != null) {
+                return null;
+            }
+            if (advance.isDone()) {
+                advance = new CompletableFuture<>();
+            }
+            return advance;
+        }
+
+        private void signal() {
+            CompletableFuture<Void> current = advance;
+            if (!current.isDone()) {
+                current.complete(null);
+            }
         }
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -64,6 +64,14 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             Long.getLong("tank.ws.bootstrap.maxConnectionMs", 180_000L);
     // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
     private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
+    // Jetty's default WS idle timeout is 30s. The controller holds connections idle while waiting for
+    // a whole fleet of agents to become ready before broadcasting START — raise it well past that.
+    private static final long WS_IDLE_TIMEOUT_MS =
+            Math.max(60_000L, Long.getLong("tank.ws.idleTimeoutMs", 600_000L));
+    // Interval for the application-level keepalive ping that holds idle connections open and detects
+    // dead ones early (well under WS_IDLE_TIMEOUT_MS).
+    private static final long WS_KEEPALIVE_PING_MS =
+            Math.max(5_000L, Long.getLong("tank.ws.keepAlivePingMs", 10_000L));
 
     private final java.net.http.HttpClient httpClient =
             java.net.http.HttpClient.newBuilder().build();
@@ -75,6 +83,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private final ConcurrentHashMap<String, String> agentTransferProgress = new ConcurrentHashMap<>();
     private volatile byte[] cachedHarnessJarBytes;
     private volatile WebSocketClient wsClient;
+    private volatile java.util.concurrent.ScheduledExecutorService keepAliveExecutor;
 
     private volatile VMTracker vmTracker;
 
@@ -96,12 +105,48 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                     client = new WebSocketClient(jettyHttpClient);
                     client.setMaxBinaryMessageSize(MAX_WS_MESSAGE_BYTES);
                     client.setMaxTextMessageSize(MAX_WS_MESSAGE_BYTES);
+                    // Match the agents' raised idle timeout: the controller may hold connections idle
+                    // while waiting for a whole fleet to become ready before broadcasting START.
+                    client.setIdleTimeout(java.time.Duration.ofMillis(WS_IDLE_TIMEOUT_MS));
                     client.start();
                     wsClient = client;
+                    startKeepAlive();
                 }
             }
         }
         return client;
+    }
+
+    /**
+     * Periodically pings every open session so a connection held idle (e.g. while the controller waits
+     * for a whole fleet to become ready before broadcasting START) is kept warm and not closed by the
+     * peer's idle timeout. The agent servers reply with pong; a send failure closes the dead session.
+     */
+    private void startKeepAlive() {
+        java.util.concurrent.ScheduledExecutorService executor =
+                java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                    Thread t = new Thread(r, "ws-keepalive");
+                    t.setDaemon(true);
+                    return t;
+                });
+        executor.scheduleWithFixedDelay(this::pingOpenSessions,
+                WS_KEEPALIVE_PING_MS, WS_KEEPALIVE_PING_MS, TimeUnit.MILLISECONDS);
+        keepAliveExecutor = executor;
+    }
+
+    private void pingOpenSessions() {
+        for (Map.Entry<String, SessionContext> entry : sessions.entrySet()) {
+            SessionContext context = entry.getValue();
+            if (context == null || !context.isOpen()) {
+                continue;
+            }
+            try {
+                sendEnvelope(context, AgentWsEnvelope.ping(UUID.randomUUID().toString()));
+            } catch (Exception e) {
+                LOG.debug(new ObjectMessage(Map.of("Message",
+                        "[WS] Keepalive ping failed for " + entry.getKey() + ": " + e.getMessage())));
+            }
+        }
     }
 
     public Optional<AgentWsEnvelope> connect(String instanceId, String wsUrl, String token, long helloTimeoutMillis) {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -343,6 +343,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         agentTransferProgress.put(agentId, "1/1 files");
         agentWsState.put(agentId, "bootstrap_sent");
         LOG.info(new ObjectMessage(Map.of("Message", "[WS] Bootstrap JAR sent to " + agentId + " — waiting for harness to start")));
+        sessions.remove(agentId, context);
+        fileTransferReady.remove(agentId);
         context.close();
         return false;
     }

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -112,7 +112,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             }
 
             CompletableFuture<AgentWsEnvelope> helloFuture = new CompletableFuture<>();
-            Endpoint endpoint = new Endpoint(instanceId, helloFuture);
+            Endpoint endpoint = new Endpoint(this, instanceId, helloFuture);
 
             ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
             upgradeRequest.setHeader("Authorization", "bearer " + token);
@@ -764,13 +764,20 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         agentWsState.put(instanceId, "disconnected");
     }
 
-    private class Endpoint implements Session.Listener.AutoDemanding {
+    /**
+     * WebSocket listener. Must be a {@code public static} class: Jetty 12 invokes the callback
+     * methods via MethodHandles, which cannot reach a non-public (e.g. private inner) endpoint class.
+     */
+    public static class Endpoint implements Session.Listener.AutoDemanding {
+        private final ControllerInitiatedAgentWsClient client;
         private final String instanceId;
         private final CompletableFuture<AgentWsEnvelope> helloFuture;
         private volatile SessionContext context;
         private Session session;
 
-        private Endpoint(String instanceId, CompletableFuture<AgentWsEnvelope> helloFuture) {
+        private Endpoint(ControllerInitiatedAgentWsClient client, String instanceId,
+                         CompletableFuture<AgentWsEnvelope> helloFuture) {
+            this.client = client;
             this.instanceId = instanceId;
             this.helloFuture = helloFuture;
         }
@@ -782,19 +789,19 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
         @Override
         public void onWebSocketText(String message) {
-            handleText(instanceId, session, message, helloFuture);
+            client.handleText(instanceId, session, message, helloFuture);
         }
 
         @Override
         public void onWebSocketClose(int statusCode, String reason) {
-            onClosed(instanceId, session);
+            client.onClosed(instanceId, session);
         }
 
         @Override
         public void onWebSocketError(Throwable cause) {
             LOG.warn(new ObjectMessage(Map.of("Message",
                     "[WS] Controller initiated WS listener error for " + instanceId + ": " + cause.getMessage())));
-            onClosed(instanceId, session);
+            client.onClosed(instanceId, session);
         }
     }
 

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
@@ -27,7 +27,9 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
@@ -42,6 +44,7 @@ import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 import jakarta.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -49,7 +52,7 @@ import java.util.stream.Collectors;
 public class AmazonInstance implements IEnvironmentInstance {
 
     protected static String INSUFFICIENT_INSTANCE_CAPACITY = "InsufficientInstanceCapacity";
-    protected static String REQUEST_LIMIT_EXCEEDED = "RequestLimitExceeded";
+    protected static String INVALID_AMI_ID_UNAVAILABLE = "InvalidAMIID.Unavailable";
     protected static final long ASSOCIATE_IP_MAX_WAIT_MILIS = 1000 * 60 * 2;// 2 minutes
     private static final Logger LOG = LogManager.getLogger(AmazonInstance.class);
 
@@ -75,7 +78,10 @@ public class AmazonInstance implements IEnvironmentInstance {
         this.vmRegion = vmRegion;
         try {
             CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
-            Ec2AsyncClientBuilder ec2ClientBuilder = Ec2AsyncClient.builder();
+            Ec2AsyncClientBuilder ec2ClientBuilder = Ec2AsyncClient.builder()
+                    .overrideConfiguration(ClientOverrideConfiguration.builder()
+                            .retryStrategy(RetryMode.ADAPTIVE_V2)
+                            .build());
             if (creds != null && StringUtils.isNotBlank(creds.getProxyHost())) {
                 try {
                     ProxyConfiguration.Builder proxyConfig = ProxyConfiguration.builder().host(creds.getProxyHost());
@@ -337,8 +343,8 @@ public class AmazonInstance implements IEnvironmentInstance {
     }
 
     /**
-     * @param runInstancesRequestTemplate
      * @param subnetId
+     * @param runInstancesRequestTemplate
      * @param requestCount
      * @return
      */
@@ -357,20 +363,18 @@ public class AmazonInstance implements IEnvironmentInstance {
                         .minCount(1).maxCount(requestCount).build())
                 .exceptionally(completionException -> {
                     Throwable cause = completionException.getCause();
-                    if (cause instanceof Ec2Exception) {
-                        String errorCode = ((Ec2Exception)cause).awsErrorDetails().errorCode();
+                    if (cause instanceof Ec2Exception && ((Ec2Exception) cause).awsErrorDetails() != null) {
+                        String errorCode = ((Ec2Exception) cause).awsErrorDetails().errorCode();
                         if ( errorCode.equals(INSUFFICIENT_INSTANCE_CAPACITY) ) {
                             LOG.warn("Failure requesting instance type: {} : {} : {}", instanceType, vmRegion, cause.getMessage());
                             return requestInstances(runInstancesRequestTemplate, subnetId, requestCount, remainingTypes).join();
-                        } else if ( errorCode.equals(REQUEST_LIMIT_EXCEEDED) ) {
-                            LOG.warn("Exceeded request limit: {} : {} : {}", instanceType, vmRegion, cause.getMessage());
-                            try { Thread.sleep(new Random().nextInt(1000) + 500); } catch (InterruptedException ignored) {}
-                            return requestInstances(runInstancesRequestTemplate, subnetId, requestCount, instanceTypes).join();
+                        } else if ( errorCode.equals(INVALID_AMI_ID_UNAVAILABLE) ) {
+                            LOG.error("AMI is not available in {}: {}", vmRegion, cause.getMessage());
+                            throw new CompletionException(cause);
                         }
-                    } else {
-                        LOG.error("Error requesting instances: {}: {}", vmRegion, cause.getMessage(), cause);
                     }
-                    return RunInstancesResponse.builder().build();
+                    LOG.error("Error requesting instances: {}: {}", vmRegion, cause.getMessage(), cause);
+                    throw new CompletionException(cause);
                 })
                 .thenApply(response -> {
                     if (response.instances().size() < requestCount) {


### PR DESCRIPTION
## [SRE-38860] Migrate controller↔agent WebSocket file transfer to WebSocket-over-HTTP/2

### Why
Controller→agent file transfer over WebSocket was slow on any high-latency link. The bottleneck was an application-level stop-and-wait ack gate (the sender blocked ~1 RTT every N chunks), and the transport stack (JDK `java.net.http.WebSocket` pinned to HTTP/1.1 on the controller; `org.java-websocket` 1.5.6 on the agents) could not do WebSocket-over-HTTP/2. This PR moves the transfer to WebSocket-over-HTTP/2 (RFC 8441) on Jetty 12 and replaces the stop-and-wait gate with a bounded sliding window so throughput no longer degrades with RTT.

### What changed

**Transport migration to Jetty 12 (RFC 8441, h2c)**
- Replaced `org.java-websocket:Java-WebSocket:1.5.6` with Jetty 12 WebSocket-over-HTTP/2 on both agent-side servers: `StartupWebSocketServer` (bootstrap harness-JAR push) and `AgentCommandWebSocketServer` (job config / files / commands). Each runs an embedded Jetty `Server` with `HttpConnectionFactory` + `HTTP2CServerConnectionFactory` (`setConnectProtocolEnabled(true)`), so the same port accepts HTTP/2 extended-CONNECT WebSocket upgrades and still falls back to HTTP/1.1.
- Replaced the JDK `java.net.http.WebSocket` client with the Jetty `WebSocketClient` over `HttpClientTransportOverHTTP2` in `ControllerInitiatedAgentWsClient`. Public `AgentWsCommandSender` surface and CDI bean shape unchanged.
- The `AgentWsEnvelope` message model and the `TWC1` binary chunk framing are reused unchanged, so the wire protocol is identical across transports.

**Latency fix — sliding send window**
- Replaced the fixed "block every N chunks for an ack" gate with a bounded in-flight (credit) window: the sender only blocks when too many chunks are unacked, advancing as `chunk_received`/`complete` acks arrive. This keeps the pipe full across the RTT, making throughput independent of latency.

**Build / dependency management**
- Added `org.eclipse.jetty:jetty-bom` import and pinned Jetty to `12.0.30` — the line that WireMock's Jetty 12 build targets — to avoid a mixed Jetty 11/12 classpath.
- Switched the test dependency from `org.wiremock:wiremock` (Jetty 11) to `org.wiremock:wiremock-jetty12` in the modules that use it (`api`, `agent/http_client_3/4/jdk`), so WireMock's transitive Jetty aligns with the BOM.

**Reliability fixes found during end-to-end validation**
- **Endpoint visibility:** Jetty 12 invokes WebSocket callbacks via `MethodHandles`, which cannot reach a non-public listener. Made all three endpoint classes `public static` (was failing at runtime with `Unable to access method … onWebSocketOpen`).
- **Bootstrap→harness handoff:** flush the terminal `complete` file-ack synchronously before completing the future that stops the startup server, so the ack isn't dropped on shutdown; and remove the bootstrap session from the controller's session map on completion so the reconnect to the harness starts clean.
- **Idle timeout / keepalive:** Jetty's default 30s WebSocket idle timeout closed connections while the controller held them idle waiting for the whole fleet to become ready before broadcasting START (symptom: `Connection Idle Timeout`, START never delivered). Raised the idle timeout (configurable, default 600s) on both agent servers and the client, and added a controller-side keepalive ping (default every 10s) that holds idle connections open and detects dead ones early.

**Unrelated change riding on this branch**
- `AmazonInstance.java`: EC2 request resilience — use `RetryMode.ADAPTIVE_V2`, fail fast on `InvalidAMIID.Unavailable`, and propagate errors via `CompletionException` instead of returning an empty response.

### Tuning knobs (system properties)
- `tank.ws.chunkBytes` (default 2 MiB), `tank.ws.chunkWindow` (default 32)
- `tank.ws.idleTimeoutMs` (default 600000), `tank.ws.keepAlivePingMs` (default 10000)
- `tank.ws.bootstrap.maxConnectionMs` (default 180000)

### Compatibility / rollout
Not backward compatible at the transport layer with pre-Jetty agents — controller and agent images must be upgraded together. The dual HTTP/1.1 + h2c connection factories allow a Jetty↔Jetty pair to negotiate either transport during transition.

### Testing
- `mvn clean install -P release` — full suite green.
- Standalone reproductions against the real Jetty server + HTTP/2 client verified: h2c handshake, `file_offer → chunks → complete` round-trip, the `public static` endpoint fix, and connection survival across an idle period longer than the old 30s default (both via the raised timeout and via keepalive alone under a deliberately tight timeout).

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default```

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.
