### PR TITLE
Add load test flow system tests

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,11 +10,12 @@ phases:
   install:
     runtime-versions:
       java: corretto25
+    commands:
+      - yum install -y atk at-spi2-atk cups-libs libdrm libXcomposite libXdamage libXrandr libgbm libxkbcommon pango alsa-lib nss nspr || true
   build:
     commands:
       - java -version
       - export WATS_PROPERTIES="$CODEBUILD_SRC_DIR/api/src/main/resources"
-      # Run the complete build with both unit and integration tests
       - mvn clean install surefire-report:report -P release
       - export PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
       - |
@@ -47,3 +48,5 @@ artifacts:
 cache:
   paths:
     - '/root/.m2/**/*'
+    - '/root/.cache/ms-playwright/**/*'
+    - '/root/.cache/tank-system-tests/**/*'

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <module>data_access</module>
         <module>tank_vmManager</module>
         <module>web</module>
+        <module>system_tests</module>
       </modules>
     </profile>
 
@@ -248,6 +249,30 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>system-integration</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>agent</module>
+        <module>tools</module>
+        <module>rest-mvc</module>
+        <module>tank_common</module>
+        <module>proxy-parent</module>
+        <module>script_processor</module>
+        <module>harness_data</module>
+        <module>reporting</module>
+        <module>test_support</module>
+        <module>api</module>
+        <module>data_model</module>
+        <module>data_access</module>
+        <module>tank_vmManager</module>
+        <module>web</module>
+        <module>system_tests</module>
+      </modules>
     </profile>
 
     <profile>

--- a/system_tests/pom.xml
+++ b/system_tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.intuit.tank</groupId>
     <artifactId>tank-parent</artifactId>
-    <version>4.3.9-SNAPSHOT</version>
+    <version>4.3.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>tank-system-tests</artifactId>

--- a/system_tests/pom.xml
+++ b/system_tests/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.intuit.tank</groupId>
+    <artifactId>tank-parent</artifactId>
+    <version>4.3.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tank-system-tests</artifactId>
+  <packaging>jar</packaging>
+  <name>Tank System Tests</name>
+  <description>Self-contained system tests for job creation against the packaged WAR</description>
+
+  <properties>
+    <version.playwright>1.50.0</version.playwright>
+    <checkstyle.skip>true</checkstyle.skip>
+    <tank.ui.headless>true</tank.ui.headless>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tank</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-catalina</artifactId>
+      <version>${version.tomcat}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jasper</artifactId>
+      <version>${version.tomcat}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>${version.tomcat}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>${version.playwright}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <executions>
+          <execution>
+            <id>install-playwright-chromium</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>com.microsoft.playwright.CLI</mainClass>
+              <classpathScope>test</classpathScope>
+              <blockSystemExit>true</blockSystemExit>
+              <arguments>
+                <argument>install</argument>
+                <argument>chromium</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.surefire}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.jboss.weld:weld-junit5</classpathDependencyExclude>
+            <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
+            <classpathDependencyExclude>org.jboss.weld.servlet:weld-servlet-core</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+          <systemPropertyVariables>
+            <project.version>${project.version}</project.version>
+            <tank.embedded.websocket.jar>${settings.localRepository}/org/apache/tomcat/embed/tomcat-embed-websocket/${version.tomcat}/tomcat-embed-websocket-${version.tomcat}.jar</tank.embedded.websocket.jar>
+            <tank.ui.headless>${tank.ui.headless}</tank.ui.headless>
+          </systemPropertyVariables>
+          <trimStackTrace>false</trimStackTrace>
+          <redirectTestOutputToFile>false</redirectTestOutputToFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/system_tests/pom.xml
+++ b/system_tests/pom.xml
@@ -156,6 +156,9 @@
             <tank.embedded.websocket.jar>${settings.localRepository}/org/apache/tomcat/embed/tomcat-embed-websocket/${version.tomcat}/tomcat-embed-websocket-${version.tomcat}.jar</tank.embedded.websocket.jar>
             <tank.ui.headless>${tank.ui.headless}</tank.ui.headless>
           </systemPropertyVariables>
+          <environmentVariables>
+            <WATS_PROPERTIES>${project.build.directory}/system-test-runtime/settings</WATS_PROPERTIES>
+          </environmentVariables>
           <trimStackTrace>false</trimStackTrace>
           <redirectTestOutputToFile>false</redirectTestOutputToFile>
         </configuration>

