### PR TITLE
Fix WS agent bootstrap and terminate agents after graceful STOP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <version.wiremock>3.13.2</version.wiremock>
     <version.jackson>2.22.1</version.jackson>
     <version.log4j>2.26.1</version.log4j>
-    <version.jetty>12.0.30</version.jetty>
+    <version.jetty>12.0.35</version.jetty>
 
     <!-- maven-compiler-plugin -->
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <version.wiremock>3.13.2</version.wiremock>
     <version.jackson>2.22.1</version.jackson>
     <version.log4j>2.26.1</version.log4j>
-    <version.jetty>12.0.36</version.jetty>
+    <version.jetty>12.0.30</version.jetty>
 
     <!-- maven-compiler-plugin -->
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -6,9 +6,12 @@ import com.intuit.tank.vm.agent.messages.AgentWsCommandSender;
 import com.intuit.tank.vm.agent.messages.AgentWsEnvelope;
 import com.intuit.tank.vm.agent.messages.AgentWsEnvelope.AckStatus;
 import com.intuit.tank.vm.agent.messages.DataFileRequest;
+import com.intuit.tank.vm.api.enumerated.JobStatus;
 import com.intuit.tank.vm.settings.TankConfig;
+import com.intuit.tank.vm.vmManager.VMTerminator;
 import com.intuit.tank.vm.vmManager.VMTracker;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
+import com.intuit.tank.vm.vmManager.models.VMStatus;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,17 +84,23 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private final ConcurrentHashMap<String, Long> agentLastSeen = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> agentWsState = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> agentTransferProgress = new ConcurrentHashMap<>();
+    private final java.util.Set<String> terminationRequestedInstances = ConcurrentHashMap.newKeySet();
     private volatile byte[] cachedHarnessJarBytes;
     private volatile WebSocketClient wsClient;
     private volatile java.util.concurrent.ScheduledExecutorService keepAliveExecutor;
 
     private volatile VMTracker vmTracker;
+    private volatile VMTerminator vmTerminator;
 
     public ControllerInitiatedAgentWsClient() {
     }
 
     public void setVmTracker(VMTracker vmTracker) {
         this.vmTracker = vmTracker;
+    }
+
+    public void setVmTerminator(VMTerminator vmTerminator) {
+        this.vmTerminator = vmTerminator;
     }
 
     private WebSocketClient webSocketClient() throws Exception {
@@ -774,10 +783,41 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
         try {
             status.setInstanceId(instanceId);
+            requestTerminationForTerminalStatus(instanceId, status);
             vmTracker.setStatus(status);
         } catch (Exception e) {
             LOG.warn(new ObjectMessage(Map.of("Message", "[WS] Failed status update from " + instanceId + ": " + e.getMessage())));
         }
+    }
+
+    private void requestTerminationForTerminalStatus(String instanceId, CloudVmStatus status) {
+        if (!isTerminalStatus(status)) {
+            return;
+        }
+        VMTerminator terminator = vmTerminator;
+        if (terminator == null) {
+            LOG.error(new ObjectMessage(Map.of("Message", "[WS] Terminal status from " + instanceId
+                    + " but VMTerminator is unavailable; instance termination was not scheduled")));
+            return;
+        }
+        if (!terminationRequestedInstances.add(instanceId)) {
+            return;
+        }
+        try {
+            LOG.info(new ObjectMessage(Map.of("Message", "[WS] Scheduling VM termination for terminal status from "
+                    + instanceId + " job " + status.getJobId())));
+            terminator.terminate(instanceId);
+        } catch (Exception e) {
+            terminationRequestedInstances.remove(instanceId);
+            LOG.error(new ObjectMessage(Map.of("Message", "[WS] Failed scheduling VM termination for "
+                    + instanceId + ": " + e.getMessage())), e);
+        }
+    }
+
+    private boolean isTerminalStatus(CloudVmStatus status) {
+        return status.getJobStatus() == JobStatus.Completed
+                || status.getVmStatus() == VMStatus.terminated
+                || status.getVmStatus() == VMStatus.replaced;
     }
 
     private void onClosed(String instanceId, Session session) {
@@ -802,6 +842,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                     "[WS] Ignoring close for replaced session " + instanceId)));
             return;
         }
