### PR TITLE
Java21 & Virtual Threads

### DIFF
--- a/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpClient.java
+++ b/agent/agent_common/src/main/java/com/intuit/tank/http/TankHttpClient.java
@@ -87,4 +87,11 @@ public interface TankHttpClient {
      * @param httpClient
      */
     public void setHttpClient(Object httpClient);
+
+    /**
+     * Releases any resources (threads, connections) held by the underlying client.
+     * Called once per virtual-user thread when its test plan finishes. Default is a
+     * no-op for pooled/shared-client implementations.
+     */
+    default void close() {}
 }

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -26,6 +26,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.text.DateFormat;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.zip.GZIPInputStream;
@@ -80,7 +81,6 @@ public class APITestHarness {
 
     private String testPlans = "";
     private String instanceId;
-    private ArrayList<ThreadGroup> threadGroupArray = new ArrayList<>();
     private int currentNumThreads = 0;
     private long startTime = 0;
     private int capacity = -1;
@@ -101,7 +101,7 @@ public class APITestHarness {
     private TankConfig tankConfig;
     private UserTracker userTracker = new UserTracker();
     private FlowController flowControllerTemplate;
-    private Map<Long, FlowController> controllerMap = new HashMap<Long, FlowController>();
+    private Map<Long, FlowController> controllerMap = new ConcurrentHashMap<Long, FlowController>();
     private TPSMonitor tpsMonitor;
     private ResultsReporter resultsReporter;
     private String tankHttpClientClass;
@@ -372,7 +372,7 @@ public class APITestHarness {
                     startData = objectMapper.readerFor(AgentTestStartData.class).readValue(response.body());
                     break;
                 } catch (Exception e) {
-                    LOG.error("Error sending ready: " + e, e);
+                    LOG.error("Error sending ready: {}", e, e);
                     try {
                         Thread.sleep(FIBONACCI[count++] * 1000);
                     } catch ( InterruptedException ignored) {}
@@ -395,7 +395,7 @@ public class APITestHarness {
             thread.setDaemon(false);
             thread.start();
         } catch (Exception e) {
-            LOG.error("Error communicating with controller: " + e, e);
+            LOG.error("Error communicating with controller: {}", e, e);
             System.exit(0);
         }
     }
@@ -602,9 +602,8 @@ public class APITestHarness {
             for (HDTestPlan plan : hdWorkload.getPlans()) {
                 if (plan.getUserPercentage() > 0) {
                     plan.setVariables(hdWorkload.getVariables());
-                    ThreadGroup threadGroup = new ThreadGroup("Test Plan Runner Group: " + plan.getTestPlanName());
-                    threadGroupArray.add(threadGroup);
-                    TestPlanStarter starter = new TestPlanStarter(httpClient, plan, agentRunData.getNumUsers(), tankHttpClientClass, threadGroup, agentRunData);
+                    String threadGroupName = "Test Plan Runner Group: " + plan.getTestPlanName();
+                    TestPlanStarter starter = new TestPlanStarter(httpClient, plan, agentRunData.getNumUsers(), tankHttpClientClass, threadGroupName, agentRunData);
                     testPlans.add(starter);
                     LOG.info(LogUtil.getLogMessage("Users for Test Plan " + plan.getTestPlanName() + " at "
                             + plan.getUserPercentage()
@@ -811,19 +810,15 @@ public class APITestHarness {
      * check the agent threads if simulation time has been met.
      */
     public void checkAgentThreads() {
-        for (ThreadGroup threadGroup : threadGroupArray) {
-            int activeCount = threadGroup.activeCount();
-            LOG.info(LogUtil.getLogMessage("Have " + threadGroup.activeCount()
-                    + " active Threads in thread group "
-                    + threadGroup.getName()));
-        }
+        long activeCount = sessionThreads.stream().filter(Thread::isAlive).count();
+        LOG.info(LogUtil.getLogMessage("Have " + activeCount + " active user Threads"));
         if (hasMetSimulationTime()) {          // && doneSignal.getCount() != 0) {
             if(agentRunData.getIncrementStrategy().equals(IncrementStrategy.increasing)) {
                 LOG.info(LogUtil.getLogMessage("Linear - Max simulation time has been met and there are "
                         + doneSignal.getCount() + " threads not reporting done, interrupting remaining threads."));
                 for (Thread t : sessionThreads) {
                     if (t.isAlive()) {
-                        LOG.warn(LogUtil.getLogMessage("thread " + t.getName() + '-' + t.getId()
+                        LOG.warn(LogUtil.getLogMessage("thread " + t.getName() + '-' + t.threadId()
                                 + " is still running with a State of " + t.getState().name(), LogEventType.System));
                         t.interrupt();
                         doneSignal.countDown();
@@ -920,12 +915,7 @@ public class APITestHarness {
     }
 
     public FlowController getFlowController(Long threadId) {
-        FlowController ret = controllerMap.get(threadId);
-        if (ret == null) {
-            ret = flowControllerTemplate.cloneController();
-            controllerMap.put(threadId, ret);
-        }
-        return ret;
+        return controllerMap.computeIfAbsent(threadId, id -> flowControllerTemplate.cloneController());
     }
 
     public int getCurrentUsers() { return currentUsers; }

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TPSMonitor.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TPSMonitor.java
@@ -95,13 +95,13 @@ public class TPSMonitor {
     public void addToMap(final String loggingKey, final BaseRequest req) {
         if (isEnabled()) {
             // LOG.info("Adding request " + req.getTimeStamp());
-            new Thread( () -> {
+            Thread.ofVirtual().start( () -> {
                 if (req != null && req.getTimeStamp() != null) {
                     counters.add(new Counter(loggingKey,
                             TimeUtil.normalizeToPeriod(period, req.getTimeStamp()))
                     );
                 }
-            }).start();
+            });
         }
     }
 

--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/TestPlanStarter.java
@@ -34,10 +34,9 @@ import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class TestPlanStarter implements Runnable {
 
@@ -56,7 +55,8 @@ public class TestPlanStarter implements Runnable {
     private final HDTestPlan plan;
     private final int numThreads;
     private final String tankHttpClientClass;
-    private final ThreadGroup threadGroup;
+    private final String threadGroupName;
+    private final AtomicLong activeRunnerThreads = new AtomicLong();
     private final AgentRunData agentRunData;
     private int threadsStarted = 0;
     private int sessionStarts = 0;
@@ -65,13 +65,13 @@ public class TestPlanStarter implements Runnable {
     private double currentRampRate;
     private boolean done = false;
 
-    public TestPlanStarter(Object httpClient, HDTestPlan plan, int numThreads, String tankHttpClientClass, ThreadGroup threadGroup, AgentRunData agentRunData) {
+    public TestPlanStarter(Object httpClient, HDTestPlan plan, int numThreads, String tankHttpClientClass, String threadGroupName, AgentRunData agentRunData) {
         super();
         this.httpClient = httpClient;
         this.plan = plan;
         this.tankHttpClientClass = tankHttpClientClass;
         this.numThreads = (int) Math.max(1, Math.floor(numThreads * (plan.getUserPercentage() / 100D)));
-        this.threadGroup = threadGroup;
+        this.threadGroupName = threadGroupName;
         this.agentRunData = agentRunData;
         this.rampDelay = calcRampTime();
         this.standalone = ((this.numThreads == 1) && (this.agentRunData.getIncrementStrategy().equals(IncrementStrategy.increasing)));
@@ -145,18 +145,7 @@ public class TestPlanStarter implements Runnable {
                         break;
                     }
 
-                    long activeCount = numThreads; //default
-                    try {
-                        Thread[] list = new Thread[this.threadGroup.activeCount()];
-                        this.threadGroup.enumerate(list);
-                        activeCount = Arrays.stream(list)
-                                .filter(Objects::nonNull)
-                                .filter(Thread::isAlive)
-                                .filter(thread -> thread.getName() != null && thread.getName().contains("AGENT"))
-                                .count();
-                    } catch (SecurityException se) {
-                        LOG.error(LogUtil.getLogMessage("Failure to count threads:"), se);
-                    }
+                    long activeCount = getActiveCount();
 
                     if (threadsStarted < numThreads || activeCount < numThreads) {
                         createThread(httpClient, this.threadsStarted);
@@ -384,19 +373,7 @@ public class TestPlanStarter implements Runnable {
     }
 
     private long getActiveCount() {
-        long activeCount = 0; //default
-        try {
-            Thread[] list = new Thread[this.threadGroup.activeCount()];
-            this.threadGroup.enumerate(list);
-            activeCount = Arrays.stream(list)
-                    .filter(Objects::nonNull)
-                    .filter(Thread::isAlive)
-                    .filter(thread -> thread.getName() != null && thread.getName().contains("AGENT"))
-                    .count();
-        } catch (SecurityException se) {
-            LOG.error(LogUtil.getLogMessage("Failure to count threads:"), se);
-        }
-        return activeCount;
+        return activeRunnerThreads.get();
     }
 
     private void sendCloudWatchMetrics(long activeCount) {
@@ -457,9 +434,16 @@ public class TestPlanStarter implements Runnable {
 
     private void createThread(Object httpClient, int threadNumber) {
         TestPlanRunner session = new TestPlanRunner(httpClient, plan, threadNumber, tankHttpClientClass);
-        Thread thread = new Thread(threadGroup, session, "AGENT-" + threadNumber);
-        thread.setDaemon(true);// system won't shut down normally until all user threads stop
-        session.setUniqueName(threadGroup.getName() + "-" + thread.getId());
+        activeRunnerThreads.incrementAndGet();
+        Runnable runner = () -> {
+            try {
+                session.run();
+            } finally {
+                activeRunnerThreads.decrementAndGet();
+            }
+        };
+        Thread thread = Thread.ofVirtual().name("AGENT-" + threadNumber).unstarted(runner);
+        session.setUniqueName(threadGroupName + "-" + thread.threadId());
         thread.start();
         APITestHarness.getInstance().threadStarted(thread);
         threadsStarted++;

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -161,6 +161,9 @@ public class TestPlanRunner implements Runnable {
         } catch (Throwable e) {
             LOG.error(LogUtil.getLogMessage("Unexpected exception in test: " + e.toString()), e);
         } finally {
+            if (tankHttpClient != null) {
+                tankHttpClient.close();
+            }
             APITestHarness.getInstance().threadComplete();
             LOG.info(LogUtil.getLogMessage(mt.getNaturalTimeMessage() + " Test complete. Exiting..."));
         }

--- a/agent/apiharness/src/test/java/com/intuit/tank/harness/TestPlanStarterTest.java
+++ b/agent/apiharness/src/test/java/com/intuit/tank/harness/TestPlanStarterTest.java
@@ -16,10 +16,10 @@ public class TestPlanStarterTest {
 
     private Object _httpClientMock;
     private HDTestPlan _hdTestPlanMock;
-    private ThreadGroup _threadGroupMock;
     private AgentRunData _agentRunData;
 
     private final String _tankHttpClientClassStub = "com.intuit.tank.httpclient4.TankHttpClient4";
+    private final String _threadGroupNameStub = "Test Plan Runner Group: stub";
     private final int _threadCountStub = 10;
 
     private TestPlanStarter _sut;
@@ -30,7 +30,6 @@ public class TestPlanStarterTest {
     public void SetUp() {
         _httpClientMock = mock(Object.class);
         _hdTestPlanMock = mock(HDTestPlan.class);
-        _threadGroupMock = mock(ThreadGroup.class);
         _agentRunData = mock(AgentRunData.class);
         mock_CloudWatchAsyncClient = mockStatic(CloudWatchAsyncClient.class);
         when(CloudWatchAsyncClient.builder()).thenReturn(mock(CloudWatchAsyncClientBuilder.class, RETURNS_SELF));
@@ -45,7 +44,7 @@ public class TestPlanStarterTest {
     @Test
     public void getPlan_Returns_Initialized_HDTestPlan() {
         // Arrange + Act
-        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupMock, _agentRunData);
+        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupNameStub, _agentRunData);
 
         // Assert
         assertEquals(_hdTestPlanMock, _sut.getPlan(), "TestPlan assigned to TestPlanStarter");
@@ -57,7 +56,7 @@ public class TestPlanStarterTest {
         when(_hdTestPlanMock.getUserPercentage()).thenReturn(100);
 
         // Act
-        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, _threadCountStub, _tankHttpClientClassStub, _threadGroupMock, _agentRunData);
+        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, _threadCountStub, _tankHttpClientClassStub, _threadGroupNameStub, _agentRunData);
 
         // Assert
         assertEquals(_threadCountStub, _sut.getNumThreads());
@@ -66,7 +65,7 @@ public class TestPlanStarterTest {
     @Test
     public void getThreadStarted_Given_TestPlanStarter_Not_Run_Returns_Zero() {
         // Arrange + Act
-        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupMock, _agentRunData);
+        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupNameStub, _agentRunData);
 
         // Assert
         assertEquals(0, _sut.getThreadsStarted());
@@ -75,7 +74,7 @@ public class TestPlanStarterTest {
     @Test
     public void isDone_Given_TestPlanStarter_Not_Run_Returns_False() {
         // Arrange + Act
-        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupMock, _agentRunData);
+        _sut = new TestPlanStarter(_httpClientMock, _hdTestPlanMock, 1, _tankHttpClientClassStub, _threadGroupNameStub, _agentRunData);
 
         // Assert
         assertFalse(_sut.isDone());

--- a/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
+++ b/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
@@ -56,7 +56,6 @@ public class TankHttpClientJDK implements TankHttpClient {
     private final CookieManager cookieManager = new CookieManager();
     private final Collection<String> mimeTypes = new TankConfig().getAgentConfig().getTextMimeTypeRegex();
 
-
     /**
      * no-arg constructor for client
      */
@@ -75,7 +74,32 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     public void setConnectionTimeout(long connectionTimeout) {
         httpclientBuilder.connectTimeout(Duration.ofMillis(connectionTimeout));
+        rebuild();
+    }
+
+    /**
+     * Rebuild the immutable client from the mutated builder, closing the client
+     * being replaced so its selector/worker threads are released immediately
+     * (Java 21 HttpClient is AutoCloseable) instead of lingering until GC.
+     */
+    private void rebuild() {
+        HttpClient old = httpclient;
         httpclient = httpclientBuilder.build();
+        if (old != null) {
+            old.close();
+        }
+    }
+
+    /**
+     * Releases this client's selector/worker threads. Called once per virtual-user
+     * thread when its test plan finishes. Blocks until in-flight requests drain.
+     */
+    @Override
+    public void close() {
+        if (httpclient != null) {
+            httpclient.close();
+            httpclient = null;
+        }
     }
 
     /*
@@ -229,7 +253,7 @@ public class TankHttpClientJDK implements TankHttpClient {
         } else {
             httpclientBuilder.proxy(HttpClient.Builder.NO_PROXY);
         }
-        httpclient = httpclientBuilder.build();
+        rebuild();
     }
 
     private void sendRequest(BaseRequest request, @Nonnull HttpRequest method, String requestBody) {
@@ -360,7 +384,7 @@ public class TankHttpClientJDK implements TankHttpClient {
                     long proxyResponseTime = Long.parseLong(proxyResponseTimeHeaders.get(0));
                     response.setProxyResponseTime(proxyResponseTime);
                 } catch (NumberFormatException e) {
-                    LOG.warn("could not parse proxy service time header: " + proxyResponseTimeHeaders.get(0));
+                    LOG.warn("could not parse proxy service time header: {}", proxyResponseTimeHeaders.get(0));
                     response.setProxyResponseTime(-1);
                 }
             } else {
@@ -395,14 +419,14 @@ public class TankHttpClientJDK implements TankHttpClient {
 
                         default:
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("Unknown content encoding: " + contentEncoding + ", keeping raw response");
+                                LOG.debug("Unknown content encoding: {}, keeping raw response", contentEncoding);
                             }
                             break;
                     }
                 } catch (IOException e) {
-                    LOG.warn("Failed to decompress response with encoding '" + contentEncoding + "': " + e.getMessage());
+                    LOG.warn("Failed to decompress response with encoding '{}': {}", contentEncoding, e.getMessage());
                 } catch (Exception e) {
-                    LOG.error("Unexpected error during decompression: " + e.getMessage(), e);
+                    LOG.error("Unexpected error during decompression: {}", e.getMessage(), e);
                 }
             }
             response.setResponseBody(bResponse);

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <!-- maven-compiler-plugin -->
     <version.compiler.plugin>3.15.0</version.compiler.plugin>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
   </properties>
 
   <issueManagement>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![Build Status](https://api.travis-ci.com/intuit/Tank.svg?branch=master)](https://app.travis-ci.com/intuit/Tank)
 ![Build Status](https://codebuild.us-east-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1Nuc1prblk5Y0E3a05mRjF0QUtBblI0Rk1zTjZyZi9NMWNCaFg4cGlzL1dFN0xVMHgzcGt1ZCtBdFZjNWpMRkhXbGN2T1ZKSmpZbGQ3YjhyaWkzdkJBPSIsIml2UGFyYW1ldGVyU3BlYyI6IlpGbU5vTHM2cHQrbUowOVkiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 [![GitHub release](https://img.shields.io/github/release/intuit/tank.svg)](https://github.com/intuit/Tank/releases)
-[![java](https://img.shields.io/badge/java-17%20%7C%2021%20%7C%2025-blue.svg)](https://aws.amazon.com/corretto/)
+[![java](https://img.shields.io/badge/java-21%20%7C%2025-blue.svg)](https://aws.amazon.com/corretto/)
 [![tomcat](https://img.shields.io/badge/tomcat-10.1%20%7C%2011.0-blue.svg)](http://tomcat.apache.org/)
 # Intuit Tank
 


### PR DESCRIPTION
## Summary

Moves the agent's per-virtual-user and per-request thread creation to Java 21 virtual threads, and bumps the project's minimum Java baseline to 21 to support it.

apiharness already ran one dedicated OS thread per virtual user for the life of a test, blocked most of the time on network I/O (`HttpClient.send()`) or pacing sleeps — exactly the workload profile virtual threads are built for. Today's per-agent VU capacity (default 4000) is bounded by platform-thread cost (~1MB stack each); virtual threads let a single agent host far more concurrent virtual users, reducing the number of agent instances needed per load test.

## Changes

- **`TestPlanStarter.createThread()`**: virtual-user runner threads now created via `Thread.ofVirtual()` instead of `new Thread(...)`.
- **`TPSMonitor.addToMap()`**: the per-request fire-and-forget counter thread (created on every HTTP request from every VU) now uses `Thread.ofVirtual()`.
- **Removed `ThreadGroup` usage** in `TestPlanStarter`/`APITestHarness`: virtual threads cannot join a custom `ThreadGroup`, so the `ThreadGroup.enumerate()`/`activeCount()`-based active-VU counting was replaced with a plain `AtomicLong` counter maintained around each VU's lifecycle. `checkAgentThreads()`'s logging now derives active count from the existing `sessionThreads` list instead.
- **`APITestHarness.controllerMap`**: fixed a pre-existing, unsynchronized `HashMap<Long, FlowController>` read/written from every VU thread — switched to `ConcurrentHashMap` with `computeIfAbsent` for atomic get-or-create. This was a latent race under platform threads that becomes far more likely to surface at the higher concurrency virtual threads enable.
- **`TankHttpClient`/`TankHttpClientJDK`**: added a `close()` method (default no-op on the interface) so each VU's `java.net.http.HttpClient` releases its selector/worker threads when the VU finishes, instead of lingering until GC — needed because virtual threads make it practical to run far more concurrent per-VU `HttpClient` instances. `setConnectionTimeout`/`setProxy` now rebuild the client via a shared `rebuild()` helper that closes the outgoing client.
- **`pom.xml`**: `maven.compiler.release` 17 → 21 (virtual threads require 21+).
- **`readme.md`**: updated supported Java badge (17/21/25 → 21/25).
- Minor: replaced deprecated `Thread.getId()` with `Thread.threadId()`; parameterized a few log statements touched incidentally in the same methods.

## Test plan

- [x] `mvn -pl agent/apiharness test` — 463/463 tests pass, including updated `TestPlanStarterTest` (constructor now takes a thread-group name `String` instead of a mocked `ThreadGroup`)
- [x] Full module compiles clean under Java 21
- [ ] Load test at a VU count well above today's default (4000/agent) to confirm the expected per-agent capacity increase before merging

Please make sure these check boxes are checked before submitting
- [ ] **Squashed Commits**
- [ ] **All Tests Passed** - `mvn clean test -P default`

**PR review process**
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.