### PR TITLE
[SRE-39090] Preserve nonlinear workload selection during job creation

### DIFF
--- a/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
+++ b/data_model/src/main/java/com/intuit/tank/project/BaseJob.java
@@ -125,7 +125,7 @@ public abstract class BaseJob extends BaseEntity {
      */
     public BaseJob(BaseJob copy) {
         this.baselineVirtualUsers = copy.baselineVirtualUsers;
-        this.incrementStrategy = copy.incrementStrategy;
+        this.incrementStrategy = copy.getIncrementStrategy();
         this.rampTime = copy.rampTime;
         this.simulationTime = copy.simulationTime;
         this.terminationPolicy = copy.terminationPolicy;

--- a/data_model/src/test/java/com/intuit/tank/project/JobInstanceTest.java
+++ b/data_model/src/test/java/com/intuit/tank/project/JobInstanceTest.java
@@ -30,6 +30,7 @@ import com.intuit.tank.project.JobConfiguration;
 import com.intuit.tank.project.JobInstance;
 import com.intuit.tank.project.JobVMInstance;
 import com.intuit.tank.project.Workload;
+import com.intuit.tank.vm.api.enumerated.IncrementStrategy;
 import com.intuit.tank.vm.api.enumerated.JobQueueStatus;
 
 /**
@@ -64,6 +65,26 @@ public class JobInstanceTest {
     public void testJobInstance_2() {
         JobInstance result = new JobInstance(Workload.builder().build(), "");
         assertNotNull(result);
+    }
+
+    @Test
+    public void testJobInstanceCopiesNonlinearStrategyFromProxyGetter() {
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new ProxyJobConfiguration(IncrementStrategy.standard));
+
+        JobInstance result = new JobInstance(workload, "nonlinear");
+
+        assertEquals(IncrementStrategy.standard, result.getIncrementStrategy());
+    }
+
+    @Test
+    public void testJobInstanceCopiesLinearStrategyFromProxyGetter() {
+        Workload workload = new Workload();
+        workload.setJobConfiguration(new ProxyJobConfiguration(IncrementStrategy.increasing));
+
+        JobInstance result = new JobInstance(workload, "linear");
+
+        assertEquals(IncrementStrategy.increasing, result.getIncrementStrategy());
     }
 
     /**
@@ -1047,5 +1068,20 @@ public class JobInstanceTest {
 
         String result = fixture.toString();
         assertNotNull(result);
+    }
+
+    private static final class ProxyJobConfiguration extends JobConfiguration {
+        private static final long serialVersionUID = 1L;
+
+        private final IncrementStrategy loadedStrategy;
+
+        private ProxyJobConfiguration(IncrementStrategy loadedStrategy) {
+            this.loadedStrategy = loadedStrategy;
+        }
+
+        @Override
+        public IncrementStrategy getIncrementStrategy() {
+            return loadedStrategy;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Preserve the selected workload strategy when creating a job.
- Use the Hibernate proxy getter instead of direct field access.
- Add regression coverage for Linear and Nonlinear strategies.

## Root cause
`JobConfiguration` is lazily loaded as a Hibernate proxy. The `BaseJob` copy constructor accessed `incrementStrategy` directly, bypassing proxy interception and copying its default value (`increasing`/Linear).

## Impact
Users can now create Nonlinear jobs with the configured ramp behavior intact.

JIRA: https://jira.cloud.intuit.com/browse/SRE-39090


## Testing
- [x] JobInstance regression tests pass
- [x] Created a Linear job through the local UI
- [x] Created a Nonlinear job through the local UI
- [x] Verified both selections persist correctly