### PR TITLE
Performance Optimizations on Agent Threads

### DIFF
--- a/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/harness/APITestHarness.java
@@ -26,7 +26,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.text.DateFormat;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.zip.GZIPInputStream;
@@ -101,7 +100,6 @@ public class APITestHarness {
     private TankConfig tankConfig;
     private UserTracker userTracker = new UserTracker();
     private FlowController flowControllerTemplate;
-    private Map<Long, FlowController> controllerMap = new ConcurrentHashMap<Long, FlowController>();
     private TPSMonitor tpsMonitor;
     private ResultsReporter resultsReporter;
     private String tankHttpClientClass;
@@ -912,10 +910,6 @@ public class APITestHarness {
      */
     public void setFlowControllerTemplate(FlowController flowControllerTemplate) {
         this.flowControllerTemplate = flowControllerTemplate;
-    }
-
-    public FlowController getFlowController(Long threadId) {
-        return controllerMap.computeIfAbsent(threadId, id -> flowControllerTemplate.cloneController());
     }
 
     public int getCurrentUsers() { return currentUsers; }

--- a/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
+++ b/agent/apiharness/src/main/java/com/intuit/tank/runner/TestPlanRunner.java
@@ -64,11 +64,16 @@ public class TestPlanRunner implements Runnable {
     private String httpClientClass;
     private BaseRequest previousRequest = null;
     private BaseResponse previousResponse = null;
+    private FlowController flowController;
     private boolean finished = false;
     private Map<String, String> headerMap;
 
+    private static final class AgentHeaders {
+        private static final Map<String, String> MAP = new TankConfig().getAgentConfig().getRequestHeaderMap();
+    }
+
     public TestPlanRunner(Object httpClient, HDTestPlan testPlan, int threadNumber, String httpClientClass) {
-        headerMap = new TankConfig().getAgentConfig().getRequestHeaderMap();
+        headerMap = AgentHeaders.MAP;
         this.testPlan = testPlan;
         this.threadNumber = threadNumber;
         this.httpClientClass = httpClientClass;
@@ -76,7 +81,7 @@ public class TestPlanRunner implements Runnable {
     }
     
     public TestPlanRunner( HDTestPlan testPlan, int threadNumber, String httpClientClass) {
-        headerMap = new TankConfig().getAgentConfig().getRequestHeaderMap();
+        headerMap = AgentHeaders.MAP;
         this.testPlan = testPlan;
         this.threadNumber = threadNumber;
         this.httpClientClass = httpClientClass;
@@ -104,6 +109,7 @@ public class TestPlanRunner implements Runnable {
     public void run() {
         tankHttpClient = initHttpClient();
         tankHttpClient.setHttpClient(httpClient);
+        flowController = APITestHarness.getInstance().getFlowControllerTemplate().cloneController();
 
         MethodTimer mt = new MethodTimer(LOG, getClass(), "runTestPlan(" + testPlan.getTestPlanName() + ")");
         LogEvent logEvent = LogUtil.getLogEvent();
@@ -288,9 +294,6 @@ public class TestPlanRunner implements Runnable {
                     }
                 }
             }
-
-            FlowController flowController = APITestHarness.getInstance().getFlowController(
-                    Thread.currentThread().getId());
 
             TestStepContext tsc = new TestStepContext(testStep, variables,
                     testPlan.getTestPlanName(),

--- a/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
+++ b/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
@@ -26,6 +26,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
@@ -51,6 +53,14 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     private static final Logger LOG = LogManager.getLogger(TankHttpClientJDK.class);
 
+    /**
+     * Shared across all client instances (one per virtual user) so request
+     * processing runs on virtual threads instead of each client's default
+     * cached pool of platform threads. HttpClient.close() does not shut down
+     * a user-supplied executor, so per-user clients can close independently.
+     */
+    private static final ExecutorService SHARED_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
+
     private HttpClient httpclient;
     private HttpClient.Builder httpclientBuilder;
     private final CookieManager cookieManager = new CookieManager();
@@ -63,6 +73,7 @@ public class TankHttpClientJDK implements TankHttpClient {
         cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
         httpclientBuilder = HttpClient.newBuilder()
                 .cookieHandler(cookieManager)
+                .executor(SHARED_EXECUTOR)
                 .connectTimeout(Duration.ofSeconds(30))
                 .followRedirects(HttpClient.Redirect.ALWAYS);
         httpclient = httpclientBuilder.build();


### PR DESCRIPTION
title: - Performance optimizations for agent virtual-user threads

## Summary

Profiling an agent under load showed `TestPlanRunner.run()` (the per-virtual-user session loop) burning CPU on overhead unrelated to the HTTP work itself. This PR removes three sources of that overhead:

### 1. Parse `settings.xml` once per JVM instead of once per virtual user
`TestPlanRunner`'s constructors called `new TankConfig().getAgentConfig().getRequestHeaderMap()`, and `TankConfig` re-reads and re-parses `settings.xml` from disk on every construction — once per virtual user, on the `TestPlanStarter` thread. For a 10k-user agent that is 10k XML parses in the ramp's critical path. The header map is now cached in a lazy static holder (`AgentHeaders`) and parsed exactly once. Safe to share: the map is only ever read (`RequestRunner` iterates it, never mutates).

### 2. `FlowController` is now a per-runner field instead of a per-step map lookup
`runScriptSteps` called `APITestHarness.getFlowController(Thread.currentThread().getId())` on **every test step**. That backing `ConcurrentHashMap` was keyed by thread id — and with virtual threads every user has a unique id — so it grew unbounded and leaked one cloned `FlowController` per finished user for the life of the test, on top of the per-step map probe. Each `TestPlanRunner` now clones the template once at the start of `run()` and uses the field directly. Semantics are unchanged (a runner lives on exactly one thread, so the map always returned the same clone per runner). `controllerMap` and `getFlowController(Long)` are removed; nothing else referenced them.

### 3. Shared virtual-thread executor for the JDK HTTP client
Each `TankHttpClientJDK` (one per virtual user) previously let `java.net.http.HttpClient` create its own default cached pool of platform threads. All client instances now share a single `Executors.newVirtualThreadPerTaskExecutor()`, so request processing runs on virtual threads and per-user clients stop multiplying platform-thread pools. `HttpClient.close()` does not shut down a user-supplied executor, so per-user clients still close independently.

## Impact

- Faster, smoother ramps: no disk I/O / XML parsing in `createThread`'s path.
- Eliminates unbounded `controllerMap` growth (memory + GC pressure) and the per-step map lookup on the hottest path.
- Removes per-user platform-thread pool creation in the JDK HTTP client.
- No behavior change to test execution semantics.

## Testing

- `mvn clean test -P default`: full suite passes (BUILD SUCCESS, 0 failures).
- `mvn test -pl agent/apiharness`: 463/463 pass.

Please make sure these check boxes are checked before submitting
- [x] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default```

** PR review process **
- Requires one +1 from a reviewer
- Repository owners will merge your PR once it is approved.
