### PR TITLE
Fix startAgent.sh delivery during WebSocket bootstrap

### DIFF
--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -267,9 +267,7 @@ public class StartupWebSocketServer {
                 }
             }
         } catch (Exception e) {
-            closeCurrentFileQuietly();
-            sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, e.getMessage());
-            harnessJarFuture.completeExceptionally(e);
+            failCurrentFileTransfer(conn, fileId, chunkIndex, e);
         }
     }
 
@@ -347,6 +345,16 @@ public class StartupWebSocketServer {
 
     private void sendText(Session conn, String text) {
         conn.sendText(text, Callback.NOOP);
+    }
+
+    private synchronized void failCurrentFileTransfer(
+            Session conn, String fileId, Integer chunkIndex, Exception error) {
+        boolean harnessJar = API_HARNESS_JAR.equals(currentFileName);
+        closeCurrentFileQuietly();
+        sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, error.getMessage());
+        if (harnessJar) {
+            harnessJarFuture.completeExceptionally(error);
+        }
     }
 
     private synchronized void handleFatalError(Exception ex) {
@@ -454,9 +462,8 @@ public class StartupWebSocketServer {
                         : java.util.Base64.getDecoder().decode(envelope.getChunkData());
                 server.handleFileChunk(conn, envelope.getFileId(), envelope.getChunkIndex(), payload);
             } catch (Exception e) {
-                server.closeCurrentFileQuietly();
-                server.sendFileAck(conn, envelope.getFileId(), envelope.getChunkIndex(), AckStatus.failed, e.getMessage());
-                server.harnessJarFuture.completeExceptionally(e);
+                server.failCurrentFileTransfer(
+                        conn, envelope.getFileId(), envelope.getChunkIndex(), e);
             }
         }
 

--- a/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
+++ b/agent/agent_startup/src/main/java/com/intuit/tank/agent/StartupWebSocketServer.java
@@ -25,8 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Agent-side WebSocket server that receives the harness JAR pushed by the controller during startup
- * bootstrap. Runs over WebSocket-over-HTTP/2 (RFC 8441) using Jetty 12; the same connector also
+ * Agent-side WebSocket server that receives startup files pushed by the controller during bootstrap.
+ * Runs over WebSocket-over-HTTP/2 (RFC 8441) using Jetty 12; the same connector also
  * accepts HTTP/1.1 WebSocket upgrades so a controller may negotiate either transport via ALPN/prior
  * knowledge.
  */
