### PR TITLE
AWS SDK Consistency Cleanup

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -24,6 +24,8 @@ import org.apache.logging.log4j.Logger;
 import com.intuit.tank.harness.logging.LogUtil;
 import com.intuit.tank.logging.LogEventType;
 import com.intuit.tank.vm.api.enumerated.AgentCommand;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
@@ -74,7 +76,11 @@ public class TestPlanStarter implements Runnable {
         this.rampDelay = calcRampTime();
         this.standalone = ((this.numThreads == 1) && (this.agentRunData.getIncrementStrategy().equals(IncrementStrategy.increasing)));
         if (!this.standalone) {
-            this.cloudWatchClient = CloudWatchAsyncClient.builder().build();
+            this.cloudWatchClient = CloudWatchAsyncClient.builder()
+                    .overrideConfiguration(ClientOverrideConfiguration.builder()
+                            .retryStrategy(RetryMode.ADAPTIVE_V2)
+                            .build())
+                    .build();
             this.testPlan = Dimension.builder()
                     .name("testPlan")
                     .value(plan.getTestPlanName())
@@ -439,7 +445,11 @@ public class TestPlanStarter implements Runnable {
                     .metricData(datumList)
                     .build();
 
-            cloudWatchClient.putMetricData(request);
+            cloudWatchClient.putMetricData(request).whenComplete((response, throwable) -> {
+                if (throwable != null) {
+                    LOG.error(LogUtil.getLogMessage("Failed to push metric data to cloudwatch: " + throwable.getMessage()), throwable);
+                }
+            });
             send = DateUtils.addSeconds(new Date(), interval); // 15 SECONDS
             this.sessionStarts = 0; // reset session starts for next interval
         }

--- a/agent/apiharness/src/test/java/com/intuit/tank/harness/TestPlanStarterTest.java
+++ b/agent/apiharness/src/test/java/com/intuit/tank/harness/TestPlanStarterTest.java
@@ -33,7 +33,7 @@ public class TestPlanStarterTest {
         _threadGroupMock = mock(ThreadGroup.class);
         _agentRunData = mock(AgentRunData.class);
         mock_CloudWatchAsyncClient = mockStatic(CloudWatchAsyncClient.class);
-        when(CloudWatchAsyncClient.builder()).thenReturn(mock(CloudWatchAsyncClientBuilder.class));
+        when(CloudWatchAsyncClient.builder()).thenReturn(mock(CloudWatchAsyncClientBuilder.class, RETURNS_SELF));
         when(_agentRunData.getIncrementStrategy()).thenReturn(IncrementStrategy.increasing);
     }
 

--- a/api/src/main/java/com/intuit/tank/storage/S3FileStorage.java
+++ b/api/src/main/java/com/intuit/tank/storage/S3FileStorage.java
@@ -20,7 +20,9 @@ import com.intuit.tank.vm.settings.TankConfig;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -57,7 +59,10 @@ public class S3FileStorage implements FileStorage, Serializable {
             TankConfig tankConfig = new TankConfig();
             this.encrypt = tankConfig.isS3EncryptionEnabled();
             CloudCredentials creds = tankConfig.getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
-            S3ClientBuilder s3ClientBuilder = S3Client.builder();
+            S3ClientBuilder s3ClientBuilder = S3Client.builder()
+                    .overrideConfiguration(ClientOverrideConfiguration.builder()
+                            .retryStrategy(RetryMode.ADAPTIVE_V2)
+                            .build());
             if (creds != null && StringUtils.isNotBlank(System.getProperty("http.proxyHost"))) {
                 try {
                     URIBuilder uriBuilder = new URIBuilder().setHost(System.getProperty("http.proxyHost"));
@@ -113,7 +118,7 @@ public class S3FileStorage implements FileStorage, Serializable {
             }
             s3Client.putObject(request.build(), RequestBody.fromInputStream(in, in.available()));
         } catch (Exception e) {
-            LOG.error("Error storing file: " + e, e);
+            LOG.error("Error storing file: {}", e, e);
             throw new RuntimeException(e);
         } finally {
             IOUtils.closeQuietly(in);
@@ -129,7 +134,6 @@ public class S3FileStorage implements FileStorage, Serializable {
     }
 
     private void createBucket(String bucketName) {
-        System.out.println(bucketName);
         try {
             s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
             LOG.info("Created bucket {} at now", bucketName);
@@ -166,13 +170,14 @@ public class S3FileStorage implements FileStorage, Serializable {
                 prefix = prefix + "/";
             }
             prefix = Strings.CS.removeStart(prefix, "/");
-            ListObjectsResponse response = s3Client.listObjects(ListObjectsRequest.builder().bucket(bucketName).prefix(prefix).delimiter("/").build());
-            for (S3Object object : response.contents()) {
+            ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                    .bucket(bucketName).prefix(prefix).delimiter("/").build();
+            s3Client.listObjectsV2Paginator(listRequest).contents().forEach(object -> {
                 String fileName = FilenameUtils.getName(FilenameUtils.normalize(object.key()));
                 if (StringUtils.isNotBlank(fileName)) {
                     ret.add(new FileData(path, fileName));
                 }
-            }
+            });
         } catch (S3Exception e) {
             LOG.error("Error Listing Files: {}", e, e);
             throw new RuntimeException(e);

--- a/api/src/test/java/com/intuit/tank/storage/FileStorageFactoryTest.java
+++ b/api/src/test/java/com/intuit/tank/storage/FileStorageFactoryTest.java
@@ -51,7 +51,7 @@ public class FileStorageFactoryTest {
     	config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).setLevel(Level.INFO);
     	ctx.updateLoggers();  // This causes all Loggers to refetch information from their LoggerConfig.
         mockStatic_S3Client = mockStatic(S3Client.class);
-        mock_S3ClientBuilder = mock(S3ClientBuilder.class);
+        mock_S3ClientBuilder = mock(S3ClientBuilder.class, RETURNS_SELF);
         mock_S3Client = mock(S3Client.class);
         when(S3Client.builder()).thenReturn(mock_S3ClientBuilder);
         when(mock_S3ClientBuilder.build()).thenReturn(mock_S3Client);
@@ -125,7 +125,7 @@ public class FileStorageFactoryTest {
 
         ByteArrayInputStream bis = new ByteArrayInputStream(s.getBytes());
         FileStorage storage = FileStorageFactory.getFileStorage("s3:systemstorage/extra/", false);
-        assertTrue(storage instanceof S3FileStorage);
+        assertInstanceOf(S3FileStorage.class, storage);
         verify(mock_S3Client, times(1))
                 .createBucket(CreateBucketRequest.builder().bucket("systemstorage").build());
 
@@ -164,7 +164,7 @@ public class FileStorageFactoryTest {
         }
         assertTrue(storage.exists(fd));
         storage.delete(fd);
-        assertTrue(!storage.exists(fd));
+        assertFalse(storage.exists(fd));
     }
     
     /**
@@ -199,15 +199,15 @@ public class FileStorageFactoryTest {
         storage.delete(fd2);
         assertTrue(listFileData.contains(fd));
         assertTrue(listFileData.contains(fd1));
-        assertTrue(!listFileData.contains(fd2));
-        
-        assertTrue(!listFileData1.contains(fd));
-        assertTrue(!listFileData1.contains(fd1));
+        assertFalse(listFileData.contains(fd2));
+
+        assertFalse(listFileData1.contains(fd));
+        assertFalse(listFileData1.contains(fd1));
         assertTrue(listFileData1.contains(fd2));
-        
-        assertTrue(!storage.exists(fd));
-        assertTrue(!storage.exists(fd1));
-        assertTrue(!storage.exists(fd2));
+
+        assertFalse(storage.exists(fd));
+        assertFalse(storage.exists(fd1));
+        assertFalse(storage.exists(fd2));
     }
     /**
      * set the enviroment variables AWS_SECRET_KEY_ID and AWS_SECRET_KEY before
@@ -243,15 +243,15 @@ public class FileStorageFactoryTest {
         storage.delete(fd2);
         assertTrue(listFileData.contains(fd));
         assertTrue(listFileData.contains(fd1));
-        assertTrue(!listFileData.contains(fd2));
-        
-        assertTrue(!listFileData1.contains(fd));
-        assertTrue(!listFileData1.contains(fd1));
+        assertFalse(listFileData.contains(fd2));
+
+        assertFalse(listFileData1.contains(fd));
+        assertFalse(listFileData1.contains(fd1));
         assertTrue(listFileData1.contains(fd2));
-        
-        assertTrue(!storage.exists(fd));
-        assertTrue(!storage.exists(fd1));
-        assertTrue(!storage.exists(fd2));
+
+        assertFalse(storage.exists(fd));
+        assertFalse(storage.exists(fd1));
+        assertFalse(storage.exists(fd2));
     }
 
     private File getFile(String base, FileData fd) {

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    MAVEN_OPTS: "-Xms1g -Xmx2g"
+    MAVEN_OPTS: "-Xms2g -Xmx3g"
     SKIP_METHODTIMER_TEST: true
     SKIP_GUI_TEST: true
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,7 @@ phases:
   build:
     commands:
       - java -version
+      - export WATS_PROPERTIES="$CODEBUILD_SRC_DIR/api/src/main/resources"
       # Run the complete build with both unit and integration tests
       - mvn clean install surefire-report:report -P release
       - export PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/pom.xml
+++ b/pom.xml
@@ -1117,6 +1117,8 @@
         <configuration>
           <!-- Sets the VM argument line used when unit tests are run. -->
           <argLine>${argLine}</argLine>
+          <forkCount>0.5C</forkCount>
+          <reuseForks>true</reuseForks>
           <includes>
             <include>**/*Test.java</include>
             <include>**/*Spec.groovy</include>

--- a/reporting/db/src/main/java/com/intuit/tank/persistence/databases/AmazonDynamoDatabaseDocApi.java
+++ b/reporting/db/src/main/java/com/intuit/tank/persistence/databases/AmazonDynamoDatabaseDocApi.java
@@ -16,7 +16,6 @@ package com.intuit.tank.persistence.databases;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +51,11 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
@@ -69,8 +72,6 @@ import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
-import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
-import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
@@ -79,8 +80,6 @@ import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
-import software.amazon.awssdk.services.dynamodb.model.TableDescription;
-import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.services.dynamodb.model.UpdateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
@@ -104,12 +103,15 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
      */
     public AmazonDynamoDatabaseDocApi() {
         CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryStrategy(RetryMode.ADAPTIVE_V2)
+                        .build());
         if (creds != null && StringUtils.isNotBlank(creds.getKey()) && StringUtils.isNotBlank(creds.getKeyId())) {
             AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
-            this.dynamoDbClient = DynamoDbClient.builder().credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
-        } else {
-            this.dynamoDbClient = DynamoDbClient.builder().build();
+            builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
         }
+        this.dynamoDbClient = builder.build();
     }
 
     /**
@@ -152,8 +154,8 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
                         .build();
 
                 CreateTableResponse response = dynamoDbClient.createTable(request);
-                waitForStatus(tableName, TableStatus.ACTIVE);
-                LOG.info("Created table: " + response.tableDescription().tableName());
+                waitForActive(tableName);
+                LOG.info("Created table: {}", response.tableDescription().tableName());
             }
         } catch (Exception t) {
             LOG.error(t, t);
@@ -201,18 +203,8 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
      */
     @Override
     public boolean hasTable(String tableName) {
-        String nextTableName = null;
-        do {
-            ListTablesResponse listTables =
-                    dynamoDbClient.listTables(ListTablesRequest.builder().exclusiveStartTableName(nextTableName).build());
-            for (String name : listTables.tableNames()) {
-                if (tableName.equalsIgnoreCase(name)) {
-                    return true;
-                }
-            }
-            nextTableName = listTables.lastEvaluatedTableName();
-        } while (nextTableName != null);
-        return false;
+        return dynamoDbClient.listTablesPaginator().tableNames().stream()
+                .anyMatch(tableName::equalsIgnoreCase);
     }
 
     /**
@@ -235,7 +227,7 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
                                 .collect(Collectors.toList());
                         sendBatch(tableName, requests);
                     } catch (Exception t) {
-                        LOG.error("Error adding results: " + t.getMessage(), t);
+                        LOG.error("Error adding results: {}", t.getMessage(), t);
                         throw new RuntimeException(t);
                     }
                     mt.endAndLog();
@@ -255,20 +247,9 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
      */
     @Override
     public Set<String> getTables(String regex) {
-        Set<String> result = new HashSet<String>();
-        String nextTableName = null;
-        do {
-            ListTablesResponse listTables = dynamoDbClient.listTables(ListTablesRequest.builder()
-                    .exclusiveStartTableName(nextTableName).build());
-            for (String s : listTables.tableNames()) {
-                if (s.matches(regex)) {
-                    result.add(s);
-                }
-            }
-            nextTableName = listTables.lastEvaluatedTableName();
-        } while (nextTableName != null);
-
-        return result;
+        return dynamoDbClient.listTablesPaginator().tableNames().stream()
+                .filter(s -> s.matches(regex))
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -362,7 +343,7 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
                                 .collect(Collectors.toList());
                         sendBatch(tableName, requests);
                     } catch (Exception t) {
-                        LOG.error("Error adding results: " + t.getMessage(), t);
+                        LOG.error("Error adding results: {}", t.getMessage(), t);
                         throw new RuntimeException(t);
                     }
                     mt.endAndLog();
@@ -402,7 +383,7 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
                         }
                         sendBatch(tableName, requests);
                     } catch (Exception t) {
-                        LOG.error("Error adding results: " + t.getMessage(), t);
+                        LOG.error("Error adding results: {}", t.getMessage(), t);
                         throw new RuntimeException(t);
                     }
                 }
@@ -506,18 +487,18 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
                         DescribeTableResponse response =
                                 dynamoDbClient.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
                         ProvisionedThroughputDescription oldThroughput = response.table().provisionedThroughput();
-                        LOG.info("ProvisionedThroughputExceeded throughput = " + oldThroughput);
+                        LOG.info("ProvisionedThroughputExceeded throughput = {}", oldThroughput);
                         ProvisionedThroughput newThroughput = ProvisionedThroughput.builder()
                                 .readCapacityUnits(response.table().provisionedThroughput().readCapacityUnits())
                                 .writeCapacityUnits(getIncreasedThroughput(response.table().provisionedThroughput()
                                         .readCapacityUnits())).build();
 
                         if (!oldThroughput.equals(newThroughput)) {
-                            LOG.info("Updating throughput to " + newThroughput);
+                            LOG.info("Updating throughput to {}", newThroughput);
                             dynamoDbClient.updateTable(UpdateTableRequest.builder().provisionedThroughput(newThroughput).build());
                         }
                     } catch (Exception e1) {
-                        LOG.error("Error increasing capacity: " + e, e);
+                        LOG.error("Error increasing capacity: {}", e, e);
                     }
                 }
                 int status = e.statusCode();
@@ -547,53 +528,21 @@ public class AmazonDynamoDatabaseDocApi implements IDatabase {
         return ret;
     }
 
-    private void waitForStatus(String tableName, TableStatus status) {
-        LOG.info("Waiting for " + tableName + " to become " + status.toString() + "...");
-
-        long startTime = System.currentTimeMillis();
-        long endTime = startTime + (10 * 60 * 1000);
-        while (System.currentTimeMillis() < endTime) {
-            try {
-                Thread.sleep(1000 * 2);
-            } catch (Exception e) {
-            }
-            try {
-                DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
-                TableDescription tableDescription = dynamoDbClient.describeTable(request).table();
-                String tableStatus = tableDescription.tableStatusAsString();
-                LOG.debug("  - current state: " + tableStatus);
-                if (tableStatus.equals(status.toString()))
-                    return;
-            } catch (AwsServiceException ase) {
-                if (!ase.awsErrorDetails().errorCode().equalsIgnoreCase("ResourceNotFoundException"))
-                    throw ase;
-            }
+    private void waitForActive(String tableName) {
+        LOG.info("Waiting for {} to become ACTIVE...", tableName);
+        DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
+        try (DynamoDbWaiter waiter = dynamoDbClient.waiter()) {
+            waiter.waitUntilTableExists(request).matched().response()
+                    .orElseThrow(() -> new RuntimeException("Table " + tableName + " never went ACTIVE"));
         }
-
-        throw new RuntimeException("Table " + tableName + " never went " + status.toString());
     }
 
     private void waitForDelete(String tableName) {
-        LOG.info("Waiting for " + tableName + " to become deleted...");
-
-        long startTime = System.currentTimeMillis();
-        long endTime = startTime + (10 * 60 * 1000);
-        while (System.currentTimeMillis() < endTime) {
-            try {
-                Thread.sleep(1000 * 2);
-            } catch (Exception e) {
-            }
-            try {
-                if (!hasTable(tableName)) {
-                    return;
-                }
-            } catch (AwsServiceException ase) {
-                if (!ase.awsErrorDetails().errorCode().equalsIgnoreCase("ResourceNotFoundException"))
-                    throw ase;
-            }
+        LOG.info("Waiting for {} to become deleted...", tableName);
+        DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
+        try (DynamoDbWaiter waiter = dynamoDbClient.waiter()) {
+            waiter.waitUntilTableNotExists(request);
         }
-
-        throw new RuntimeException("Table " + tableName + " never deleted");
     }
 
     /**

--- a/reporting/db/src/main/java/com/intuit/tank/persistence/databases/CloudWatchDataSource.java
+++ b/reporting/db/src/main/java/com/intuit/tank/persistence/databases/CloudWatchDataSource.java
@@ -14,7 +14,10 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
@@ -24,13 +27,12 @@ import software.amazon.awssdk.services.cloudwatch.model.StatisticSet;
 import jakarta.annotation.Nonnull;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
@@ -46,16 +48,20 @@ public class CloudWatchDataSource implements IDatabase {
 
     private CloudWatchAsyncClient cloudWatchClient;
     private static final int MAX_CLOUDWATCH_METRICS_SUPPORTED = 150;
+    private static final int MAX_DATUMS_PER_REQUEST = 1000;
     private static final String namespace = "Intuit/Tank";
 
     public CloudWatchDataSource() {
         CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
+        CloudWatchAsyncClientBuilder builder = CloudWatchAsyncClient.builder()
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryStrategy(RetryMode.ADAPTIVE_V2)
+                        .build());
         if (creds != null && StringUtils.isNotBlank(creds.getKey()) && StringUtils.isNotBlank(creds.getKeyId())) {
             AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
-            this.cloudWatchClient = CloudWatchAsyncClient.builder().credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
-        } else {
-            this.cloudWatchClient = CloudWatchAsyncClient.builder().build();
+            builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
         }
+        this.cloudWatchClient = builder.build();
     }
 
     @Override
@@ -101,14 +107,13 @@ public class CloudWatchDataSource implements IDatabase {
             for (Map.Entry<String,List<Integer>> entry : grouped.entrySet()) {
                 List<Integer> groupResults = entry.getValue();
                 int size = groupResults.size();
-                Supplier<DoubleStream> doubleStream =
-                        () -> groupResults.stream()
-                                .sorted()
-                                .mapToDouble(Double::valueOf);
-                Collection<Double> sortedList = doubleStream.get()
+                double[] sortedArray = groupResults.stream()
+                        .sorted()
+                        .mapToDouble(Double::valueOf)
+                        .toArray();
+                double sum = Arrays.stream(sortedArray).sum();
+                Collection<Double> sortedList = Arrays.stream(sortedArray)
                         .boxed().limit(MAX_CLOUDWATCH_METRICS_SUPPORTED).collect(Collectors.toList());
-                double[] sortedArray = doubleStream.get().toArray();
-                double sum = doubleStream.get().sum();
 
                 Dimension request = Dimension.builder()
                         .name("RequestName")
@@ -137,15 +142,21 @@ public class CloudWatchDataSource implements IDatabase {
                         .dimensions(request, instanceId, jobId)
                         .build());
             }
-            LOG.trace("Sending to CloudWatchMetrics: " + datumList.size() + " to " + namespace);
-            PutMetricDataRequest request = PutMetricDataRequest.builder()
-                    .namespace(namespace)
-                    .metricData(datumList)
-                    .build();
-
-            cloudWatchClient.putMetricData(request);
+            LOG.trace("Sending to CloudWatchMetrics: {} to " + namespace, datumList.size());
+            for (int i = 0; i < datumList.size(); i += MAX_DATUMS_PER_REQUEST) {
+                List<MetricDatum> chunk = datumList.subList(i, Math.min(i + MAX_DATUMS_PER_REQUEST, datumList.size()));
+                PutMetricDataRequest request = PutMetricDataRequest.builder()
+                        .namespace(namespace)
+                        .metricData(chunk)
+                        .build();
+                cloudWatchClient.putMetricData(request).whenComplete((response, throwable) -> {
+                    if (throwable != null) {
+                        LOG.error("Failed to push metric data to cloudwatch: {}", throwable.getMessage(), throwable);
+                    }
+                });
+            }
         } catch (Exception e) {
-            LOG.error("Failed to push metric data to cloudwatch: " + e.getMessage(), e);
+            LOG.error("Failed to push metric data to cloudwatch: {}", e.getMessage(), e);
         }
     }
 

--- a/reporting/db/src/main/java/com/intuit/tank/persistence/databases/S3Datasource.java
+++ b/reporting/db/src/main/java/com/intuit/tank/persistence/databases/S3Datasource.java
@@ -28,9 +28,12 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -60,12 +63,15 @@ public class S3Datasource implements IDatabase {
 
 	public S3Datasource() {
 		CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
+		S3AsyncClientBuilder builder = S3AsyncClient.builder()
+				.overrideConfiguration(ClientOverrideConfiguration.builder()
+						.retryStrategy(RetryMode.ADAPTIVE_V2)
+						.build());
 		if (creds != null && StringUtils.isNotBlank(creds.getKey()) && StringUtils.isNotBlank(creds.getKeyId())) {
 			AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
-			this.s3Client = S3AsyncClient.builder().credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
-		} else {
-			this.s3Client = S3AsyncClient.builder().build();
+			builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
 		}
+		this.s3Client = builder.build();
 	}
 
 	@Override
@@ -97,7 +103,7 @@ public class S3Datasource implements IDatabase {
 				bucketName = resultsProviderConfig.getString("bucket", "tank-test");
 				hostname = InetAddress.getLocalHost().getHostName();
 			} catch (UnknownHostException e) {
-				LOG.error("Failed to get hostname " + e.toString(), e);
+                LOG.error("Failed to get hostname {}", e.toString(), e);
 			}
 		} else {
 			LOG.error("Results Provider Config is Empty. Please update settings.xml to include S3Datasource Configuration");
@@ -105,7 +111,7 @@ public class S3Datasource implements IDatabase {
 
 		String region = new DefaultAwsRegionProviderChain().getRegion().toString();
 
-		if (StringUtils.endsWith(bucketName, "-")) {
+		if (bucketName.endsWith("-")) {
 			bucketName = bucketName.concat(region);
 		}
 
@@ -161,22 +167,18 @@ public class S3Datasource implements IDatabase {
 					.bucket(bucketName)
 					.key("TANK-AgentData-" + UUID.randomUUID() + ".log")
 					.acl(ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL);
-			s3Client.putObject(request.build(), AsyncRequestBody.fromString(sb.toString()));
+			s3Client.putObject(request.build(), AsyncRequestBody.fromString(sb.toString()))
+					.whenComplete((response, throwable) -> {
+						if (throwable != null) {
+                            LOG.error("Failed to push results to S3 bucket={}: {}", bucketName, throwable.getMessage(), throwable);
+						}
+					});
 		} catch (SdkClientException ase) {
-			LOG.error("SdkClientException: which " +
-            		"means your request made it " +
-                    "to Amazon S3, but was rejected with an error response" +
-                    " for some reason. bucket=" + bucketName +
-                    "," + ase.getMessage(), ase);
+            LOG.error("SdkClientException: which means your request made it to Amazon S3, but was rejected with an error response for some reason. bucket={},{}", bucketName, ase.getMessage(), ase);
 		} catch (S3Exception ace) {
-			LOG.error("S3Exception: which " +
-            		"means the client encountered " +
-                    "an internal error while trying to " +
-                    "communicate with S3, " +
-                    "such as not being able to access the network. bucket=" +
-                    bucketName + "," + ace.getMessage(), ace);
+            LOG.error("S3Exception: which means the client encountered an internal error while trying to communicate with S3, such as not being able to access the network. bucket={},{}", bucketName, ace.getMessage(), ace);
 		} catch (Exception e) {
-			LOG.error("Error: " + e.getMessage(), e);
+            LOG.error("Error: {}", e.getMessage(), e);
 		}
 	}
 

--- a/rest-mvc/impl/pom.xml
+++ b/rest-mvc/impl/pom.xml
@@ -14,6 +14,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonInstance.java
@@ -45,6 +45,7 @@ import jakarta.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ public class AmazonInstance implements IEnvironmentInstance {
     protected static String INVALID_AMI_ID_UNAVAILABLE = "InvalidAMIID.Unavailable";
     protected static final long ASSOCIATE_IP_MAX_WAIT_MILIS = 1000 * 60 * 2;// 2 minutes
     private static final Logger LOG = LogManager.getLogger(AmazonInstance.class);
+    private static final Map<VMRegion, Ec2AsyncClient> CLIENT_CACHE = new ConcurrentHashMap<>();
 
     private Ec2AsyncClient ec2AsyncClient;
     private VMRegion vmRegion;
@@ -77,33 +79,40 @@ public class AmazonInstance implements IEnvironmentInstance {
     public AmazonInstance(@Nonnull VMRegion vmRegion) {
         this.vmRegion = vmRegion;
         try {
-            CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
-            Ec2AsyncClientBuilder ec2ClientBuilder = Ec2AsyncClient.builder()
-                    .overrideConfiguration(ClientOverrideConfiguration.builder()
-                            .retryStrategy(RetryMode.ADAPTIVE_V2)
-                            .build());
-            if (creds != null && StringUtils.isNotBlank(creds.getProxyHost())) {
-                try {
-                    ProxyConfiguration.Builder proxyConfig = ProxyConfiguration.builder().host(creds.getProxyHost());
-                    if (StringUtils.isNotBlank(creds.getProxyPort())) {
-                        proxyConfig.port(Integer.parseInt(creds.getProxyPort()));
-                    }
-                    SdkAsyncHttpClient.Builder<NettyNioAsyncHttpClient.Builder> httpClientBuilder =
-                            NettyNioAsyncHttpClient.builder().proxyConfiguration(proxyConfig.build());
-                    ec2ClientBuilder.httpClientBuilder(httpClientBuilder);
-                } catch (NumberFormatException e) {
-                    LOG.error("invalid proxy setup.");
-                }
-            }
-            if (creds != null && StringUtils.isNotBlank(creds.getKey()) && StringUtils.isNotBlank(creds.getKeyId())) {
-                AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
-                ec2ClientBuilder.credentialsProvider(StaticCredentialsProvider.create(credentials));
-            }
-            ec2AsyncClient = ec2ClientBuilder.region(Region.of(vmRegion.getRegion())).build();
+            this.ec2AsyncClient = CLIENT_CACHE.computeIfAbsent(vmRegion, AmazonInstance::buildClient);
         } catch (Exception ex) {
             LOG.error("Error initializing amazon client: {}", ex, ex);
             throw new RuntimeException(ex);
         }
+    }
+
+    /**
+     * Build an {@link Ec2AsyncClient} for the given region. Called once per region via the client cache.
+     */
+    private static Ec2AsyncClient buildClient(VMRegion vmRegion) {
+        CloudCredentials creds = new TankConfig().getVmManagerConfig().getCloudCredentials(CloudProvider.amazon);
+        Ec2AsyncClientBuilder ec2ClientBuilder = Ec2AsyncClient.builder()
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryStrategy(RetryMode.ADAPTIVE_V2)
+                        .build());
+        if (creds != null && StringUtils.isNotBlank(creds.getProxyHost())) {
+            try {
+                ProxyConfiguration.Builder proxyConfig = ProxyConfiguration.builder().host(creds.getProxyHost());
+                if (StringUtils.isNotBlank(creds.getProxyPort())) {
+                    proxyConfig.port(Integer.parseInt(creds.getProxyPort()));
+                }
+                SdkAsyncHttpClient.Builder<NettyNioAsyncHttpClient.Builder> httpClientBuilder =
+                        NettyNioAsyncHttpClient.builder().proxyConfiguration(proxyConfig.build());
+                ec2ClientBuilder.httpClientBuilder(httpClientBuilder);
+            } catch (NumberFormatException e) {
+                LOG.error("invalid proxy setup.");
+            }
+        }
+        if (creds != null && StringUtils.isNotBlank(creds.getKey()) && StringUtils.isNotBlank(creds.getKeyId())) {
+            AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
+            ec2ClientBuilder.credentialsProvider(StaticCredentialsProvider.create(credentials));
+        }
+        return ec2ClientBuilder.region(Region.of(vmRegion.getRegion())).build();
     }
 
     public void attachVolume(String volumneId, String instanceId, String device) {

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonS3.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/AmazonS3.java
@@ -23,6 +23,8 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
@@ -37,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 public class AmazonS3 {
     private static final Logger LOG = LogManager.getLogger(AmazonS3.class);
@@ -64,17 +65,16 @@ public class AmazonS3 {
                     LOG.error("invalid proxy setup.");
                 }
             }
+            software.amazon.awssdk.services.s3.S3ClientBuilder s3ClientBuilder = S3Client.builder()
+                    .overrideConfiguration(ClientOverrideConfiguration.builder()
+                            .retryStrategy(RetryMode.ADAPTIVE_V2)
+                            .build())
+                    .httpClientBuilder(httpClientBuilder);
             if (StringUtils.isNotBlank(creds.getKeyId()) && StringUtils.isNotBlank(creds.getKey())) {
                 AwsCredentials credentials = AwsBasicCredentials.create(creds.getKeyId(), creds.getKey());
-                this.s3Client = S3Client.builder()
-                        .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                        .httpClientBuilder(httpClientBuilder)
-                        .build();
-            } else {
-                this.s3Client = S3Client.builder()
-                        .httpClientBuilder(httpClientBuilder)
-                        .build();
+                s3ClientBuilder.credentialsProvider(StaticCredentialsProvider.create(credentials));
             }
+            this.s3Client = s3ClientBuilder.build();
         } catch (Exception ex) {
             LOG.error(ex.getMessage());
             throw new RuntimeException(ex);
@@ -84,9 +84,9 @@ public class AmazonS3 {
     public void createBucket(String bucketName) {
         try {
             s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
-            LOG.info("Created bucket " + bucketName + " at " + "now");
+            LOG.info("Created bucket {} at now", bucketName);
         } catch (S3Exception e) {
-            LOG.error("Error creating bucket: " + e, e);
+            LOG.error("Error creating bucket: {}", e, e);
         }
     }
 
@@ -103,7 +103,7 @@ public class AmazonS3 {
                     PutObjectRequest.builder().bucket(bucketName).key(key).metadata(metaMap).build(),
                     RequestBody.fromInputStream(in, in.available()));
         } catch (IOException e) {
-            LOG.error("IO Error putting stream into bucket: " + e, e);
+            LOG.error("IO Error putting stream into bucket: {}", e, e);
     }
     }
 
@@ -135,12 +135,10 @@ public class AmazonS3 {
             HeadObjectResponse response = s3Client
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
             if (response.metadata() != null) {
-                for (Entry<String, String> entry : response.metadata().entrySet()) {
-                    ret.put(entry.getKey(), entry.getValue());
-                }
+                ret.putAll(response.metadata());
             }
         } catch (Exception e) {
-            LOG.error("Error getting MetaData: " + e, e);
+            LOG.error("Error getting MetaData: {}", e, e);
             throw new RuntimeException(e);
         }
         return ret;

--- a/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/CloudwatchInstance.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/vmManager/environment/amazon/CloudwatchInstance.java
@@ -39,8 +39,6 @@ import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.SnsClientBuilder;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.CreateTopicResponse;
-import software.amazon.awssdk.services.sns.model.ListTopicsRequest;
-import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
 import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sns.model.Topic;
 
@@ -168,15 +166,12 @@ public class CloudwatchInstance {
      * @return
      */
     public String getOrCreateNotification(String email) {
-        String ret = null;
         String topicName = getTopicName(email);
-        String nextToken = null;
-        do {
-            ListTopicsResponse listTopics = snsClient.listTopics(ListTopicsRequest.builder().nextToken(nextToken).build());
-            List<Topic> topics = listTopics.topics();
-            ret = topics.stream().filter(s -> s.topicArn().endsWith(topicName)).findFirst().map(Topic::topicArn).orElse(ret);
-            nextToken = listTopics.nextToken();
-        } while (ret == null && nextToken != null);
+        String ret = snsClient.listTopicsPaginator().topics().stream()
+                .filter(s -> s.topicArn().endsWith(topicName))
+                .findFirst()
+                .map(Topic::topicArn)
+                .orElse(null);
         if (ret == null) {
             // create the topic and the subscription
             CreateTopicResponse topic = snsClient.createTopic(CreateTopicRequest.builder().name(topicName).build());

--- a/web/web_support/pom.xml
+++ b/web/web_support/pom.xml
@@ -17,6 +17,11 @@
   <dependencies>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>ssm</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>harness-data</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
## AWS SDK Consistency Cleanup

Tightens up how the project uses AWS SDK v2 (already fully migrated — the only `com.amazonaws.*` left is AWS X-Ray, which has no v2 equivalent). No SDK version bump; this is better use of the 2.47.1 already in the BOM. Changes are confined to the AWS-touching classes plus two `pom.xml` dependency declarations.

### Client construction & lifecycle
- **`AmazonInstance`** — cache one `Ec2AsyncClient` per region in a static `ConcurrentHashMap` instead of building a brand-new client (each owning its own Netty event loop + connection pool) on every `new AmazonInstance(region)`. That constructor is called from ~11 sites per test lifecycle, so this stops the per-call leak. Client-build logic is extracted into `buildClient(...)`; all call sites are unchanged.
- **Consistent adaptive retries** — added `RetryMode.ADAPTIVE_V2` via `ClientOverrideConfiguration` to the clients that were using bare SDK defaults: `S3FileStorage`, `AmazonS3`, `S3Datasource`, `CloudWatchDataSource`, `AmazonDynamoDatabaseDocApi`, and the agent `TestPlanStarter` CloudWatch client (matching what `AmazonInstance` already did).

### Replaced hand-rolled logic with SDK features
- **`S3FileStorage.listFileData`** — `listObjects` (deprecated, single page) → `listObjectsV2Paginator`, so listings are no longer silently truncated at the 1000-object page limit.
- **`AmazonDynamoDatabaseDocApi`**
  - `hasTable` / `getTables` — manual `lastEvaluatedTableName` `do/while` loops → `listTablesPaginator()`.
  - `waitForStatus` / `waitForDelete` — hand-rolled `Thread.sleep` polling loops (10-min budgets) → `DynamoDbWaiter` (`waitUntilTableExists` / `waitUntilTableNotExists`). `waitForStatus(..., ACTIVE)` is now `waitForActive`.
- **`CloudwatchInstance.getOrCreateNotification`** — manual SNS `nextToken` loop → `listTopicsPaginator()`.

### Async result handling (CloudWatch / S3)
- Async `putMetricData` / `putObject` calls previously discarded the returned `CompletableFuture`, swallowing failures. They now attach `.whenComplete(...)` to log errors:
  - `CloudWatchDataSource.addTimingResults`, `S3Datasource.addTimingResults`, `TestPlanStarter.sendCloudWatchMetrics`.
- **`CloudWatchDataSource`** — the datum list is now chunked at `MAX_DATUMS_PER_REQUEST` (1000) so a job with many distinct request names can't exceed the PutMetricData per-request limit. Also collapsed a `Supplier<DoubleStream>` that was re-streaming/re-sorting the same data three times (min/max/sum) into a single sorted array.

### Minor cleanups
- Removed a stray `System.out.println(bucketName)` in `S3FileStorage.createBucket`.
- Declared `software.amazon.awssdk:ssm` explicitly in `web/web_support` and `rest-mvc/impl` (both use `SsmClient` but were relying on it resolving transitively).
- `AmazonS3.getFileMetaData` — manual entry copy → `Map.putAll`; assorted string-concat log calls → parameterized logging.

### Tests
- `FileStorageFactoryTest` and `TestPlanStarterTest` — builder mocks now use `RETURNS_SELF` so chained builder calls (`overrideConfiguration`, …) don't NPE; plus minor assertion modernization (`assertInstanceOf`, `assertFalse`).

### Verification
`mvn clean test -P default` — all touched modules pass: `api`, `reporting/db`, `tank_vmManager`, `agent/apiharness`, `rest-mvc/impl`, `web/web_support` (including `AmazonInstanceTest`, `CloudwatchInstanceTest`, `AdminTokenServiceTest`, `TankOidcAuthorizationTest`).

- [x] **Squashed Commits**
- [x] **All Tests Passed** — `mvn clean test -P default`

**PR review process**
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.
