### PR TITLE
JDK httpclient rewrite

### DIFF
--- a/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
+++ b/agent/http_client_jdk/src/main/java/com/intuit/tank/httpclientjdk/TankHttpClientJDK.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.net.*;
 import java.net.http.HttpClient;
@@ -26,8 +27,10 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
@@ -54,29 +57,47 @@ public class TankHttpClientJDK implements TankHttpClient {
     private static final Logger LOG = LogManager.getLogger(TankHttpClientJDK.class);
 
     /**
-     * Shared across all client instances (one per virtual user) so request
-     * processing runs on virtual threads instead of each client's default
-     * cached pool of platform threads. HttpClient.close() does not shut down
-     * a user-supplied executor, so per-user clients can close independently.
+     * Every JDK HttpClient instance owns a selector-manager platform thread, so
+     * clients cannot be created per virtual user (or per proxy/timeout change)
+     * without exhausting the agent's platform threads. Instead a small pool of
+     * clients per connection configuration is shared by all virtual users and
+     * lives for the life of the agent JVM. Cookies are applied per request from
+     * each user's own CookieManager (a client-level cookieHandler would be
+     * shared too), which requires following redirects manually so each hop
+     * still sends and stores that user's cookies.
+     */
+    private static final int CLIENT_POOL_SIZE = Integer.getInteger("tank.http.jdk.client.pool.size",
+            Math.max(2, Runtime.getRuntime().availableProcessors()));
+
+    /** Matches the JDK's default redirect retry limit (jdk.httpclient.redirects.retrylimit). */
+    private static final int MAX_REDIRECTS = Integer.getInteger("tank.http.jdk.redirect.limit", 5);
+
+    /**
+     * Shared across all client instances so request processing runs on virtual
+     * threads instead of each client's default cached pool of platform threads.
      */
     private static final ExecutorService SHARED_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
-    private HttpClient httpclient;
-    private HttpClient.Builder httpclientBuilder;
+    private static final ConcurrentHashMap<ClientConfig, HttpClient[]> CLIENT_POOLS = new ConcurrentHashMap<>();
+    private static final AtomicInteger NEXT_SLOT = new AtomicInteger();
+
+    private record ClientConfig(long connectTimeoutMs, String proxyHost, int proxyPort) {}
+
     private final CookieManager cookieManager = new CookieManager();
     private final Collection<String> mimeTypes = new TankConfig().getAgentConfig().getTextMimeTypeRegex();
+    /** Fixed pool slot per virtual user so a user keeps the same client (and its connections) across requests. */
+    private final int slot = Math.floorMod(NEXT_SLOT.getAndIncrement(), CLIENT_POOL_SIZE);
+
+    private long connectTimeoutMs = 30_000L;
+    private String proxyHost;
+    private int proxyPort = -1;
+    private HttpClient httpclient;
 
     /**
      * no-arg constructor for client
      */
     public TankHttpClientJDK() {
         cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
-        httpclientBuilder = HttpClient.newBuilder()
-                .cookieHandler(cookieManager)
-                .executor(SHARED_EXECUTOR)
-                .connectTimeout(Duration.ofSeconds(30))
-                .followRedirects(HttpClient.Redirect.ALWAYS);
-        httpclient = httpclientBuilder.build();
     }
 
     public Object createHttpClient() { return null; }
@@ -84,38 +105,55 @@ public class TankHttpClientJDK implements TankHttpClient {
     public void setHttpClient(Object httpClient) {}
 
     public void setConnectionTimeout(long connectionTimeout) {
-        httpclientBuilder.connectTimeout(Duration.ofMillis(connectionTimeout));
-        rebuild();
-    }
-
-    /**
-     * Rebuild the immutable client from the mutated builder, closing the client
-     * being replaced so its selector/worker threads are released immediately
-     * (Java 21 HttpClient is AutoCloseable) instead of lingering until GC.
-     */
-    private void rebuild() {
-        HttpClient old = httpclient;
-        httpclient = httpclientBuilder.build();
-        if (old != null) {
-            old.close();
-        }
-    }
-
-    /**
-     * Releases this client's selector/worker threads. Called once per virtual-user
-     * thread when its test plan finishes. Blocks until in-flight requests drain.
-     */
-    @Override
-    public void close() {
-        if (httpclient != null) {
-            httpclient.close();
+        if (connectionTimeout != connectTimeoutMs) {
+            connectTimeoutMs = connectionTimeout;
             httpclient = null;
         }
     }
 
+    /**
+     * Resolves the shared client for this user's connection settings, building
+     * it lazily so repeated setProxy/setConnectionTimeout calls before (or
+     * between) requests never construct throwaway clients.
+     */
+    private HttpClient client() {
+        if (httpclient == null) {
+            ClientConfig config = new ClientConfig(connectTimeoutMs, proxyHost, proxyPort);
+            HttpClient[] pool = CLIENT_POOLS.computeIfAbsent(config, k -> new HttpClient[CLIENT_POOL_SIZE]);
+            synchronized (pool) {
+                if (pool[slot] == null) {
+                    pool[slot] = newClient(config);
+                }
+                httpclient = pool[slot];
+            }
+        }
+        return httpclient;
+    }
+
+    private static HttpClient newClient(ClientConfig config) {
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .executor(SHARED_EXECUTOR)
+                .connectTimeout(Duration.ofMillis(config.connectTimeoutMs()))
+                .followRedirects(HttpClient.Redirect.NEVER);
+        if (config.proxyHost() != null) {
+            builder.proxy(ProxySelector.of(new InetSocketAddress(config.proxyHost(), config.proxyPort())));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Ends this virtual user's session. The underlying HttpClient is shared
+     * with other users and must not be closed here.
+     */
+    @Override
+    public void close() {
+        cookieManager.getCookieStore().removeAll();
+        httpclient = null;
+    }
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#doGet(com.intuit.tank.http.
      * BaseRequest)
@@ -129,7 +167,7 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#doPut(com.intuit.tank.http.
      * BaseRequest)
@@ -152,7 +190,7 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#doDelete(com.intuit.tank.http.
      * BaseRequest)
@@ -163,10 +201,10 @@ public class TankHttpClientJDK implements TankHttpClient {
         request.getHeaderInformation().forEach(httpdelete::header);
         sendRequest(request, httpdelete.build(), request.getBody());
     }
-    
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#doOptions(com.intuit.tank.http.
      * BaseRequest)
@@ -181,7 +219,7 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#doPost(com.intuit.tank.http.
      * BaseRequest)