@@ -36,6 +36,8 @@ public class StartupWebSocketServer {
     private static final String TANK_AGENT_DIR = "/opt/tank_agent";
     private static final String API_HARNESS_JAR = "apiharness-1.0-all.jar";
     private static final String SUPPORT_JAR_FILE_TYPE = "support_jar";
+    private static final String START_AGENT_SCRIPT = "startAgent.sh";
+    private static final String STARTUP_SCRIPT_FILE_TYPE = "startup_script";
     // 2 MiB chunks * a healthy window can exceed Jetty's default frame/message limits.
     private static final long MAX_WS_MESSAGE_BYTES = 64L * 1024 * 1024;
     // Raise Jetty's 30s default WS idle timeout so a slow/paused bootstrap transfer isn't dropped.
@@ -46,6 +48,7 @@ public class StartupWebSocketServer {
     private final String instanceId;
     private final String jobId;
     private final int capacity;
+    private final File agentDir;
     private final String agentSessionId = UUID.randomUUID().toString();
     private final CompletableFuture<File> harnessJarFuture = new CompletableFuture<>();
     private final CompletableFuture<Void> serverStoppedFuture = new CompletableFuture<>();
@@ -57,6 +60,7 @@ public class StartupWebSocketServer {
     private FileOutputStream currentFileStream;
     private File currentTempFile;
     private File targetFile;
+    private String currentFileName;
     private String currentFileId;
     private int receivedChunks;
     private int expectedChunks;
@@ -65,10 +69,15 @@ public class StartupWebSocketServer {
     private long transferStartedAtNs;
 
     public StartupWebSocketServer(int port, String instanceId, String jobId, int capacity) {
+        this(port, instanceId, jobId, capacity, new File(TANK_AGENT_DIR));
+    }
+
+    StartupWebSocketServer(int port, String instanceId, String jobId, int capacity, File agentDir) {
         this.port = port;
         this.instanceId = instanceId;
         this.jobId = jobId;
         this.capacity = capacity;
+        this.agentDir = agentDir;
         this.server = new Server();
     }
 
@@ -162,10 +171,15 @@ public class StartupWebSocketServer {
         return serverStoppedFuture.isDone();
     }
 
-    private synchronized void handleFileOffer(Session conn, AgentWsEnvelope envelope) {
-        String fileName = new File(envelope.getFileName() != null ? envelope.getFileName() : "").getName();
+    synchronized void handleFileOffer(Session conn, AgentWsEnvelope envelope) {
+        String offeredFileName = envelope.getFileName() != null ? envelope.getFileName() : "";
+        String fileName = new File(offeredFileName).getName();
         String fileType = envelope.getFileType();
-        if (!API_HARNESS_JAR.equals(fileName) && !SUPPORT_JAR_FILE_TYPE.equalsIgnoreCase(fileType)) {
+        boolean harnessJar = API_HARNESS_JAR.equals(fileName)
+                && SUPPORT_JAR_FILE_TYPE.equalsIgnoreCase(fileType);
+        boolean startupScript = START_AGENT_SCRIPT.equals(fileName)
+                && STARTUP_SCRIPT_FILE_TYPE.equalsIgnoreCase(fileType);
+        if (!offeredFileName.equals(fileName) || (!harnessJar && !startupScript)) {
             sendFileAck(conn, envelope.getFileId(), null, AckStatus.failed, "unsupported_startup_file");
             return;
         }
@@ -175,12 +189,12 @@ public class StartupWebSocketServer {
         int offerTotalChunks = envelope.getTotalChunks() != null ? envelope.getTotalChunks() : 0;
         int offerChunkBytes = envelope.getChunkBytes() != null ? envelope.getChunkBytes() : 0;
         try {
-            File agentDir = new File(TANK_AGENT_DIR);
             if (!agentDir.exists() && !agentDir.mkdirs()) {
                 throw new IOException("Unable to create " + agentDir.getAbsolutePath());
             }
             currentFileConnection = conn;
-            targetFile = new File(agentDir, API_HARNESS_JAR);
+            currentFileName = fileName;
+            targetFile = new File(agentDir, fileName);
             currentTempFile = new File(targetFile.getAbsolutePath() + ".part");
 
             // Check for resumable partial file from a previous failed transfer
@@ -232,7 +246,7 @@ public class StartupWebSocketServer {
         }
     }
 
-    private synchronized void handleFileChunk(Session conn, String fileId, Integer chunkIndex, byte[] payload) {
+    synchronized void handleFileChunk(Session conn, String fileId, Integer chunkIndex, byte[] payload) {
         if (currentFileStream == null || currentFileId == null || !currentFileId.equals(fileId)) {
             sendFileAck(conn, fileId, chunkIndex, AckStatus.failed, "file_offer_not_found");
             return;
@@ -244,10 +258,13 @@ public class StartupWebSocketServer {
             receivedChunks++;
             sendFileAck(conn, fileId, chunkIndex, AckStatus.chunk_received, null);
 
-            if (expectedBytes > 0 && receivedBytes >= expectedBytes) {
-                File completedFile = finalizeHarnessJar();
+            if (expectedBytes >= 0 && receivedBytes >= expectedBytes) {
+                boolean harnessJar = API_HARNESS_JAR.equals(currentFileName);
+                File completedFile = finalizeStartupFile();
                 sendFileAckSync(conn, fileId, chunkIndex, AckStatus.complete, null);
-                harnessJarFuture.complete(completedFile);
+                if (harnessJar) {
+                    harnessJarFuture.complete(completedFile);
+                }
             }
         } catch (Exception e) {
             closeCurrentFileQuietly();
@@ -265,7 +282,7 @@ public class StartupWebSocketServer {
         }
     }
 
-    private File finalizeHarnessJar() throws IOException {
+    private File finalizeStartupFile() throws IOException {
         currentFileStream.close();
         currentFileStream = null;
         if (expectedBytes >= 0 && expectedBytes != receivedBytes) {
@@ -278,16 +295,20 @@ public class StartupWebSocketServer {
             Files.move(currentTempFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
         File completedFile = targetFile;
+        if (START_AGENT_SCRIPT.equals(currentFileName) && !completedFile.setExecutable(true, false)) {
+            throw new IOException("Unable to make " + completedFile.getAbsolutePath() + " executable");
+        }
         long durationMs = transferStartedAtNs > 0L
                 ? TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - transferStartedAtNs)
                 : 0L;
         double throughputMiBps = durationMs > 0
                 ? Math.round(((receivedBytes / (1024.0 * 1024.0)) / (durationMs / 1000.0)) * 100.0) / 100.0
                 : 0.0;
-        logger.info("Startup WS harness JAR received bytes={} chunks={}/{} durationMs={} throughputMiBps={}",
-                receivedBytes, receivedChunks, expectedChunks, durationMs, throughputMiBps);
+        logger.info("Startup WS file received file={} bytes={} chunks={}/{} durationMs={} throughputMiBps={}",
+                currentFileName, receivedBytes, receivedChunks, expectedChunks, durationMs, throughputMiBps);
         currentTempFile = null;
         targetFile = null;
+        currentFileName = null;
         currentFileId = null;
         transferStartedAtNs = 0L;
         return completedFile;

--- a/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
+++ b/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
@@ -68,6 +68,27 @@ class StartupWebSocketServerTest {
     }
 
     @Test
+    void startupScriptFailureDoesNotPreventHarnessRetry() throws Exception {
+        StartupWebSocketServer server =
+                new StartupWebSocketServer(0, "i-agent", "job-1", 1, agentDir.toFile());
+        Session session = sessionThatCompletesCallbacks();
+
+        server.handleFileOffer(session, fileOffer(
+                "script-id", "startup_script", "startAgent.sh", 1));
+        server.handleFileChunk(session, "script-id", 0, new byte[] { 1, 2 });
+
+        assertFalse(isHarnessJarReady(server));
+        verify(session).sendText(contains("file size mismatch"), any(Callback.class));
+
+        byte[] harnessJar = new byte[] { 3 };
+        server.handleFileOffer(session, fileOffer(
+                "jar-id", "support_jar", "apiharness-1.0-all.jar", harnessJar.length));
+        server.handleFileChunk(session, "jar-id", 0, harnessJar);
+
+        assertEquals(agentDir.resolve("apiharness-1.0-all.jar").toFile(), server.awaitHarnessJar(100));
+    }
+
+    @Test
     void keepsPackagedStartupScriptWhenControllerOnlySendsHarnessJar() throws Exception {
         byte[] packagedScript = "#!/bin/sh\necho packaged\n".getBytes(StandardCharsets.UTF_8);
         Path startupScript = agentDir.resolve("startAgent.sh");

--- a/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
+++ b/agent/agent_startup/src/test/java/com/intuit/tank/agent/StartupWebSocketServerTest.java
@@ -1,0 +1,110 @@
+package com.intuit.tank.agent;
+
+import com.intuit.tank.vm.agent.messages.AgentWsEnvelope;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class StartupWebSocketServerTest {
+
+    @TempDir
+    Path agentDir;
+
+    @Test
+    void receivesCustomStartupScriptBeforeCompletingHarnessBootstrap() throws Exception {
+        StartupWebSocketServer server =
+                new StartupWebSocketServer(0, "i-agent", "job-1", 1, agentDir.toFile());
+        Session session = sessionThatCompletesCallbacks();
+        byte[] script = "#!/bin/sh\necho custom\n".getBytes(StandardCharsets.UTF_8);
+
+        server.handleFileOffer(session, fileOffer(
+                "script-id", "startup_script", "startAgent.sh", script.length));
+        server.handleFileChunk(session, "script-id", 0, script);
+
+        Path receivedScript = agentDir.resolve("startAgent.sh");
+        assertArrayEquals(script, Files.readAllBytes(receivedScript));
+        assertTrue(Files.isExecutable(receivedScript));
+        assertFalse(isHarnessJarReady(server));
+
+        byte[] harnessJar = new byte[] { 1, 2, 3 };
+        server.handleFileOffer(session, fileOffer(
+                "jar-id", "support_jar", "apiharness-1.0-all.jar", harnessJar.length));
+        server.handleFileChunk(session, "jar-id", 0, harnessJar);
+
+        File receivedHarness = server.awaitHarnessJar(100);
+        assertEquals(agentDir.resolve("apiharness-1.0-all.jar").toFile(), receivedHarness);
+        assertArrayEquals(harnessJar, Files.readAllBytes(receivedHarness.toPath()));
+    }
+
+    @Test
+    void rejectsMismatchedStartupFileTypeAndName() {
+        StartupWebSocketServer server =
+                new StartupWebSocketServer(0, "i-agent", "job-1", 1, agentDir.toFile());
+        Session session = mock(Session.class);
+
+        server.handleFileOffer(session, fileOffer(
+                "script-id", "support_jar", "startAgent.sh", 10));
+
+        verify(session).sendText(contains("unsupported_startup_file"), any(Callback.class));
+    }
+
+    @Test
+    void keepsPackagedStartupScriptWhenControllerOnlySendsHarnessJar() throws Exception {
+        byte[] packagedScript = "#!/bin/sh\necho packaged\n".getBytes(StandardCharsets.UTF_8);
+        Path startupScript = agentDir.resolve("startAgent.sh");
+        Files.write(startupScript, packagedScript);
+        startupScript.toFile().setExecutable(true, false);
+        StartupWebSocketServer server =
+                new StartupWebSocketServer(0, "i-agent", "job-1", 1, agentDir.toFile());
+        Session session = sessionThatCompletesCallbacks();
+        byte[] harnessJar = new byte[] { 1, 2, 3 };
+
+        server.handleFileOffer(session, fileOffer(
+                "jar-id", "support_jar", "apiharness-1.0-all.jar", harnessJar.length));
+        server.handleFileChunk(session, "jar-id", 0, harnessJar);
+
+        assertArrayEquals(packagedScript, Files.readAllBytes(startupScript));
+        assertTrue(Files.isExecutable(startupScript));
+        assertEquals(agentDir.resolve("apiharness-1.0-all.jar").toFile(), server.awaitHarnessJar(100));
+    }
+
+    private AgentWsEnvelope fileOffer(String fileId, String fileType, String fileName, int totalBytes) {
+        return AgentWsEnvelope.fileOffer(
+                "i-agent", "bootstrap", fileId, fileType, fileName, totalBytes, 1, totalBytes, false);
+    }
+
+    private Session sessionThatCompletesCallbacks() {
+        Session session = mock(Session.class);
+        doAnswer(invocation -> {
+            Callback callback = invocation.getArgument(1);
+            callback.succeed();
+            return null;
+        }).when(session).sendText(anyString(), any(Callback.class));
+        return session;
+    }
+
+    private boolean isHarnessJarReady(StartupWebSocketServer server) throws Exception {
+        Field field = StartupWebSocketServer.class.getDeclaredField("harnessJarFuture");
+        field.setAccessible(true);
+        return ((CompletableFuture<?>) field.get(server)).isDone();
+    }
+}

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -1,5 +1,8 @@
 package com.intuit.tank.perfManager.workLoads;
 
+import com.intuit.tank.storage.FileData;
+import com.intuit.tank.storage.FileStorage;
+import com.intuit.tank.storage.FileStorageFactory;
 import com.intuit.tank.vm.agent.messages.AgentData;
 import com.intuit.tank.vm.agent.messages.AgentTestStartData;
 import com.intuit.tank.vm.agent.messages.AgentWsCommandSender;
@@ -55,6 +58,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
     private static final Logger LOG = LogManager.getLogger(ControllerInitiatedAgentWsClient.class);
     private static final String API_HARNESS_JAR = "apiharness-1.0-all.jar";
+    private static final String START_AGENT_SCRIPT = "startAgent.sh";
+    private static final String STARTUP_SCRIPT_FILE_TYPE = "startup_script";
     private static final String SETTINGS_FILE_NAME = "settings.xml";
     private static final String SCRIPT_FILE_NAME = "script.xml";
     private static final String LOCAL_CONTROLLER_ORIGIN = "http://localhost:8080";
@@ -86,6 +91,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
     private final ConcurrentHashMap<String, String> agentTransferProgress = new ConcurrentHashMap<>();
     private final java.util.Set<String> terminationRequestedInstances = ConcurrentHashMap.newKeySet();
     private volatile byte[] cachedHarnessJarBytes;
+    private volatile Optional<byte[]> cachedStartupScript;
     private volatile WebSocketClient wsClient;
     private volatile java.util.concurrent.ScheduledExecutorService keepAliveExecutor;
 
@@ -345,24 +351,12 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
 
     private boolean pushStartupBootstrapJar(String agentId, SessionContext context, long transferTimeoutMillis)
             throws Exception {
-        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId
-                + " needs startup bootstrap — pushing harness JAR"
-                + " chunkBytes=" + DEFAULT_CHUNK_BYTES
-                + " window=" + CHUNK_WINDOW
-                + " maxConnectionMs=" + MAX_BOOTSTRAP_CONNECTION_MS)));
         File harnessJar = findHarnessJar();
         if (harnessJar == null || !harnessJar.exists() || !harnessJar.isFile()) {
             LOG.error(new ObjectMessage(Map.of("Message", "[WS] Harness JAR not found on controller for startup bootstrap")));
             context.close();
             return false;
         }
-
-        context.jobId = "bootstrap";
-        context.expectedFiles = 1;
-        context.bootstrapTransfer = true;
-        fileTransferReady.put(agentId, false);
-        agentWsState.put(agentId, "bootstrap_transferring");
-        agentTransferProgress.put(agentId, "0/1 files");
 
         byte[] jarBytes = cachedHarnessJarBytes;
         if (jarBytes == null) {
@@ -376,8 +370,22 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 }
             }
         }
-        List<TransferFile> bootstrapFiles = new ArrayList<>();
-        bootstrapFiles.add(new TransferFile("support_jar", API_HARNESS_JAR, jarBytes, false));
+        Optional<byte[]> startupScript = loadStartupScript();
+        List<TransferFile> bootstrapFiles = buildStartupBootstrapFiles(jarBytes, startupScript);
+        int bootstrapFileCount = bootstrapFiles.size();
+        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId
+                + " needs startup bootstrap — pushing " + bootstrapFileCount + " files"
+                + " customStartAgent=" + startupScript.isPresent()
+                + " chunkBytes=" + DEFAULT_CHUNK_BYTES
+                + " window=" + CHUNK_WINDOW
+                + " maxConnectionMs=" + MAX_BOOTSTRAP_CONNECTION_MS)));
+
+        context.jobId = "bootstrap";
+        context.expectedFiles = bootstrapFileCount;
+        context.bootstrapTransfer = true;
+        fileTransferReady.put(agentId, false);
+        agentWsState.put(agentId, "bootstrap_transferring");
+        agentTransferProgress.put(agentId, "0/" + bootstrapFileCount + " files");
 
         long connectionDeadlineMs = context.openedAtMs + MAX_BOOTSTRAP_CONNECTION_MS;
         boolean sentAllChunks = sendFilesWithBudget(context, agentId, "bootstrap", bootstrapFiles,
@@ -394,13 +402,52 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
 
         context.transferCompleteFuture.get(transferTimeoutMillis, TimeUnit.MILLISECONDS);
-        agentTransferProgress.put(agentId, "1/1 files");
+        agentTransferProgress.put(agentId, bootstrapFileCount + "/" + bootstrapFileCount + " files");
         agentWsState.put(agentId, "bootstrap_sent");
-        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Bootstrap JAR sent to " + agentId + " — waiting for harness to start")));
+        LOG.info(new ObjectMessage(Map.of("Message", "[WS] Startup bootstrap files sent to " + agentId
+                + " — waiting for harness to start")));
         sessions.remove(agentId, context);
         fileTransferReady.remove(agentId);
         context.close();
         return false;
+    }
+
+    private Optional<byte[]> loadStartupScript() throws IOException {
+        Optional<byte[]> startupScript = cachedStartupScript;
+        if (startupScript == null) {
+            synchronized (this) {
+                startupScript = cachedStartupScript;
+                if (startupScript == null) {
+                    FileStorage fileStorage =
+                            FileStorageFactory.getFileStorage(new TankConfig().getJarDir(), false);
+                    startupScript = readStartupScript(fileStorage);
+                    cachedStartupScript = startupScript;
+                }
+            }
+        }
+        return startupScript;
+    }
+
+    static Optional<byte[]> readStartupScript(FileStorage fileStorage) throws IOException {
+        FileData startupScript = new FileData("", START_AGENT_SCRIPT);
+        if (!fileStorage.exists(startupScript)) {
+            LOG.warn(new ObjectMessage(Map.of("Message",
+                    "[WS] Custom startAgent.sh not found in configured JAR storage — using packaged default")));
+            return Optional.empty();
+        }
+        try (InputStream input = fileStorage.readFileData(startupScript)) {
+            return Optional.of(input.readAllBytes());
+        } catch (RuntimeException e) {
+            throw new IOException("Failed reading startAgent.sh from configured JAR storage", e);
+        }
+    }
+
+    static List<TransferFile> buildStartupBootstrapFiles(byte[] jarBytes, Optional<byte[]> startupScript) {
+        List<TransferFile> files = new ArrayList<>();
+        startupScript.ifPresent(content ->
+                files.add(new TransferFile(STARTUP_SCRIPT_FILE_TYPE, START_AGENT_SCRIPT, content, false)));
+        files.add(new TransferFile("support_jar", API_HARNESS_JAR, jarBytes, false));
+        return files;
     }
 
     private File findHarnessJar() {
@@ -950,7 +997,7 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         }
     }
 
-    private record TransferFile(String fileType, String fileName, byte[] content, boolean defaultDataFile) {
+    record TransferFile(String fileType, String fileName, byte[] content, boolean defaultDataFile) {
     }
 
     /**

--- a/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
+++ b/tank_vmManager/src/main/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClient.java
@@ -388,8 +388,21 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         agentTransferProgress.put(agentId, "0/" + bootstrapFileCount + " files");
 
         long connectionDeadlineMs = context.openedAtMs + MAX_BOOTSTRAP_CONNECTION_MS;
-        boolean sentAllChunks = sendFilesWithBudget(context, agentId, "bootstrap", bootstrapFiles,
-                DEFAULT_CHUNK_BYTES, connectionDeadlineMs);
+        boolean sentAllChunks;
+        try {
+            sentAllChunks = sendFilesWithBudget(context, agentId, "bootstrap", bootstrapFiles,
+                    DEFAULT_CHUNK_BYTES, connectionDeadlineMs);
+        } catch (UnsupportedStartupScriptException e) {
+            bootstrapFiles = buildStartupBootstrapFiles(jarBytes, Optional.empty());
+            bootstrapFileCount = bootstrapFiles.size();
+            context.expectedFiles = bootstrapFileCount;
+            context.completedFiles.clear();
+            agentTransferProgress.put(agentId, "0/" + bootstrapFileCount + " files");
+            LOG.warn(new ObjectMessage(Map.of("Message", "[WS] Agent " + agentId
+                    + " does not support startup_script — retrying bootstrap with harness JAR only")));
+            sentAllChunks = sendFilesWithBudget(context, agentId, "bootstrap", bootstrapFiles,
+                    DEFAULT_CHUNK_BYTES, connectionDeadlineMs);
+        }
 
         if (!sentAllChunks) {
             LOG.info(new ObjectMessage(Map.of("Message",
@@ -589,6 +602,9 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
             AgentWsEnvelope offerAck = offerAckFuture.get(10, TimeUnit.SECONDS);
             if (offerAck != null) {
                 if (offerAck.getStatus() == AckStatus.failed) {
+                    if (isLegacyStartupScriptRejection(file, offerAck)) {
+                        throw new UnsupportedStartupScriptException();
+                    }
                     throw new IOException("File offer rejected by agent: " + offerAck.getError());
                 }
                 if (offerAck.getStatus() == AckStatus.resume
@@ -691,6 +707,14 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
                 throw new IOException("Timed out waiting for WS chunk ack for " + instanceId, e);
             }
         }
+    }
+
+    static boolean isLegacyStartupScriptRejection(TransferFile file, AgentWsEnvelope offerAck) {
+        return STARTUP_SCRIPT_FILE_TYPE.equals(file.fileType())
+                && START_AGENT_SCRIPT.equals(file.fileName())
+                && offerAck != null
+                && offerAck.getStatus() == AckStatus.failed
+                && "unsupported_startup_file".equals(offerAck.getError());
     }
 
     private void logFileTransferComplete(String instanceId, TransferFile file, long totalBytes, int totalChunks,
@@ -1071,5 +1095,8 @@ public class ControllerInitiatedAgentWsClient implements AgentWsCommandSender {
         private BootstrapBudgetExceededException(String message) {
             super(message);
         }
+    }
+
+    private static class UnsupportedStartupScriptException extends IOException {
     }
 }

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -10,13 +10,19 @@ import com.intuit.tank.vm.vmManager.VMTracker;
 import com.intuit.tank.vm.vmManager.models.CloudVmStatus;
 import com.intuit.tank.vm.vmManager.models.VMStatus;
 import com.intuit.tank.vm.vmManager.models.ValidationStatus;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -35,6 +44,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ControllerInitiatedAgentWsClientTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void testStartupBootstrapSendsCustomScriptBeforeHarnessJar() {
@@ -75,6 +87,63 @@ public class ControllerInitiatedAgentWsClientTest {
                 harnessJar, unsupported));
         assertFalse(ControllerInitiatedAgentWsClient.isLegacyStartupScriptRejection(
                 startupScript, otherFailure));
+    }
+
+    @Test
+    void testLegacyAgentRejectionRetriesBootstrapWithHarnessJarOnly() throws Exception {
+        ControllerInitiatedAgentWsClient client = new ControllerInitiatedAgentWsClient();
+        Session session = mock(Session.class);
+        Object context = installSession(client, "i-agent", session);
+        List<String> offeredFiles = new ArrayList<>();
+        setField(client, "cachedStartupScript", Optional.of(new byte[] { 1 }));
+
+        Path toolsDir = tempDir.resolve("webapps/ROOT/tools");
+        Files.createDirectories(toolsDir);
+        Files.write(toolsDir.resolve("apiharness-1.0-all.jar"), new byte[] { 2 });
+        String previousCatalinaHome = System.getProperty("catalina.home");
+        System.setProperty("catalina.home", tempDir.toString());
+
+        doAnswer(invocation -> {
+            AgentWsEnvelope offer = AgentWsEnvelope.fromJson(invocation.getArgument(0));
+            Callback callback = invocation.getArgument(1);
+            callback.succeed();
+            if (offer.getType() == AgentWsEnvelope.Type.file_offer) {
+                offeredFiles.add(offer.getFileName());
+                AgentWsEnvelope.AckStatus status = "startAgent.sh".equals(offer.getFileName())
+                        ? AgentWsEnvelope.AckStatus.failed
+                        : AgentWsEnvelope.AckStatus.ok;
+                String error = status == AgentWsEnvelope.AckStatus.failed
+                        ? "unsupported_startup_file"
+                        : null;
+                invokeHandleText(client, "i-agent", session, AgentWsEnvelope.fileAck(
+                        "i-agent", "bootstrap", offer.getFileId(), null, status, error));
+            }
+            return null;
+        }).when(session).sendText(anyString(), any(Callback.class));
+        doAnswer(invocation -> {
+            AgentWsEnvelope.BinaryFileChunk chunk =
+                    AgentWsEnvelope.fromBinaryFileChunk(((ByteBuffer) invocation.getArgument(0)).duplicate());
+            Callback callback = invocation.getArgument(1);
+            callback.succeed();
+            invokeHandleText(client, "i-agent", session, AgentWsEnvelope.fileAck(
+                    "i-agent", "bootstrap", chunk.fileId(), chunk.chunkIndex(),
+                    AgentWsEnvelope.AckStatus.complete, null));
+            return null;
+        }).when(session).sendBinary(any(ByteBuffer.class), any(Callback.class));
+
+        try {
+            boolean result = invokePushStartupBootstrap(client, context);
+
+            assertFalse(result);
+            assertEquals(List.of("startAgent.sh", "apiharness-1.0-all.jar"), offeredFiles);
+            assertEquals("1/1 files", client.getTransferProgress("i-agent"));
+        } finally {
+            if (previousCatalinaHome == null) {
+                System.clearProperty("catalina.home");
+            } else {
+                System.setProperty("catalina.home", previousCatalinaHome);
+            }
+        }
     }
 
     @Test
@@ -203,10 +272,23 @@ public class ControllerInitiatedAgentWsClientTest {
 
     private void invokeHandleText(ControllerInitiatedAgentWsClient client, String instanceId,
                                   AgentWsEnvelope envelope) throws Exception {
+        invokeHandleText(client, instanceId, null, envelope);
+    }
+
+    private void invokeHandleText(ControllerInitiatedAgentWsClient client, String instanceId,
+                                  Session session, AgentWsEnvelope envelope) throws Exception {
         Method method = ControllerInitiatedAgentWsClient.class.getDeclaredMethod(
                 "handleText", String.class, Session.class, String.class, CompletableFuture.class);
         method.setAccessible(true);
-        method.invoke(client, instanceId, null, envelope.toJson(), new CompletableFuture<AgentWsEnvelope>());
+        method.invoke(client, instanceId, session, envelope.toJson(), new CompletableFuture<AgentWsEnvelope>());
+    }
+
+    private boolean invokePushStartupBootstrap(
+            ControllerInitiatedAgentWsClient client, Object sessionContext) throws Exception {
+        Method method = ControllerInitiatedAgentWsClient.class.getDeclaredMethod(
+                "pushStartupBootstrapJar", String.class, sessionContext.getClass(), long.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(client, "i-agent", sessionContext, 1_000L);
     }
 
     private void invokeOnClosed(ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {
@@ -217,7 +299,8 @@ public class ControllerInitiatedAgentWsClientTest {
     }
 
     @SuppressWarnings("unchecked")
-    private void installSession(ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {
+    private Object installSession(
+            ControllerInitiatedAgentWsClient client, String instanceId, Session session) throws Exception {
         Class<?> sessionContextClass = Class.forName(
                 "com.intuit.tank.perfManager.workLoads.ControllerInitiatedAgentWsClient$SessionContext");
         Class<?> endpointClass = Class.forName(
@@ -238,6 +321,13 @@ public class ControllerInitiatedAgentWsClientTest {
         ConcurrentHashMap<String, Object> sessions =
                 (ConcurrentHashMap<String, Object>) sessionsField.get(client);
         sessions.put(instanceId, sessionContext);
+        return sessionContext;
+    }
+
+    private void setField(ControllerInitiatedAgentWsClient client, String name, Object value) throws Exception {
+        Field field = ControllerInitiatedAgentWsClient.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(client, value);
     }
 
     private CloudVmStatus createStatus(String instanceId, JobStatus jobStatus, VMStatus vmStatus) {

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -51,6 +52,29 @@ public class ControllerInitiatedAgentWsClientTest {
         assertEquals("support_jar", files.get(1).fileType());
         assertEquals("apiharness-1.0-all.jar", files.get(1).fileName());
         assertArrayEquals(harnessJar, files.get(1).content());
+    }
+
+    @Test
+    void testLegacyAgentRejectionTriggersFallbackOnlyForStartupScript() {
+        ControllerInitiatedAgentWsClient.TransferFile startupScript =
+                new ControllerInitiatedAgentWsClient.TransferFile(
+                        "startup_script", "startAgent.sh", new byte[] { 1 }, false);
+        ControllerInitiatedAgentWsClient.TransferFile harnessJar =
+                new ControllerInitiatedAgentWsClient.TransferFile(
+                        "support_jar", "apiharness-1.0-all.jar", new byte[] { 2 }, false);
+        AgentWsEnvelope unsupported = AgentWsEnvelope.fileAck(
+                "i-agent", "bootstrap", "file-id", null,
+                AgentWsEnvelope.AckStatus.failed, "unsupported_startup_file");
+        AgentWsEnvelope otherFailure = AgentWsEnvelope.fileAck(
+                "i-agent", "bootstrap", "file-id", null,
+                AgentWsEnvelope.AckStatus.failed, "disk_full");
+
+        assertTrue(ControllerInitiatedAgentWsClient.isLegacyStartupScriptRejection(
+                startupScript, unsupported));
+        assertFalse(ControllerInitiatedAgentWsClient.isLegacyStartupScriptRejection(
+                harnessJar, unsupported));
+        assertFalse(ControllerInitiatedAgentWsClient.isLegacyStartupScriptRejection(
+                startupScript, otherFailure));
     }
 
     @Test

--- a/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
+++ b/tank_vmManager/src/test/java/com/intuit/tank/perfManager/workLoads/ControllerInitiatedAgentWsClientTest.java
@@ -1,5 +1,6 @@
 package com.intuit.tank.perfManager.workLoads;
 
+import com.intuit.tank.storage.FileStorage;
 import com.intuit.tank.vm.agent.messages.AgentWsEnvelope;
 import com.intuit.tank.vm.api.enumerated.JobStatus;
 import com.intuit.tank.vm.api.enumerated.VMImageType;
@@ -12,21 +13,72 @@ import com.intuit.tank.vm.vmManager.models.ValidationStatus;
 import org.eclipse.jetty.websocket.api.Session;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ControllerInitiatedAgentWsClientTest {
+
+    @Test
+    void testStartupBootstrapSendsCustomScriptBeforeHarnessJar() {
+        byte[] startupScript = "#!/bin/sh\necho custom\n".getBytes();
+        byte[] harnessJar = new byte[] { 1, 2, 3 };
+
+        List<ControllerInitiatedAgentWsClient.TransferFile> files =
+                ControllerInitiatedAgentWsClient.buildStartupBootstrapFiles(
+                        harnessJar, Optional.of(startupScript));
+
+        assertEquals(2, files.size());
+        assertEquals("startup_script", files.get(0).fileType());
+        assertEquals("startAgent.sh", files.get(0).fileName());
+        assertArrayEquals(startupScript, files.get(0).content());
+        assertEquals("support_jar", files.get(1).fileType());
+        assertEquals("apiharness-1.0-all.jar", files.get(1).fileName());
+        assertArrayEquals(harnessJar, files.get(1).content());
+    }
+
+    @Test
+    void testStartupBootstrapUsesPackagedScriptWhenCustomScriptIsMissing() {
+        byte[] harnessJar = new byte[] { 1, 2, 3 };
+
+        List<ControllerInitiatedAgentWsClient.TransferFile> files =
+                ControllerInitiatedAgentWsClient.buildStartupBootstrapFiles(
+                        harnessJar, Optional.empty());
+
+        assertEquals(1, files.size());
+        assertEquals("support_jar", files.get(0).fileType());
+        assertEquals("apiharness-1.0-all.jar", files.get(0).fileName());
+    }
+
+    @Test
+    void testStartupScriptIsReadFromConfiguredFileStorage() throws Exception {
+        byte[] startupScript = "#!/bin/sh\necho configured\n".getBytes();
+        FileStorage fileStorage = mock(FileStorage.class);
+        when(fileStorage.exists(argThat(file -> "startAgent.sh".equals(file.getFileName())))).thenReturn(true);
+        when(fileStorage.readFileData(argThat(file -> "startAgent.sh".equals(file.getFileName()))))
+                .thenReturn(new ByteArrayInputStream(startupScript));
+
+        Optional<byte[]> result = ControllerInitiatedAgentWsClient.readStartupScript(fileStorage);
+
+        assertTrue(result.isPresent());
+        assertArrayEquals(startupScript, result.orElseThrow());
+    }
 
     @Test
     void testTerminalStatusSchedulesTerminationAndUpdatesTracker() throws Exception {


### PR DESCRIPTION
## Summary

- Deliver the controller’s custom `startAgent.sh` to agents during WebSocket bootstrap.
- Write the script atomically and preserve executable permissions.
- Keep the packaged script when no custom script exists.
- Retry with the harness JAR only when bootstrapping legacy agents.
- Allow harness transfer retries after startup-script failures.
- Add controller and agent regression coverage.

## Validation

- 2,095 tests passed with no failures.
- Validated end-to-end using QA in EAST and WEST.
- Confirmed WebSocket transfer logs, matching script checksums, `755` permissions, and successful harness startup.

Please make sure these check boxes are checked before submitting
- [ ] ** Squashed Commits **
- [ ] ** All Tests Passed ** - ```mvn clean test -P default``` 

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.