--- a/system_tests/src/test/java/com/intuit/tank/integration/JobCreationContract.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/JobCreationContract.java
@@ -1,0 +1,103 @@
+package com.intuit.tank.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Canonical job-creation request payloads used by the system tests.
+ */
+public final class JobCreationContract {
+
+    static final int INCREASING_CONFIGURED_USERS = 2800;
+    static final String STANDARD_TARGET_RAMP_RATE = "0.382";
+    static final String STANDARD_TARGET_RATE_PER_AGENT = "0.211";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JobCreationContract() {
+    }
+
+    enum Profile {
+        INCREASING("contracts/increasing-job.json"),
+        STANDARD("contracts/standard-job.json");
+
+        private final String resourcePath;
+
+        Profile(String resourcePath) {
+            this.resourcePath = resourcePath;
+        }
+    }
+
+    static String buildRequestJson(Profile profile, int projectId, String jobInstanceName)
+            throws IOException {
+        String template = loadResource(profile.resourcePath);
+        return template
+                .replace("${projectId}", Integer.toString(projectId))
+                .replace("${jobInstanceName}", jobInstanceName);
+    }
+
+    static JsonNode parseRequest(String requestJson) throws IOException {
+        return MAPPER.readTree(requestJson);
+    }
+
+    static void assertMatchesContract(String actualRequestJson, Profile profile,
+                                      int projectId, String jobInstanceName) throws IOException {
+        JsonNode expected = parseRequest(buildRequestJson(profile, projectId, jobInstanceName));
+        JsonNode actual = parseRequest(actualRequestJson);
+        assertJsonEquals(expected, actual, "");
+    }
+
+    private static void assertJsonEquals(JsonNode expected, JsonNode actual, String path)
+            throws IOException {
+        if (expected.equals(actual)) {
+            return;
+        }
+        if (expected.isObject() && actual.isObject()) {
+            ObjectNode expectedObject = (ObjectNode) expected;
+            expectedObject.fieldNames().forEachRemaining(field -> {
+                String childPath = path.isEmpty() ? field : path + "." + field;
+                if (!actual.has(field)) {
+                    throw new AssertionError("Missing field " + childPath);
+                }
+                try {
+                    assertJsonEquals(expected.get(field), actual.get(field), childPath);
+                } catch (IOException e) {
+                    throw new AssertionError("Failed comparing " + childPath, e);
+                }
+            });
+            actual.fieldNames().forEachRemaining(field -> {
+                if (!expected.has(field)) {
+                    throw new AssertionError("Unexpected field " + path + "." + field);
+                }
+            });
+            return;
+        }
+        if (expected.isArray() && actual.isArray()) {
+            if (expected.size() != actual.size()) {
+                throw new AssertionError("Array size mismatch at " + path + ": expected "
+                        + expected.size() + " got " + actual.size());
+            }
+            for (int i = 0; i < expected.size(); i++) {
+                assertJsonEquals(expected.get(i), actual.get(i), path + "[" + i + "]");
+            }
+            return;
+        }
+        throw new AssertionError("JSON mismatch at " + path + ": expected "
+                + expected + " got " + actual);
+    }
+
+    private static String loadResource(String classpathPath) throws IOException {
+        try (InputStream in = JobCreationContract.class.getClassLoader()
+                .getResourceAsStream(classpathPath)) {
+            if (in == null) {
+                throw new IOException("Missing classpath resource: " + classpathPath);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/system_tests/src/test/java/com/intuit/tank/integration/JobCreationIT.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/JobCreationIT.java
@@ -1,0 +1,183 @@
+package com.intuit.tank.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates two job-creation configurations against the packaged WAR.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class JobCreationIT {
+
+    static {
+        try {
+            TankIntegrationEnvironment.installSettingsRoot();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static final String UI_USER = "admin";
+    private static final String UI_PASSWORD = "adminadmin";
+    private static final String BUILD_USER = "system-test";
+    private static final List<String> SCRIPT_ROLES = List.of(
+            "setup", "new-user", "transition", "return-user", "cleanup");
+
+    private TankIntegrationEnvironment env;
+    private TankApiClient api;
+    private TankUiBrowser uiBrowser;
+    private final List<Integer> scriptIdsToDelete = new ArrayList<>();
+    private final List<Integer> projectIdsToDelete = new ArrayList<>();
+    private Path artifactDir;
+
+    @BeforeAll
+    void startEnvironment() {
+        env = TankIntegrationEnvironment.start();
+        api = new TankApiClient(env);
+        uiBrowser = new TankUiBrowser(env.baseUrl(), UI_USER, UI_PASSWORD);
+        artifactDir = Path.of("target", "playwright-artifacts");
+        try {
+            Files.createDirectories(artifactDir);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to create Playwright artifact directory", e);
+        }
+    }
+
+    @AfterEach
+    void cleanupScenario() {
+        if (api != null) {
+            for (int i = projectIdsToDelete.size() - 1; i >= 0; i--) {
+                api.deleteProject(projectIdsToDelete.get(i));
+            }
+            projectIdsToDelete.clear();
+            for (int i = scriptIdsToDelete.size() - 1; i >= 0; i--) {
+                api.deleteScript(scriptIdsToDelete.get(i));
+            }
+            scriptIdsToDelete.clear();
+        }
+    }
+
+    @AfterAll
+    void stopEnvironment() {
+        if (uiBrowser != null) {
+            uiBrowser.close();
+        }
+        if (env != null) {
+            env.close();
+        }
+    }
+
+    @Test
+    @Tag("system-integration")
+    void createIncreasingJob_persistsCreatedState_andShowsInUi() throws Exception {
+        try {
+            Scenario scenario = createScenario("increasing");
+            String jobName = "system_test_job_" + BUILD_USER + "_"
+                    + Instant.now().toEpochMilli();
+            TankApiClient.CreatedJob created = api.createJobFromContract(
+                    JobCreationContract.Profile.INCREASING, scenario.projectId(), jobName);
+            JsonNode job = assertCreatedJob(created, jobName);
+            assertEquals(JobCreationContract.INCREASING_CONFIGURED_USERS, job.get("numUsers").asInt(),
+                    "Configured users must match the increasing profile");
+
+            TankApiClient.PersistedJobConfiguration config =
+                    api.queryJobConfiguration(created.jobId());
+            assertEquals("increasing", config.workloadType(),
+                    "Persisted workload_type must remain increasing");
+            assertEquals(0, api.getVmStatusCount(created.jobId()),
+                    "Create-only flow must not launch agent VMs");
+
+            confirmJobInUi(created.jobId(), scenario.projectName(), jobName, "Created",
+                    String.valueOf(JobCreationContract.INCREASING_CONFIGURED_USERS));
+        } catch (Throwable failure) {
+            env.retainLogsOnFailure(failure);
+            throw failure;
+        }
+    }
+
+    @Test
+    @Tag("system-integration")
+    void createStandardJob_persistsRates_andShowsInUi() throws Exception {
+        try {
+            Scenario scenario = createScenario("standard");
+            String jobName = "system_test_job_" + BUILD_USER + "_"
+                    + Instant.now().toEpochMilli();
+            TankApiClient.CreatedJob created = api.createJobFromContract(
+                    JobCreationContract.Profile.STANDARD, scenario.projectId(), jobName);
+            assertCreatedJob(created, jobName);
+
+            TankApiClient.PersistedJobConfiguration config =
+                    api.queryJobConfiguration(created.jobId());
+            assertEquals("standard", config.workloadType(),
+                    "Persisted workload_type must remain standard");
+            assertEquals(Double.parseDouble(JobCreationContract.STANDARD_TARGET_RAMP_RATE),
+                    config.targetRampRate(), 0.001,
+                    "Target ramp rate must match the standard profile");
+            assertEquals(Double.parseDouble(JobCreationContract.STANDARD_TARGET_RATE_PER_AGENT),
+                    config.targetRatePerAgent(), 0.001,
+                    "Target rate per agent must match the standard profile");
+            assertEquals(0, api.getVmStatusCount(created.jobId()),
+                    "Create-only flow must not launch agent VMs");
+
+            confirmJobInUi(created.jobId(), scenario.projectName(), jobName, "Created", null);
+        } catch (Throwable failure) {
+            env.retainLogsOnFailure(failure);
+            throw failure;
+        }
+    }
+
+    private Scenario createScenario(String profileLabel) throws Exception {
+        String suffix = Instant.now().toEpochMilli() + "-"
+                + UUID.randomUUID().toString().substring(0, 8);
+        List<Integer> scenarioScriptIds = new ArrayList<>();
+        for (String role : SCRIPT_ROLES) {
+            int scriptId = api.uploadScript(
+                    "it-" + profileLabel + "-" + role + "-" + suffix);
+            scenarioScriptIds.add(scriptId);
+            scriptIdsToDelete.add(scriptId);
+        }
+
+        String projectName = "it-" + profileLabel + "-project-" + suffix;
+        int projectId = api.createProject(projectName, scenarioScriptIds);
+        projectIdsToDelete.add(projectId);
+        assertEquals(scenarioScriptIds, api.getProjectScriptIds(projectId),
+                "Project must preserve all five automation-style scripts in order");
+        return new Scenario(suffix, projectName, projectId);
+    }
+
+    private JsonNode assertCreatedJob(TankApiClient.CreatedJob created, String jobName)
+            throws Exception {
+        assertEquals("created", created.createStatus().toLowerCase());
+        assertTrue(created.jobId() > 0, "JobId should be positive");
+
+        JsonNode job = api.getJob(created.jobId());
+        assertEquals(created.jobId(), job.get("id").asInt());
+        assertEquals(jobName, job.get("name").asText());
+        assertEquals("Created", job.get("status").asText());
+        return job;
+    }
+
+    private void confirmJobInUi(int jobId, String projectName, String expectedName,
+                                String expectedStatus, String expectedUsers) {
+        uiBrowser.confirmJobInQueue(artifactDir, jobId, projectName, expectedName,
+                expectedStatus, expectedUsers);
+    }
+
+    private record Scenario(String suffix, String projectName, int projectId) {}
+}

--- a/system_tests/src/test/java/com/intuit/tank/integration/JobCreationIT.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/JobCreationIT.java
@@ -34,7 +34,7 @@ public class JobCreationIT {
     }
 
     private static final String UI_USER = "admin";
-    private static final String UI_PASSWORD = "adminadmin";
+    private static final String UI_PASSWORD = "admin";
     private static final String BUILD_USER = "system-test";
     private static final List<String> SCRIPT_ROLES = List.of(
             "setup", "new-user", "transition", "return-user", "cleanup");

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankApiClient.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankApiClient.java
@@ -1,0 +1,289 @@
+package com.intuit.tank.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * REST helper for job creation against the embedded Tank runtime.
+ */
+public final class TankApiClient {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final TankIntegrationEnvironment env;
+
+    public TankApiClient(TankIntegrationEnvironment env) {
+        this.env = env;
+    }
+
+    public int uploadScript(String scriptName) throws Exception {
+        byte[] xml = loadFixture("fixtures/Minimal_TS.xml");
+        String xmlText = new String(xml, StandardCharsets.UTF_8)
+                .replace("<name>IT Minimal Script</name>", "<name>" + scriptName + "</name>");
+        xml = xmlText.getBytes(StandardCharsets.UTF_8);
+
+        String boundary = "----TankBoundary" + UUID.randomUUID().toString().replace("-", "");
+        byte[] body = multipartBody(boundary, "file", scriptName + ".xml", "application/xml", xml);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(env.baseUrl() + "/v2/scripts"))
+                .timeout(Duration.ofSeconds(60))
+                .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        HttpResponse<String> response = env.httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 201) {
+            throw new IllegalStateException("Script upload failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+        JsonNode node = MAPPER.readTree(response.body());
+        if (node.has("scriptId")) {
+            return Integer.parseInt(node.get("scriptId").asText());
+        }
+        if (node.has("message")) {
+            String message = node.get("message").asText();
+            java.util.regex.Matcher matcher = java.util.regex.Pattern
+                    .compile("script ID\\s+(\\d+)", java.util.regex.Pattern.CASE_INSENSITIVE)
+                    .matcher(message);
+            if (matcher.find()) {
+                return Integer.parseInt(matcher.group(1));
+            }
+        }
+        throw new IllegalStateException("Could not parse scriptId from: " + response.body());
+    }
+
+    public int createProject(String projectName, List<Integer> scriptIds) throws Exception {
+        if (scriptIds.isEmpty()) {
+            throw new IllegalArgumentException("Project requires at least one script");
+        }
+        StringBuilder scripts = new StringBuilder();
+        for (int position = 0; position < scriptIds.size(); position++) {
+            if (!scripts.isEmpty()) {
+                scripts.append(",\n");
+            }
+            scripts.append("""
+                    {
+                      "scriptId": %d,
+                      "loop": 1,
+                      "position": %d
+                    }
+                    """.formatted(scriptIds.get(position), position));
+        }
+
+        String body = """
+                {
+                  "name": "%s",
+                  "productName": "System Test Project",
+                  "comments": "Created by JobCreationIT",
+                  "rampTime": "2m",
+                  "simulationTime": "5m",
+                  "userIntervalIncrement": 1,
+                  "location": "unspecified",
+                  "stopBehavior": "END_OF_SCRIPT_GROUP",
+                  "workloadType": "increasing",
+                  "terminationPolicy": "script",
+                  "jobRegions": [
+                    {
+                      "region": "US_EAST_2",
+                      "users": "2",
+                      "percentage": "100"
+                    }
+                  ],
+                  "testPlans": [
+                    {
+                      "name": "Main",
+                      "userPercentage": 100,
+                      "scriptGroups": [
+                        {
+                          "name": "Main Group",
+                          "loop": 1,
+                          "scripts": [
+                            %s
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """.formatted(projectName, scripts);
+
+        HttpResponse<String> response = env.postJson("/v2/projects", body);
+        if (response.statusCode() != 201) {
+            throw new IllegalStateException("Project create failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+        JsonNode node = MAPPER.readTree(response.body());
+        if (node.has("ProjectId")) {
+            return Integer.parseInt(node.get("ProjectId").asText());
+        }
+        if (node.has("projectId")) {
+            return Integer.parseInt(node.get("projectId").asText());
+        }
+        if (node.has("id")) {
+            return node.get("id").asInt();
+        }
+        throw new IllegalStateException("Could not parse project id from: " + response.body());
+    }
+
+    public List<Integer> getProjectScriptIds(int projectId) throws Exception {
+        HttpResponse<String> response = env.get("/v2/projects/" + projectId);
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Get project failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+
+        List<Integer> scriptIds = new ArrayList<>();
+        JsonNode project = MAPPER.readTree(response.body());
+        project.path("testPlans").forEach(testPlan ->
+                testPlan.path("scriptGroups").forEach(scriptGroup ->
+                        scriptGroup.path("scripts").forEach(script ->
+                                scriptIds.add(script.path("scriptId").asInt()))));
+        return scriptIds;
+    }
+
+    public CreatedJob createJobFromContract(JobCreationContract.Profile profile,
+                                            int projectId,
+                                            String jobName) throws Exception {
+        String body = JobCreationContract.buildRequestJson(profile, projectId, jobName);
+        JobCreationContract.assertMatchesContract(body, profile, projectId, jobName);
+        return createJob(body, profile);
+    }
+
+    private CreatedJob createJob(String body, JobCreationContract.Profile profile) throws Exception {
+        HttpResponse<String> response = env.postJson("/v2/jobs", body);
+        if (response.statusCode() != 201) {
+            throw new IllegalStateException("Job create failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+        JsonNode node = MAPPER.readTree(response.body());
+        int jobId = Integer.parseInt(node.get("JobId").asText());
+        String status = node.get("status").asText();
+        return new CreatedJob(jobId, status, body, profile);
+    }
+
+    public JsonNode getJob(int jobId) throws Exception {
+        HttpResponse<String> response = env.get("/v2/jobs/" + jobId);
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Get job failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+        return MAPPER.readTree(response.body());
+    }
+
+    public int getVmStatusCount(int jobId) throws Exception {
+        HttpResponse<String> response = env.get("/v2/jobs/instance-status/" + jobId);
+        if (response.statusCode() == 404) {
+            return 0;
+        }
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Get instance-status failed: HTTP " + response.statusCode()
+                    + " body=" + response.body());
+        }
+        JsonNode node = MAPPER.readTree(response.body());
+        if (node.has("statuses") && node.get("statuses").isArray()) {
+            return node.get("statuses").size();
+        }
+        if (node.has("statuses") && node.get("statuses").isObject()) {
+            return node.get("statuses").size();
+        }
+        return 0;
+    }
+
+    public PersistedJobConfiguration queryJobConfiguration(int jobId) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                env.jdbcUrl(), env.jdbcUser(), env.jdbcPassword());
+             PreparedStatement statement = connection.prepareStatement(
+                     """
+                     SELECT jc.workload_type, jc.target_rate, jc.target_rate_per_agent
+                     FROM job_instance ji
+                     INNER JOIN workload w ON ji.workload_id = w.id
+                     INNER JOIN job_configuration jc ON w.job_configuration_id = jc.id
+                     WHERE ji.id = ?
+                     """)) {
+            statement.setInt(1, jobId);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException("No job_instance row for id=" + jobId);
+                }
+                return new PersistedJobConfiguration(
+                        rs.getString("workload_type"),
+                        rs.getDouble("target_rate"),
+                        rs.getDouble("target_rate_per_agent"));
+            }
+        }
+    }
+
+    public void deleteProject(int projectId) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(env.baseUrl() + "/v2/projects/" + projectId))
+                    .timeout(Duration.ofSeconds(30))
+                    .DELETE()
+                    .build();
+            env.httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    public void deleteScript(int scriptId) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(env.baseUrl() + "/v2/scripts/" + scriptId))
+                    .timeout(Duration.ofSeconds(30))
+                    .DELETE()
+                    .build();
+            env.httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    private static byte[] loadFixture(String classpathPath) throws IOException {
+        try (InputStream in = TankApiClient.class.getClassLoader().getResourceAsStream(classpathPath)) {
+            if (in == null) {
+                throw new IOException("Missing classpath resource: " + classpathPath);
+            }
+            return in.readAllBytes();
+        }
+    }
+
+    private static byte[] multipartBody(String boundary, String fieldName, String filename,
+                                        String contentType, byte[] fileBytes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        String preamble = "--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + filename + "\"\r\n"
+                + "Content-Type: " + contentType + "\r\n\r\n";
+        out.write(preamble.getBytes(StandardCharsets.UTF_8));
+        out.write(fileBytes);
+        out.write(("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
+        return out.toByteArray();
+    }
+
+    public record CreatedJob(int jobId,
+                             String createStatus,
+                             String requestBody,
+                             JobCreationContract.Profile profile) {}
+
+    public record PersistedJobConfiguration(String workloadType,
+                                            double targetRampRate,
+                                            double targetRatePerAgent) {}
+}

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankIntegrationEnvironment.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankIntegrationEnvironment.java
@@ -17,10 +17,13 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
 
@@ -108,13 +111,17 @@ public final class TankIntegrationEnvironment implements AutoCloseable {
             waitForSchema();
             LOG.info("Embedded Tank ready at {} (jdbc={})", baseUrl, jdbcUrl);
         } catch (Exception e) {
+            try {
+                close();
+            } catch (RuntimeException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
             throw new IllegalStateException("Failed to start embedded Tank runtime", e);
         }
     }
 
     private Path resolveExplodedWar(Path warFile) throws IOException, InterruptedException {
-        String cacheKey = Files.getLastModifiedTime(warFile).toMillis()
-                + "-" + Files.size(warFile);
+        String cacheKey = warCacheKey(warFile);
         Path globalCache = Path.of(System.getProperty("user.home"), ".cache", "tank-system-tests",
                 "exploded-war", cacheKey);
         Path workExploded = workDir.resolve("exploded-war");
@@ -140,6 +147,22 @@ public final class TankIntegrationEnvironment implements AutoCloseable {
         cloneDirectory(globalCache, workExploded);
         Files.writeString(workStamp, cacheKey);
         return workExploded;
+    }
+
+    private static String warCacheKey(Path warFile) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(warFile)) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = input.read(buffer)) != -1) {
+                    digest.update(buffer, 0, bytesRead);
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
     }
 
     private static void cloneDirectory(Path source, Path destination) throws IOException, InterruptedException {
@@ -258,22 +281,7 @@ public final class TankIntegrationEnvironment implements AutoCloseable {
                 return jar;
             }
         }
-        Path copiedJar = Path.of("target", "embedded-lib", "tomcat-embed-websocket.jar")
-                .toAbsolutePath();
-        if (Files.isRegularFile(copiedJar)) {
-            return copiedJar;
-        }
-        for (String version : List.of("11.0.2", "11.0.24", "10.1.43", "10.1.41")) {
-            Path localJar = Path.of(System.getProperty("user.home"), ".m2", "repository",
-                    "org", "apache", "tomcat", "embed", "tomcat-embed-websocket",
-                    version, "tomcat-embed-websocket-" + version + ".jar");
-            if (Files.isRegularFile(localJar)) {
-                return localJar;
-            }
-        }
-        throw new IllegalStateException(
-                "Embedded websocket jar not found. Set tank.embedded.websocket.jar or install "
-                        + "org.apache.tomcat:tomcat-embed-websocket locally.");
+        throw new IllegalStateException("Embedded websocket jar not found at " + configured);
     }
 
     private static int findFreePort() throws IOException {
@@ -355,7 +363,7 @@ public final class TankIntegrationEnvironment implements AutoCloseable {
         }
     }
 