@@ -227,7 +265,7 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.intuit.tank.httpclient3.TankHttpClient#addAuth(com.intuit.tank.http.
      * AuthCredentials)
@@ -243,13 +281,16 @@ public class TankHttpClientJDK implements TankHttpClient {
         HttpCookie sessionCookie = new HttpCookie(cookie.getName(), cookie.getValue());
         sessionCookie.setDomain(cookie.getDomain());
         sessionCookie.setPath(cookie.getPath());
+        // HttpCookie defaults to version 1 (RFC 2965), which serializes with $Version/$Path
+        // noise; version 0 sends the plain name=value form servers expect
+        sessionCookie.setVersion(0);
 
         cookieManager.getCookieStore().add(URI.create(cookie.getDomain()), sessionCookie);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.intuit.tank.httpclient3.TankHttpClient#clearSession()
      */
     @Override
@@ -259,12 +300,13 @@ public class TankHttpClientJDK implements TankHttpClient {
 
     @Override
     public void setProxy(String proxyhost, int proxyport) {
-        if (StringUtils.isNotBlank(proxyhost)) {
-            httpclientBuilder.proxy(ProxySelector.of(new InetSocketAddress(proxyhost, proxyport)));
-        } else {
-            httpclientBuilder.proxy(HttpClient.Builder.NO_PROXY);
+        String newHost = StringUtils.isNotBlank(proxyhost) ? proxyhost : null;
+        int newPort = newHost != null ? proxyport : -1;
+        if (!Objects.equals(newHost, proxyHost) || newPort != proxyPort) {
+            proxyHost = newHost;
+            proxyPort = newPort;
+            httpclient = null;
         }
-        rebuild();
     }
 
     private void sendRequest(BaseRequest request, @Nonnull HttpRequest method, String requestBody) {
@@ -279,7 +321,7 @@ public class TankHttpClientJDK implements TankHttpClient {
             request.logRequest(uri, requestBody, method.method(), request.getHeaderInformation(), cookies, false);
             long startTime = System.currentTimeMillis();
             request.setTimestamp(new Date(startTime));
-            HttpResponse<InputStream> response = httpclient.send(method, HttpResponse.BodyHandlers.ofInputStream());
+            HttpResponse<InputStream> response = send(method);
 
             // Read response body:
             byte[] responseBody = new byte[0];
@@ -323,6 +365,83 @@ public class TankHttpClientJDK implements TankHttpClient {
         }
         if (waitTime != 0) {
             doWaitDueToLongResponse(request, waitTime, uri);
+        }
+    }
+
+    /**
+     * Sends the request on the shared client, applying this user's cookies to
+     * each hop and following redirects manually (mirroring the semantics of
+     * HttpClient.Redirect.ALWAYS, which cannot be used on a shared client
+     * because redirect hops would bypass per-user cookie handling).
+     */
+    private HttpResponse<InputStream> send(HttpRequest initial) throws IOException, InterruptedException {
+        HttpRequest current = withCookieHeader(initial);
+        HttpResponse<InputStream> response = client().send(current, HttpResponse.BodyHandlers.ofInputStream());
+        int hops = 0;
+        while (isRedirect(response.statusCode()) && hops++ < MAX_REDIRECTS) {
+            storeCookies(response);
+            Optional<String> location = response.headers().firstValue("location");
+            if (location.isEmpty()) {
+                break;
+            }
+            drain(response);
+            URI target = response.uri().resolve(location.get());
+            current = withCookieHeader(redirectedRequest(current, response.statusCode(), target));
+            response = client().send(current, HttpResponse.BodyHandlers.ofInputStream());
+        }
+        storeCookies(response);
+        return response;
+    }
+
+    private static boolean isRedirect(int statusCode) {
+        return statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 307 || statusCode == 308;
+    }
+
+    private static HttpRequest redirectedRequest(HttpRequest prior, int statusCode, URI target) {
+        // 303 (and 301/302 for POST) redirect as GET without a body; 307/308 keep method and body
+        boolean switchToGet = statusCode == 303
+                || ((statusCode == 301 || statusCode == 302) && "POST".equals(prior.method()));
+        HttpRequest.Builder builder = HttpRequest.newBuilder(prior, (name, value) ->
+                !"Cookie".equalsIgnoreCase(name) && !(switchToGet && "Content-Type".equalsIgnoreCase(name)));
+        builder.uri(target);
+        if (switchToGet) {
+            builder.GET();
+        }
+        return builder.build();
+    }
+
+    private HttpRequest withCookieHeader(HttpRequest request) {
+        try {
+            List<String> cookies = cookieManager.get(request.uri(), request.headers().map())
+                    .getOrDefault("Cookie", Collections.emptyList());
+            if (cookies.isEmpty()) {
+                return request;
+            }
+            return HttpRequest.newBuilder(request, (name, value) -> true)
+                    .header("Cookie", String.join("; ", cookies))
+                    .build();
+        } catch (IOException e) {
+            LOG.warn("Could not apply cookies to request " + request.uri() + ": " + e);
+            return request;
+        }
+    }
+
+    private void storeCookies(HttpResponse<?> response) {
+        try {
+            cookieManager.put(response.uri(), response.headers().map());
+        } catch (IOException e) {
+            LOG.warn("Could not store cookies from response " + response.uri() + ": " + e);
+        }
+    }
+
+    private static void drain(HttpResponse<InputStream> response) {
+        InputStream body = response.body();
+        if (body != null) {
+            try (InputStream is = body) {
+                is.transferTo(OutputStream.nullOutputStream());
+            } catch (IOException e) {
+                // connection just won't be reused
+            }
         }
     }
 

--- a/agent/http_client_jdk/src/test/java/com/intuit/tank/httpclientjdk/TankHttpClientJDKTest.java
+++ b/agent/http_client_jdk/src/test/java/com/intuit/tank/httpclientjdk/TankHttpClientJDKTest.java
@@ -310,6 +310,113 @@ public class TankHttpClientJDKTest {
 
     @Test
     @Tag(TestGroups.FUNCTIONAL)
+    public void followsRedirectAndSendsCookieSetOnHop() {
+        wireMockServer.stubFor(get(urlEqualTo("/start"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "/next")
+                        .withHeader("Set-Cookie", "hop=1; Path=/"))
+        );
+        wireMockServer.stubFor(get(urlEqualTo("/next"))
+                .withCookie("hop", equalTo("1"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("landed"))
+        );
+
+        BaseRequest request = getRequest(new TankHttpClientJDK(), wireMockServer.baseUrl() + "/start");
+        request.doGet(null);
+        BaseResponse response = request.getResponse();
+        assertNotNull(response);
+        assertEquals(200, response.getHttpCode());
+        assertEquals("landed", response.getBody());
+        assertEquals("1", response.getCookies().get("hop"));
+        verify(exactly(1), getRequestedFor(urlEqualTo("/next")));
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void redirectsPostAsGet() {
+        wireMockServer.stubFor(post(urlEqualTo("/form"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "/done"))
+        );
+        wireMockServer.stubFor(get(urlEqualTo("/done"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("ok"))
+        );
+
+        BaseRequest request = getRequest(new TankHttpClientJDK(), wireMockServer.baseUrl() + "/form");
+        request.setBody("{\"a\":1}");
+        request.setContentType("application/json");
+        request.doPost(null);
+        BaseResponse response = request.getResponse();
+        assertNotNull(response);
+        assertEquals(200, response.getHttpCode());
+        assertEquals("ok", response.getBody());
+        verify(exactly(1), getRequestedFor(urlEqualTo("/done")));
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void cookiesDoNotLeakBetweenClientInstances() {
+        wireMockServer.stubFor(get(urlEqualTo("/login"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Set-Cookie", "user-a=secret; Path=/")
+                        .withBody("{}"))
+        );
+        wireMockServer.stubFor(get(urlEqualTo("/isolated"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("{}"))
+        );
+
+        TankHttpClient userA = new TankHttpClientJDK();
+        getRequest(userA, wireMockServer.baseUrl() + "/login").doGet(null);
+        getRequest(userA, wireMockServer.baseUrl() + "/isolated").doGet(null);
+
+        // A second virtual user shares the underlying HttpClient but must not send user A's cookies
+        getRequest(new TankHttpClientJDK(), wireMockServer.baseUrl() + "/isolated").doGet(null);
+
+        verify(exactly(1), getRequestedFor(urlEqualTo("/isolated")).withHeader("Cookie", containing("user-a")));
+        verify(exactly(1), getRequestedFor(urlEqualTo("/isolated")).withoutHeader("Cookie"));
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
+    public void selectorThreadCountStaysBoundedAcrossManyUsers() {
+        wireMockServer.stubFor(get(urlEqualTo("/ping"))
+                .willReturn(aResponse().withStatus(200).withBody("pong"))
+        );
+
+        int poolSize = Integer.getInteger("tank.http.jdk.client.pool.size",
+                Math.max(2, Runtime.getRuntime().availableProcessors()));
+
+        // Simulate many virtual users, each with the per-step proxy reset RequestRunner performs
+        for (int i = 0; i < 50; i++) {
+            TankHttpClient user = new TankHttpClientJDK();
+            user.setConnectionTimeout(30000);
+            for (int step = 0; step < 3; step++) {
+                user.setProxy(null, -1);
+                getRequest(user, wireMockServer.baseUrl() + "/ping").doGet(null);
+            }
+            user.close();
+        }
+
+        long selectorThreads = Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.getName().contains("SelectorManager"))
+                .count();
+        assertTrue(selectorThreads <= poolSize,
+                "Expected at most " + poolSize + " HttpClient selector threads but found " + selectorThreads);
+    }
+
+    @Test
+    @Tag(TestGroups.FUNCTIONAL)
     public void testBrotliEncoding() {
         // Pre-compressed brotli data for "Hello, Brotli!"
         byte[] brotliCompressed = java.util.Base64.getDecoder().decode("jwaASGVsbG8sIEJyb3RsaSED");


### PR DESCRIPTION
## Problem

Agents running the JDK HTTP client were still being overwhelmed by platform-thread creation, even after the shared virtual-thread executor from #506. That fix removed the per-client worker pools, but two platform-thread sources remained:

1. **A new `HttpClient` per request step.** `RequestRunner.initialize()` unconditionally calls `setProxy(null, -1)` on every step, and `setProxy`/`setConnectionTimeout` always rebuilt the client. Every JDK `HttpClient` instance owns a `HttpClient-N-SelectorManager` **platform** thread regardless of the executor supplied, so the agent created roughly one platform thread per request executed (plus close/drain churn).
2. **One `HttpClient` per virtual user.** With virtual users running on virtual threads, thousands of users meant thousands of selector-manager platform threads at steady state.

## Changes

- **Shared client pool**: `HttpClient` instances are pooled statically, keyed by connection config (timeout + proxy). Pool size defaults to `max(2, CPU count)`, overridable with `-Dtank.http.jdk.client.pool.size`. Each virtual user is pinned to one slot so it keeps stable connections. Selector threads are now bounded by pool size instead of scaling with users × requests.
- **Change detection on `setProxy` / `setConnectionTimeout`**: same-value calls (like the per-step proxy reset) are no-ops, and clients are resolved lazily, so config calls never construct throwaway clients.
- **Per-user cookies moved out of the client**: a client-level `cookieHandler` is what forced one client per user. Each user keeps its own `CookieManager`; cookies are applied per request and stored from each response, so users sharing a client cannot see each other's sessions.
- **Manual redirect following** (client redirects disabled): required so each redirect hop still sends/stores the user's cookies. Mirrors `Redirect.ALWAYS` semantics — 303 and POST-on-301/302 become GET, 307/308 preserve method and body, 5-hop limit (`-Dtank.http.jdk.redirect.limit`).
- `close()` clears the user's session instead of closing the shared client.
- Scripted cookies (`setCookie`) now use cookie version 0 so they serialize as plain `name=value` instead of RFC 2965 `$Version` form.

## Tests

New coverage in `TankHttpClientJDKTest` (20/20 passing; `apiharness` suite 463/463 passing):
- Redirect following with a cookie set on the intermediate hop
- POST 302 → GET conversion
- Cookie isolation between client instances sharing a pooled `HttpClient`
- Regression test asserting selector-thread count stays ≤ pool size across 50 users × 3 steps with per-step proxy churn

## Notes

- Users sharing a client also share its connection pool, so against HTTP/2 targets traffic multiplexes over fewer TCP connections than the old one-client-per-user model. Raise `-Dtank.http.jdk.client.pool.size` on the agent JVM if a test needs more connection-level concurrency.
- Pre-existing (untouched here): `RequestRunner` proxy parsing splits the literal `":"` string and unsets the proxy before the request executes, so `TANK_HTTP_PROXY` has never applied; and the JDK cookie store never sends manually scripted cookies for dotless domains like `localhost` (true before this change as well).

---
- [ ] ** Squashed Commits **
- [x] ** All Tests Passed ** - ```mvn clean test -P default```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