+        terminationRequestedInstances.remove(instanceId);
         context.markClosed();
         fileTransferReady.remove(instanceId);
         ChunkWindow window = context.chunkWindow;

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -694,7 +694,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 case hello -> helloFuture.complete(envelope);
                 case ack -> handleAck(envelope);
                 case file_ack -> handleFileAck(agentId, session, envelope);
-                case status_update -> handleStatusUpdate(agentId, envelope);
+                case status_update -> handleStatusUpdate(instanceId, envelope);
                 case pong -> LOG.debug(new ObjectMessage(Map.of("Message", "[WS] Pong from " + agentId)));
                 case close -> onClosed(agentId, session);
                 default -> {

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/JobManager.java
@@ -61,6 +61,7 @@ import com.intuit.tank.vm.settings.TankConfig;
 import com.intuit.tank.vm.vmManager.JobRequest;
 import com.intuit.tank.vm.vmManager.JobVmCalculator;
 import com.intuit.tank.vm.vmManager.RegionRequest;
+import com.intuit.tank.vm.vmManager.VMTerminator;
 import com.intuit.tank.vmManager.environment.amazon.AmazonInstance;
 import org.apache.logging.log4j.message.ObjectMessage;
 
@@ -79,6 +80,9 @@ public class JobManager implements Serializable {
 
     @Inject
     private VMTracker vmTracker;
+
+    @Inject
+    private VMTerminator vmTerminator;
 
     @Inject
     private StandaloneAgentTracker standaloneTracker;
@@ -521,6 +525,7 @@ public class JobManager implements Serializable {
 
     public ControllerInitiatedAgentWsClient getControllerInitiatedAgentWsClient() {
         controllerInitiatedAgentWsClient.setVmTracker(vmTracker);
+        controllerInitiatedAgentWsClient.setVmTerminator(vmTerminator);
         com.intuit.tank.vm.agent.messages.AgentWsCommandSender.setStaticInstance(controllerInitiatedAgentWsClient);
         return controllerInitiatedAgentWsClient;
     }

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -1,0 +1,156 @@
+package com.intuit.tank.perfManager.workLoads;
+
+import com.intuit.tank.vm.agent.messages.AgentWsEnvelope;
+import com.intuit.tank.vm.api.enumerated.JobStatus;
+import com.intuit.tank.vm.api.enumerated.VMImageType;
+import com.intuit.tank.vm.api.enumerated.VMRegion;
+import com.intuit.tank.vm.vmManager.VMTerminator;
+import com.intuit.tank.vm.vmManager.VMTracker;
+import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
+import com.intuit.tank.vm.vmManager.models.VMStatus;
+import com.intuit.tank.vm.vmManager.models.ValidationStatus;
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ControllerInitiatedAgentWsClientTest {
+
+    @Test
+    void testTerminalStatusSchedulesTerminationAndUpdatesTracker() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        VMTracker vmTracker = mock(VMTracker.class);
+        VMTerminator vmTerminator = mock(VMTerminator.class);
+        client.setVmTracker(vmTracker);
+        client.setVmTerminator(vmTerminator);
+
+        CloudVmStatus status = createStatus("i-spoofed", JobStatus.Completed, VMStatus.terminated);
+        invokeHandleStatusUpdate(client, "i-agent", AgentWsEnvelope.statusUpdate("i-agent", "job-1", status));
+
+        verify(vmTerminator).terminate("i-agent");
+        verify(vmTracker).setStatus(argThat(updated -> "i-agent".equals(updated.getInstanceId())
+                && updated.getJobStatus() == JobStatus.Completed
+                && updated.getVmStatus() == VMStatus.terminated));
+        assertEquals("i-agent", status.getInstanceId());
+    }
+
+    @Test
+    void testTerminalStatusSchedulesTerminationOnlyOnce() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        VMTracker vmTracker = mock(VMTracker.class);
+        VMTerminator vmTerminator = mock(VMTerminator.class);
+        client.setVmTracker(vmTracker);
+        client.setVmTerminator(vmTerminator);
+
+        CloudVmStatus status = createStatus("i-agent", JobStatus.Completed, VMStatus.terminated);
+        AgentWsEnvelope statusUpdate = AgentWsEnvelope.statusUpdate("i-agent", "job-1", status);
+
+        invokeHandleStatusUpdate(client, "i-agent", statusUpdate);
+        invokeHandleStatusUpdate(client, "i-agent", statusUpdate);
+
+        verify(vmTerminator, times(1)).terminate("i-agent");
+        verify(vmTracker, times(2)).setStatus(status);
+    }
+
+    @Test
+    void testSessionCloseClearsTerminationDedup() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        VMTracker vmTracker = mock(VMTracker.class);
+        VMTerminator vmTerminator = mock(VMTerminator.class);
+        client.setVmTracker(vmTracker);
+        client.setVmTerminator(vmTerminator);
+
+        CloudVmStatus status = createStatus("i-agent", JobStatus.Completed, VMStatus.terminated);
+        AgentWsEnvelope statusUpdate = AgentWsEnvelope.statusUpdate("i-agent", "job-1", status);
+        invokeHandleStatusUpdate(client, "i-agent", statusUpdate);
+
+        Session session = mock(Session.class);
+        installSession(client, "i-agent", session);
+        invokeOnClosed(client, "i-agent", session);
+        invokeHandleStatusUpdate(client, "i-agent", statusUpdate);
+
+        verify(vmTerminator, times(2)).terminate("i-agent");
+    }
+
+    @Test
+    void testNonTerminalStatusUpdatesTrackerWithoutTermination() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        VMTracker vmTracker = mock(VMTracker.class);
+        VMTerminator vmTerminator = mock(VMTerminator.class);
+        client.setVmTracker(vmTracker);
+        client.setVmTerminator(vmTerminator);
+
+        CloudVmStatus status = createStatus("i-agent", JobStatus.Running, VMStatus.running);
+        invokeHandleStatusUpdate(client, "i-agent", AgentWsEnvelope.statusUpdate("i-agent", "job-1", status));
+
+        verify(vmTerminator, never()).terminate("i-agent");
+        verify(vmTracker).setStatus(status);
+    }
+
+    private void invokeHandleStatusUpdate(ControllerInitiatedAgentWsClient client, String instanceId,
+                                          AgentWsEnvelope envelope) throws Exception {
+        Method method = ControllerInitiatedAgentWsClient.class.getDeclaredMethod(
+                "handleStatusUpdate", String.class, AgentWsEnvelope.class);
+        method.setAccessible(true);
+        method.invoke(client, instanceId, envelope);
+    }
+
+    private void invokeOnClosed(ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {
+        Method method = ControllerInitiatedAgentWsClient.class.getDeclaredMethod(
+                "onClosed", String.class, Session.class);
+        method.setAccessible(true);
+        method.invoke(client, instanceId, session);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void installSession(ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {
+        Class<?> sessionContextClass = Class.forName(
+                "com.intuit.tank.perfManager.workLoads.ControllerInitiatedAgentWsClient$SessionContext");
+        Class<?> endpointClass = Class.forName(
+                "com.intuit.tank.perfManager.workLoads.ControllerInitiatedAgentWsClient$Endpoint");
+
+        Constructor<?> endpointConstructor = endpointClass.getDeclaredConstructor(
+                ControllerInitiatedAgentWsClient.class, String.class, CompletableFuture.class);
+        endpointConstructor.setAccessible(true);
+        Object endpoint = endpointConstructor.newInstance(client, instanceId, new CompletableFuture<AgentWsEnvelope>());
+
+        Constructor<?> sessionContextConstructor = sessionContextClass.getDeclaredConstructor(
+                Session.class, endpointClass, CompletableFuture.class);
+        sessionContextConstructor.setAccessible(true);
+        Object sessionContext = sessionContextConstructor.newInstance(session, endpoint, new CompletableFuture<AgentWsEnvelope>());
+
+        Field sessionsField = ControllerInitiatedAgentWsClient.class.getDeclaredField("sessions");
+        sessionsField.setAccessible(true);
+        ConcurrentHashMap<String, Object> sessions =
+                (ConcurrentHashMap<String, Object>) sessionsField.get(client);
+        sessions.put(instanceId, sessionContext);
+    }
+
+    private CloudVmStatus createStatus(String instanceId, JobStatus jobStatus, VMStatus vmStatus) {
+        return new CloudVmStatus(
+                instanceId,
+                "job-1",
+                "sg-1",
+                jobStatus,
+                VMImageType.AGENT,
+                VMRegion.US_EAST,
+                vmStatus,
+                new ValidationStatus(),
+                5,
+                jobStatus == JobStatus.Completed ? 0 : 1,
+                new Date(),
+                jobStatus == JobStatus.Completed ? new Date() : null);
+    }
+}

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -47,6 +47,24 @@ public class ControllerInitiatedAgentWsClientTest {
     }
 
     @Test
+    void testStatusUpdateUsesSessionBoundInstanceId() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        VMTracker vmTracker = mock(VMTracker.class);
+        VMTerminator vmTerminator = mock(VMTerminator.class);
+        client.setVmTracker(vmTracker);
+        client.setVmTerminator(vmTerminator);
+
+        CloudVmStatus status = createStatus("i-spoofed", JobStatus.Completed, VMStatus.terminated);
+        AgentWsEnvelope statusUpdate = AgentWsEnvelope.statusUpdate("i-spoofed", "job-1", status);
+
+        invokeHandleText(client, "i-session-bound", statusUpdate);
+
+        verify(vmTerminator).terminate("i-session-bound");
+        verify(vmTerminator, never()).terminate("i-spoofed");
+        verify(vmTracker).setStatus(argThat(updated -> "i-session-bound".equals(updated.getInstanceId())));
+    }
+
+    @Test
     void testTerminalStatusSchedulesTerminationOnlyOnce() throws Exception {
         ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
         VMTracker vmTracker = mock(VMTracker.class);
@@ -105,6 +123,14 @@ public class ControllerInitiatedAgentWsClientTest {
                 "handleStatusUpdate", String.class, AgentWsEnvelope.class);
         method.setAccessible(true);
         method.invoke(client, instanceId, envelope);
+    }
+
+    private void invokeHandleText(ControllerInitiatedAgentWsClient client, String instanceId,
+                                  AgentWsEnvelope envelope) throws Exception {
+        Method method = ControllerInitiatedAgentWsClient.class.getDeclaredMethod(
+                "handleText", String.class, Session.class, String.class, CompletableFuture.class);
+        method.setAccessible(true);
+        method.invoke(client, instanceId, null, envelope.toJson(), new CompletableFuture<AgentWsEnvelope>());
     }
 
     private void invokeOnClosed(ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {


### PR DESCRIPTION
## Summary

- Schedule EC2 termination when the controller-initiated WebSocket receives a terminal agent status after graceful STOP.
- Wire the existing `VMTerminator` into `ControllerInitiatedAgentWsClient` through `JobManager`.
- Deduplicate termination requests per instance while allowing retries after scheduling failures or reconnection.
- Restore Jetty `12.0.30` because `12.0.36` aborts Tank’s h2c connections with `GOAWAY COMPRESSION_ERROR`, preventing agent bootstrap.
- Add focused tests for terminal, duplicate, non-terminal, and reconnect status handling.

## Root cause

The controller-initiated WebSocket path updated `VMTracker` directly but did not schedule VM termination when agents completed after STOP.

Separately, Jetty 12.0.36 failed cleartext HTTP/2 locally with `GOAWAY error=9`, surfaced by the controller as `ClosedChannelException`. This prevented WebSocket bootstrap and caused `AgentWatchdog` to replace otherwise healthy agents. Jetty 12.0.30 restores the previously validated HTTP/2 behavior.

## Validation

- Targeted tests: 4 passed, 0 failures.
- WS-related Maven reactor compile/package completed successfully.
- Confirmed HTTP/2 responds normally without GOAWAY on Jetty 12.0.30.
- Validated controller-initiated bootstrap in EAST and WEST.
- Confirmed harness transfer, startup, and agent readiness in both regions.
- Gracefully stopped sample job.
- Observed terminal status and termination scheduling for both agents.
- Confirmed both EC2 instances terminated after the expected 30-second delay.

## Scope

- HTTP command fallback and KILL behavior are unchanged.
- File-transfer behavior is unchanged.
- No new lifecycle service or distributed infrastructure is introduced.

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.