-    private void writeWebSocketLib(Path webappDir) throws Exception {
+    private void writeWebSocketLib(Path webappDir) throws IOException {
         Path libDir = webappDir.resolve("WEB-INF/lib");
         Files.createDirectories(libDir);
         Files.copy(resolveEmbeddedWebsocketJar(), libDir.resolve("tomcat-embed-websocket.jar"),

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankIntegrationEnvironment.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankIntegrationEnvironment.java
@@ -1,0 +1,472 @@
+package com.intuit.tank.integration;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Boots the reactor-built Tank WAR on embedded Tomcat with disposable H2 storage.
+ */
+public final class TankIntegrationEnvironment implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TankIntegrationEnvironment.class);
+
+    private Tomcat tomcat;
+    private Path workDir;
+    private Path tomcatLogPath;
+    private String baseUrl;
+    private String jdbcUrl;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .build();
+
+    public static Path installSettingsRoot() throws IOException {
+        Path settingsDir = Path.of("target", "system-test-runtime", "settings").toAbsolutePath();
+        Files.createDirectories(settingsDir);
+        Path dataRoot = settingsDir.getParent().resolve("storage");
+        Files.createDirectories(dataRoot.resolve("datafiles"));
+        Files.createDirectories(dataRoot.resolve("timing"));
+        Files.createDirectories(dataRoot.resolve("tmpfiles"));
+        Files.createDirectories(dataRoot.resolve("jars"));
+        String settings = loadResource("runtime/settings.xml")
+                .replace("${datafiles}", dataRoot.resolve("datafiles").toString())
+                .replace("${timing}", dataRoot.resolve("timing").toString())
+                .replace("${tmpfiles}", dataRoot.resolve("tmpfiles").toString())
+                .replace("${jars}", dataRoot.resolve("jars").toString());
+        Files.writeString(settingsDir.resolve("settings.xml"), settings);
+        System.setProperty("WATS_PROPERTIES", settingsDir.toString());
+        return settingsDir;
+    }
+
+    public static TankIntegrationEnvironment start() {
+        TankIntegrationEnvironment env = new TankIntegrationEnvironment();
+        env.boot();
+        return env;
+    }
+
+    private void boot() {
+        try {
+            workDir = Path.of("target", "system-test-runtime").toAbsolutePath();
+            Files.createDirectories(workDir);
+            tomcatLogPath = workDir.resolve("embedded-tomcat.log");
+
+            String databaseName = "tank_" + UUID.randomUUID().toString().replace("-", "");
+            jdbcUrl = "jdbc:h2:mem:" + databaseName
+                    + ";MODE=MYSQL;NON_KEYWORDS=USER,END,VALUE;DB_CLOSE_DELAY=-1";
+
+            Path warFile = resolveWarFile();
+            Path webappDir = resolveExplodedWar(warFile);
+            Path settingsDir = Path.of(System.getProperty("WATS_PROPERTIES"));
+
+            System.setProperty("java.util.logging.config.file", "");
+            System.setProperty("org.apache.jasper.compiler.disablejsr199", "true");
+
+            int port = findFreePort();
+            baseUrl = "http://127.0.0.1:" + port + "/tank";
+            rewriteControllerBaseUrl(settingsDir, baseUrl);
+
+            tomcat = new Tomcat();
+            tomcat.setBaseDir(workDir.resolve("tomcat-base").toString());
+            tomcat.setPort(port);
+            tomcat.getConnector();
+
+            System.out.println("[system-test] Mounting webapp from " + webappDir);
+            Context context = tomcat.addWebapp("/tank", webappDir.toAbsolutePath().toString());
+            context.setReloadable(false);
+            context.addParameter("com.sun.faces.enableWebSocketEndpoint", "false");
+
+            writeContextXml(webappDir);
+            writePersistenceOverride(webappDir);
+            writeWebSocketLib(webappDir);
+
+            System.out.println("[system-test] Starting Tomcat (Spring/Weld/Hibernate — often 2-8 min on first boot)...");
+            long bootStart = System.currentTimeMillis();
+            tomcat.start();
+            System.out.println("[system-test] Tomcat process up in "
+                    + ((System.currentTimeMillis() - bootStart) / 1000) + "s; waiting for /v2/jobs/ping...");
+            waitForReady();
+            waitForSchema();
+            LOG.info("Embedded Tank ready at {} (jdbc={})", baseUrl, jdbcUrl);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start embedded Tank runtime", e);
+        }
+    }
+
+    private Path resolveExplodedWar(Path warFile) throws IOException, InterruptedException {
+        String cacheKey = Files.getLastModifiedTime(warFile).toMillis()
+                + "-" + Files.size(warFile);
+        Path globalCache = Path.of(System.getProperty("user.home"), ".cache", "tank-system-tests",
+                "exploded-war", cacheKey);
+        Path workExploded = workDir.resolve("exploded-war");
+        Path workStamp = workDir.resolve("exploded-war.stamp");
+
+        if (!isValidExplodedWar(globalCache)) {
+            System.out.println("[system-test] Exploding tank.war to global cache (~290MB, one-time per WAR revision)...");
+            deleteRecursively(globalCache);
+            Files.createDirectories(globalCache);
+            unpackWar(warFile, globalCache);
+        } else {
+            System.out.println("[system-test] Reusing global exploded WAR cache at " + globalCache);
+        }
+
+        if (isValidExplodedWar(workExploded) && Files.isRegularFile(workStamp)
+                && cacheKey.equals(Files.readString(workStamp).trim())) {
+            System.out.println("[system-test] Reusing workdir exploded WAR at " + workExploded);
+            return workExploded;
+        }
+
+        System.out.println("[system-test] Copying exploded WAR from cache " + globalCache);
+        deleteRecursively(workExploded);
+        cloneDirectory(globalCache, workExploded);
+        Files.writeString(workStamp, cacheKey);
+        return workExploded;
+    }
+
+    private static void cloneDirectory(Path source, Path destination) throws IOException, InterruptedException {
+        if (isMacOs()) {
+            Files.createDirectories(destination.getParent());
+            Process copy = new ProcessBuilder("cp", "-Rc", source.toString(), destination.toString())
+                    .redirectErrorStream(true)
+                    .start();
+            if (copy.waitFor() == 0 && isValidExplodedWar(destination)) {
+                return;
+            }
+            deleteRecursively(destination);
+        }
+        copyDirectory(source, destination);
+    }
+
+    private static boolean isMacOs() {
+        return System.getProperty("os.name", "").toLowerCase().contains("mac");
+    }
+
+    private static boolean isValidExplodedWar(Path dir) {
+        return Files.isDirectory(dir) && Files.isDirectory(dir.resolve("WEB-INF"));
+    }
+
+    private static void unpackWar(Path warFile, Path destination) throws IOException, InterruptedException {
+        Files.createDirectories(destination);
+        Process unpack = new ProcessBuilder("jar", "xf", warFile.toAbsolutePath().toString())
+                .directory(destination.toFile())
+                .redirectErrorStream(true)
+                .start();
+        int exit = unpack.waitFor();
+        if (exit != 0) {
+            throw new IOException("jar xf failed with exit code " + exit);
+        }
+        System.out.println("[system-test] WAR exploded to " + destination);
+    }
+
+    private static void copyDirectory(Path source, Path destination) throws IOException {
+        try (var walk = Files.walk(source)) {
+            walk.forEach(path -> {
+                try {
+                    Path target = destination.resolve(source.relativize(path));
+                    if (Files.isDirectory(path)) {
+                        Files.createDirectories(target);
+                    } else {
+                        Files.createDirectories(target.getParent());
+                        Files.copy(path, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var walk = Files.walk(root)) {
+            walk.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private Path resolveWarFile() {
+        String configured = System.getProperty("tank.war.path");
+        if (configured != null && !configured.isBlank()) {
+            Path warPath = Path.of(configured.trim());
+            if (Files.isRegularFile(warPath)) {
+                return warPath;
+            }
+            throw new IllegalStateException("Configured tank.war.path not found: " + warPath);
+        }
+        for (Path candidate : List.of(
+                Path.of("../web/web_ui/target/tank.war").toAbsolutePath().normalize(),
+                localMavenWar())) {
+            if (Files.isRegularFile(candidate)) {
+                System.out.println("[system-test] Using WAR at " + candidate);
+                return candidate;
+            }
+        }
+        throw new IllegalStateException(
+                "Tank WAR not found. Build web module (../web/web_ui/target/tank.war) or set tank.war.path.");
+    }
+
+    private static Path localMavenWar() {
+        String version = System.getProperty("project.version", "4.3.9-SNAPSHOT");
+        return Path.of(System.getProperty("user.home"), ".m2", "repository",
+                "com", "intuit", "tank", "tank", version, "tank-" + version + ".war");
+    }
+
+    private void rewriteControllerBaseUrl(Path settingsDir, String controllerBaseUrl) throws IOException {
+        Path settingsFile = settingsDir.resolve("settings.xml");
+        String settings = Files.readString(settingsFile);
+        settings = settings.replaceAll(
+                "<controller-base-url>.*</controller-base-url>",
+                "<controller-base-url>" + controllerBaseUrl + "</controller-base-url>");
+        Files.writeString(settingsFile, settings);
+    }
+
+    private Path resolveEmbeddedWebsocketJar() {
+        String configured = System.getProperty("tank.embedded.websocket.jar");
+        if (configured != null && !configured.isBlank()) {
+            Path jar = Path.of(configured.trim());
+            if (Files.isRegularFile(jar)) {
+                return jar;
+            }
+        }
+        Path copiedJar = Path.of("target", "embedded-lib", "tomcat-embed-websocket.jar")
+                .toAbsolutePath();
+        if (Files.isRegularFile(copiedJar)) {
+            return copiedJar;
+        }
+        for (String version : List.of("11.0.2", "11.0.24", "10.1.43", "10.1.41")) {
+            Path localJar = Path.of(System.getProperty("user.home"), ".m2", "repository",
+                    "org", "apache", "tomcat", "embed", "tomcat-embed-websocket",
+                    version, "tomcat-embed-websocket-" + version + ".jar");
+            if (Files.isRegularFile(localJar)) {
+                return localJar;
+            }
+        }
+        throw new IllegalStateException(
+                "Embedded websocket jar not found. Set tank.embedded.websocket.jar or install "
+                        + "org.apache.tomcat:tomcat-embed-websocket locally.");
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+
+    private void waitForReady() {
+        Duration timeout = Duration.ofMinutes(8);
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        Exception lastError = null;
+        int attempt = 0;
+        while (System.currentTimeMillis() < deadline) {
+            attempt++;
+            try {
+                HttpResponse<String> response = get("/v2/jobs/ping");
+                if (response.statusCode() == 200 && response.body() != null
+                        && response.body().toUpperCase().contains("PONG")) {
+                    System.out.println("[system-test] Tank REST ready after " + attempt + " ping attempt(s)");
+                    return;
+                }
+                lastError = new IllegalStateException("Unexpected ping response: HTTP "
+                        + response.statusCode() + " body=" + response.body());
+            } catch (Exception e) {
+                lastError = e;
+            }
+            if (attempt == 1 || attempt % 15 == 0) {
+                System.out.println("[system-test] Still waiting for /v2/jobs/ping (attempt " + attempt + ")...");
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted waiting for embedded Tank", ie);
+            }
+        }
+        throw new IllegalStateException("Embedded Tank not reachable at " + baseUrl
+                + "/v2/jobs/ping. Last error: "
+                + (lastError == null ? "unknown" : lastError.getMessage()), lastError);
+    }
+
+    private void writeContextXml(Path webappDir) throws IOException {
+        Path contextXml = webappDir.resolve("META-INF/context.xml");
+        Files.createDirectories(contextXml.getParent());
+        String template = loadResource("runtime/context.xml");
+        Files.writeString(contextXml, template.replace("${jdbcUrl}", jdbcUrl));
+        System.out.println("[system-test] Wrote H2 context.xml");
+    }
+
+    private void writePersistenceOverride(Path webappDir) throws IOException, InterruptedException {
+        Path metaInf = webappDir.resolve("WEB-INF/classes/META-INF");
+        Files.createDirectories(metaInf);
+        String persistence = loadResource("runtime/persistence.xml").replace("${jdbcUrl}", jdbcUrl);
+        Files.writeString(metaInf.resolve("persistence.xml"), persistence);
+        removeConflictingPersistenceJar(webappDir);
+        System.out.println("[system-test] Wrote H2 persistence.xml");
+    }
+
+    private void removeConflictingPersistenceJar(Path webappDir) throws IOException, InterruptedException {
+        try (var jars = Files.list(webappDir.resolve("WEB-INF/lib"))) {
+            for (Path jar : jars.filter(p -> p.getFileName().toString().startsWith("data-access-")).toList()) {
+                Process list = new ProcessBuilder("jar", "tf", jar.toAbsolutePath().toString())
+                        .redirectErrorStream(true)
+                        .start();
+                String contents = new String(list.getInputStream().readAllBytes());
+                if (list.waitFor() != 0 || !contents.contains("META-INF/persistence.xml")) {
+                    continue;
+                }
+                Process strip = new ProcessBuilder("zip", "-d", jar.toAbsolutePath().toString(),
+                        "META-INF/persistence.xml")
+                        .redirectErrorStream(true)
+                        .start();
+                if (strip.waitFor() != 0) {
+                    throw new IOException("Failed to remove persistence.xml from " + jar);
+                }
+            }
+        }
+    }
+
+    private void writeWebSocketLib(Path webappDir) throws Exception {
+        Path libDir = webappDir.resolve("WEB-INF/lib");
+        Files.createDirectories(libDir);
+        Files.copy(resolveEmbeddedWebsocketJar(), libDir.resolve("tomcat-embed-websocket.jar"),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void waitForSchema() throws Exception {
+        System.out.println("[system-test] Waiting for Hibernate schema (probing /v2/scripts)...");
+        long deadline = System.currentTimeMillis() + Duration.ofMinutes(3).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                get("/v2/scripts");
+            } catch (Exception ignored) {
+                // EMF may not be ready yet
+            }
+            try (Connection connection = DriverManager.getConnection(jdbcUrl, "sa", "")) {
+                if (tableExists(connection, "USER") || tableExists(connection, "user")) {
+                    System.out.println("[system-test] Hibernate schema ready");
+                    return;
+                }
+            } catch (Exception ignored) {
+                // database not ready yet
+            }
+            Thread.sleep(2000);
+        }
+        throw new IllegalStateException("Hibernate schema not created within 3 minutes");
+    }
+
+    private static boolean tableExists(Connection connection, String tableName) throws Exception {
+        try (ResultSet rs = connection.getMetaData().getTables(null, null, tableName, new String[] {"TABLE"})) {
+            return rs.next();
+        }
+    }
+
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    public String jdbcUrl() {
+        return jdbcUrl;
+    }
+
+    public String jdbcUser() {
+        return "sa";
+    }
+
+    public String jdbcPassword() {
+        return "";
+    }
+
+    public HttpClient httpClient() {
+        return httpClient;
+    }
+
+    public HttpResponse<String> get(String path) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(60))
+                .GET()
+                .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    public HttpResponse<String> postJson(String path, String body) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(60))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    public void retainLogsOnFailure(Throwable failure) {
+        LOG.error("System test failure against {}: {}", baseUrl, failure.getMessage());
+        try {
+            Path logDir = Path.of("target", "system-test-logs");
+            Files.createDirectories(logDir);
+            Files.writeString(logDir.resolve("failure.txt"),
+                    failure.getClass().getName() + ": " + failure.getMessage());
+            if (Files.isRegularFile(tomcatLogPath)) {
+                Files.copy(tomcatLogPath, logDir.resolve("embedded-tomcat.log"),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (Exception e) {
+            LOG.warn("Unable to write system test log artifacts: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void close() {
+        if (tomcat != null) {
+            try {
+                tomcat.stop();
+                tomcat.destroy();
+            } catch (LifecycleException e) {
+                LOG.warn("Error stopping embedded Tomcat: {}", e.getMessage());
+            }
+            tomcat = null;
+        }
+        LOG.info("Embedded Tank stopped");
+    }
+
+    private static String loadResource(String classpathPath) throws IOException {
+        try (InputStream in = TankIntegrationEnvironment.class.getClassLoader()
+                .getResourceAsStream(classpathPath)) {
+            if (in == null) {
+                throw new IOException("Missing classpath resource: " + classpathPath);
+            }
+            return new String(in.readAllBytes());
+        }
+    }
+}

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
@@ -1,0 +1,120 @@
+package com.intuit.tank.integration;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Tracing;
+import com.microsoft.playwright.options.LoadState;
+import com.microsoft.playwright.options.WaitForSelectorState;
+
+import java.nio.file.Path;
+
+/**
+ * Reuses one Chromium process across UI checks; each call gets an isolated browser context.
+ */
+final class TankUiBrowser implements AutoCloseable {
+
+    private final Playwright playwright;
+    private final Browser browser;
+    private final String baseUrl;
+    private final String username;
+    private final String password;
+
+    TankUiBrowser(String baseUrl, String username, String password) {
+        this.baseUrl = baseUrl;
+        this.username = username;
+        this.password = password;
+        playwright = Playwright.create();
+        boolean headless = Boolean.parseBoolean(System.getProperty("tank.ui.headless", "true"));
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+                .setHeadless(headless)
+                .setSlowMo(headless ? 0 : 250));
+    }
+
+    void confirmJobInQueue(Path artifactDir, int jobId, String projectName, String expectedName,
+                           String expectedStatus, String expectedUsers) {
+        Path screenshot = artifactDir.resolve("job-queue-" + jobId + ".png");
+        Path trace = artifactDir.resolve("job-queue-" + jobId + ".zip");
+
+        BrowserContext context = browser.newContext();
+        context.tracing().start(new Tracing.StartOptions()
+                .setScreenshots(true)
+                .setSnapshots(true));
+        Page page = context.newPage();
+        try {
+            page.navigate(baseUrl + "/login.jsf");
+            page.locator("#login\\:username").fill(username);
+            page.locator("#login\\:password").fill(password);
+            page.locator("#login\\:loginButton").click();
+            page.locator("#mainForm\\:projectTableId").waitFor(
+                    new Locator.WaitForOptions().setTimeout(60_000));
+
+            page.navigate(baseUrl + "/agents/index.jsf");
+            page.waitForSelector("#mainForm\\:jobTableId",
+                    new Page.WaitForSelectorOptions().setTimeout(60_000));
+            page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                    new Page.GetByRoleOptions().setName("Refresh")).click();
+            page.waitForLoadState(LoadState.NETWORKIDLE);
+
+            Locator table = page.locator("#mainForm\\:jobTableId");
+            Locator filterFinished = page.locator("#mainForm\\:filterFinishedBoxId");
+            if (filterFinished.count() > 0 && filterFinished.isChecked()) {
+                filterFinished.click();
+                page.waitForLoadState(LoadState.NETWORKIDLE);
+            }
+
+            Locator projectRow = table.locator("tbody tr").filter(
+                    new Locator.FilterOptions().setHasText(projectName)).first();
+            projectRow.waitFor(new Locator.WaitForOptions().setTimeout(60_000));
+
+            Locator collapsedToggler = projectRow.locator(
+                    ".ui-treetable-toggler.ui-icon-triangle-1-e");
+            if (collapsedToggler.count() > 0) {
+                collapsedToggler.click();
+                page.waitForLoadState(LoadState.NETWORKIDLE);
+            }
+
+            Locator jobRow = table.locator("tbody tr").filter(
+                    new Locator.FilterOptions().setHasText(expectedName));
+            jobRow.first().waitFor(new Locator.WaitForOptions()
+                    .setState(WaitForSelectorState.VISIBLE)
+                    .setTimeout(60_000));
+
+            String rowText = jobRow.first().innerText();
+            if (!rowText.contains(String.valueOf(jobId))) {
+                throw new AssertionError("Job ID should appear in the expanded job row");
+            }
+            if (!rowText.contains(expectedStatus)) {
+                throw new AssertionError("Status " + expectedStatus + " should be visible on the job row");
+            }
+            if (expectedUsers != null && !rowText.contains(expectedUsers)) {
+                throw new AssertionError("Configured user count should be visible on the job row");
+            }
+
+            page.screenshot(new Page.ScreenshotOptions().setPath(screenshot).setFullPage(true));
+        } catch (RuntimeException uiFailure) {
+            try {
+                page.screenshot(new Page.ScreenshotOptions().setPath(screenshot).setFullPage(true));
+            } catch (Exception ignored) {
+                // best effort
+            }
+            throw uiFailure;
+        } finally {
+            context.tracing().stop(new Tracing.StopOptions().setPath(trace));
+            context.close();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+}

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
@@ -49,12 +49,16 @@ final class TankUiBrowser implements AutoCloseable {
             page.locator("#login\\:username").fill(username);
             page.locator("#login\\:password").fill(password);
             page.locator("#login\\:loginButton").click();
-            page.locator("#mainForm\\:projectTableId").waitFor(
-                    new Locator.WaitForOptions().setTimeout(60_000));
 
             page.navigate(baseUrl + "/agents/index.jsf");
-            page.waitForSelector("#mainForm\\:jobTableId",
-                    new Page.WaitForSelectorOptions().setTimeout(60_000));
+            try {
+                page.waitForSelector("#mainForm\\:jobTableId",
+                        new Page.WaitForSelectorOptions().setTimeout(60_000));
+            } catch (RuntimeException navigationFailure) {
+                throw new AssertionError(
+                        "Job queue unavailable after login; current URL: " + page.url(),
+                        navigationFailure);
+            }
             page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
                     new Page.GetByRoleOptions().setName("Refresh")).click();
             page.waitForLoadState(LoadState.NETWORKIDLE);

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
@@ -51,6 +51,9 @@ final class TankUiBrowser implements AutoCloseable {
             page.locator("#login\\:loginButton").click();
 
             page.navigate(baseUrl + "/agents/index.jsf");
+            if (page.url().startsWith(baseUrl + "/login.jsf")) {
+                throw new AssertionError("UI login failed; redirected to " + page.url());
+            }
             try {
                 page.waitForSelector("#mainForm\\:jobTableId",
                         new Page.WaitForSelectorOptions().setTimeout(60_000));

--- a/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
+++ b/system_tests/src/test/java/com/intuit/tank/integration/TankUiBrowser.java
@@ -95,7 +95,7 @@ final class TankUiBrowser implements AutoCloseable {
             }
 
             page.screenshot(new Page.ScreenshotOptions().setPath(screenshot).setFullPage(true));
-        } catch (RuntimeException uiFailure) {
+        } catch (RuntimeException | AssertionError uiFailure) {
             try {
                 page.screenshot(new Page.ScreenshotOptions().setPath(screenshot).setFullPage(true));
             } catch (Exception ignored) {

--- a/system_tests/src/test/resources/contracts/increasing-job.json
+++ b/system_tests/src/test/resources/contracts/increasing-job.json
@@ -1,0 +1,21 @@
+{
+  "projectId": "${projectId}",
+  "jobInstanceName": "${jobInstanceName}",
+  "rampTime": "120m",
+  "simulationTime": "24h",
+  "userIntervalIncrement": 1,
+  "stopBehavior": "END_OF_SCRIPT",
+  "vmInstance": "m.xlarge",
+  "numUsersPerAgent": 6400,
+  "jobRegions": [
+    {
+      "region": "us-east-2",
+      "users": "1400"
+    },
+    {
+      "region": "us-west-2",
+      "users": "1400"
+    }
+  ],
+  "workloadType": "increasing"
+}

--- a/system_tests/src/test/resources/contracts/standard-job.json
+++ b/system_tests/src/test/resources/contracts/standard-job.json
@@ -1,0 +1,22 @@
+{
+  "projectId": "${projectId}",
+  "jobInstanceName": "${jobInstanceName}",
+  "rampTime": "61m",
+  "simulationTime": "24h",
+  "userIntervalIncrement": 1,
+  "stopBehavior": "END_OF_SCRIPT",
+  "vmInstance": "m.xlarge",
+  "targetRampRate": "0.382",
+  "targetRatePerAgent": "0.211",
+  "jobRegions": [
+    {
+      "region": "us-east-2",
+      "percentage": "50"
+    },
+    {
+      "region": "us-west-2",
+      "percentage": "50"
+    }
+  ],
+  "workloadType": "standard"
+}

--- a/system_tests/src/test/resources/fixtures/Minimal_TS.xml
+++ b/system_tests/src/test/resources/fixtures/Minimal_TS.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<script xmlns="urn:wats/domain/script/v1">
+    <id>0</id>
+    <name>IT Minimal Script</name>
+    <creator>integration-test</creator>
+    <productName>Tank Integration Test</productName>
+    <comments>Minimal script for JobCreationIT — request only, no variables</comments>
+    <runtime>0</runtime>
+    <steps>
+        <step>
+            <uuid>it-step-1</uuid>
+            <type>request</type>
+            <method>GET</method>
+            <url>https://example.com/health</url>
+            <label>Health Check</label>
+            <stepIndex>0</stepIndex>
+            <protocol>https</protocol>
+            <hostname>example.com</hostname>
+            <simplePath>/health</simplePath>
+            <loggingKey>health</loggingKey>
+            <requestheaders>
+                <requestHeaders>
+                    <key>Accept</key>
+                    <value>application/json</value>
+                </requestHeaders>
+            </requestheaders>
+            <responseData>
+                <responseData>
+                    <key>httpCode</key>
+                    <value>200</value>
+                </responseData>
+            </responseData>
+        </step>
+        <step>
+            <uuid>it-step-2</uuid>
+            <type>sleep</type>
+            <stepIndex>1</stepIndex>
+            <data>
+                <data>
+                    <key>time</key>
+                    <value>100</value>
+                </data>
+            </data>
+        </step>
+    </steps>
+</script>

--- a/system_tests/src/test/resources/runtime/context.xml
+++ b/system_tests/src/test/resources/runtime/context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context>
+  <Resource
+      name="BeanManager"
+      auth="Container"
+      type="jakarta.enterprise.inject.spi.BeanManager"
+      factory="org.jboss.weld.resources.ManagerObjectFactory" />
+
+  <Resource name="jdbc/watsDS"
+            auth="Container"
+            type="org.h2.jdbcx.JdbcDataSource"
+            factory="org.apache.naming.factory.BeanFactory"
+            URL="${jdbcUrl}"
+            user="sa"
+            password="" />
+</Context>

--- a/system_tests/src/test/resources/runtime/persistence.xml
+++ b/system_tests/src/test/resources/runtime/persistence.xml
@@ -1,0 +1,53 @@
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.1">
+  <persistence-unit name="tank" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+    <class>com.intuit.tank.project.DataFile</class>
+    <class>com.intuit.tank.project.ScriptFilter</class>
+    <class>com.intuit.tank.project.ScriptFilterAction</class>
+    <class>com.intuit.tank.project.ScriptFilterCondition</class>
+    <class>com.intuit.tank.project.ScriptFilterGroup</class>
+    <class>com.intuit.tank.project.JobVMInstance</class>
+    <class>com.intuit.tank.project.Preferences</class>
+    <class>com.intuit.tank.project.Project</class>
+    <class>com.intuit.tank.project.RequestData</class>
+    <class>com.intuit.tank.project.Script</class>
+    <class>com.intuit.tank.project.ScriptGroup</class>
+    <class>com.intuit.tank.project.ScriptGroupStep</class>
+    <class>com.intuit.tank.project.ColumnPreferences</class>
+    <class>com.intuit.tank.project.ScriptStep</class>
+    <class>com.intuit.tank.project.VMInstance</class>
+    <class>com.intuit.tank.project.JobConfiguration</class>
+    <class>com.intuit.tank.project.JobInstance</class>
+    <class>com.intuit.tank.project.JobQueue</class>
+    <class>com.intuit.tank.project.JobNotification</class>
+    <class>com.intuit.tank.project.JobRecipient</class>
+    <class>com.intuit.tank.project.JobRegion</class>
+    <class>com.intuit.tank.project.Workload</class>
+    <class>com.intuit.tank.project.TankRevisionInfo</class>
+    <class>com.intuit.tank.project.SerializedScriptStep</class>
+    <class>com.intuit.tank.project.ExternalScript</class>
+    <class>com.intuit.tank.project.SummaryData</class>
+    <class>com.intuit.tank.project.PeriodicData</class>
+    <class>com.intuit.tank.project.TestPlan</class>
+    <class>com.intuit.tank.project.User</class>
+    <class>com.intuit.tank.project.Group</class>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+      <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+      <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver" />
+      <property name="jakarta.persistence.jdbc.user" value="sa" />
+      <property name="jakarta.persistence.jdbc.password" value="" />
+      <property name="jakarta.persistence.jdbc.url" value="${jdbcUrl}" />
+      <property name="hibernate.connection.pool_size" value="10" />
+      <property name="hibernate.current_session_context_class" value="thread" />
+      <property name="hibernate.show_sql" value="false" />
+      <property name="org.hibernate.envers.audit_table_suffix" value="_version" />
+      <property name="org.hibernate.envers.revision_field_name" value="rev" />
+      <property name="org.hibernate.envers.revision_type_field_name" value="rev_type" />
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/system_tests/src/test/resources/runtime/settings.xml
+++ b/system_tests/src/test/resources/runtime/settings.xml
@@ -37,7 +37,7 @@
     <users>
       <user>
         <name>admin</name>
-        <password>adminadmin</password>
+        <password>admin</password>
         <email>admin@system-test.local</email>
         <group>admin</group>
         <group>job-manager</group>

--- a/system_tests/src/test/resources/runtime/settings.xml
+++ b/system_tests/src/test/resources/runtime/settings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tank-settings>
+  <instance-name>tank-system-test</instance-name>
+  <controller-base-url>http://127.0.0.1:8080/tank</controller-base-url>
+  <standalone>true</standalone>
+  <s3-encrypt>false</s3-encrypt>
+  <rest-security-enabled>false</rest-security-enabled>
+  <data-file-storage>${datafiles}</data-file-storage>
+  <timing-file-storage>${timing}</timing-file-storage>
+  <tmp-file-storage>${tmpfiles}</tmp-file-storage>
+  <jar-file-storage>${jars}</jar-file-storage>
+  <products>
+    <product name="">All Products</product>
+  </products>
+  <locations>
+    <location name="unspecified" displayName="Unspecified" />
+  </locations>
+  <reporting>
+    <provider>
+      <reporter>com.intuit.tank.reporting.db.DatabaseResultsReporter</reporter>
+      <reader>com.intuit.tank.reporting.db.DatabaseResultsReader</reader>
+      <config></config>
+    </provider>
+  </reporting>
+  <agent-config>
+    <default-tank-client>JDK HttpClient</default-tank-client>
+    <tank-http-clients>
+      <tank-client name="JDK HttpClient">com.intuit.tank.httpclientjdk.TankHttpClientJDK</tank-client>
+    </tank-http-clients>
+  </agent-config>
+  <security>
+    <groups>
+      <group>admin</group>
+      <group isDefault="true">user</group>
+      <group>job-manager</group>
+    </groups>
+    <users>
+      <user>
+        <name>admin</name>
+        <password>adminadmin</password>
+        <email>admin@system-test.local</email>
+        <group>admin</group>
+        <group>job-manager</group>
+      </user>
+    </users>
+  </security>
+  <vm-manager>
+    <default-region>US_EAST_2</default-region>
+    <use-agent-elastic-ips>false</use-agent-elastic-ips>
+    <reserved-elastic-ips></reserved-elastic-ips>
+    <default-instance-description>
+      <security-group>system-test</security-group>
+      <keypair>system-test</keypair>
+      <reuse-instances>false</reuse-instances>
+    </default-instance-description>
+    <credentials type="amazon"></credentials>
+    <instance-descriptions region="US_WEST_2">
+      <instance-description name="AGENT">
+        <ami>ami-system-test</ami>
+        <keypair>system-test</keypair>
+      </instance-description>
+    </instance-descriptions>
+    <instance-descriptions region="US_EAST_2">
+      <instance-description name="AGENT">
+        <ami>ami-system-test</ami>
+        <keypair>system-test</keypair>
+      </instance-description>
+    </instance-descriptions>
+    <instance-types type="amazon">
+      <type name="m.xlarge" types="m8g.xlarge,m7g.xlarge" cost=".1795" users="6400" cpus="4" ecus="16" mem="16" default="true" jvmArgs="-XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0 -XX:+UseG1GC" />
+    </instance-types>
+    <watchdog>
+      <max-time-for-agent-start>5m</max-time-for-agent-start>
+      <max-time-for-agent-report>10m</max-time-for-agent-report>
+      <max-restarts>2</max-restarts>
+      <sleep-time-between-check>30s</sleep-time-between-check>
+    </watchdog>
+    <results>
+      <provider>com.intuit.tank.persistence.databases.CloudWatchDataSource</provider>
+    </results>
+  </vm-manager>
+</tank-settings>


### PR DESCRIPTION
## Summary

- Adds `system_tests` module that boots the packaged WAR on embedded Tomcat + H2 and validates job creation via REST, DB, and Playwright UI (adds ~30 sec to build time)
- Wires the suite into the `release` profile and CodeBuild (Playwright deps, exploded-WAR cache, failsafe reports)
- Stabilizes flaky unit tests (`MethodTimerCpTest`, `TestStepRunnerTest`, `LogicStepEditorTest` via `LogicStepConfig` comma unescape)

## Test plan

- [x] `mvn clean install -P release -Dcheckstyle.skip=true` (local)
- [x] `mvn -pl system_tests clean verify -P release -Dcheckstyle.skip=true` (~45–50s)
- [x] CodeBuild release build on QA-Tank (verify system test timing with warm exploded-WAR cache)